### PR TITLE
Fixed service catalog permission errors

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -396,7 +396,7 @@ class CatalogController < ApplicationController
     @sb[:action] = nil
     @explorer = true
     if x_active_tree == :stcat_tree
-      assert_privileges("catalog_items_view")
+      assert_privileges("st_catalog_view")
 
       if params[:rec_id]
         # link to Catalog Item clicked on catalog summary screen
@@ -406,12 +406,17 @@ class CatalogController < ApplicationController
       else
         @record = ServiceTemplateCatalog.find(params[:id])
       end
+    elsif x_active_tree == :sandt_tree
+      assert_privileges("catalog_items_view")
+
+      identify_catalog(params[:id])
+      @record ||= ServiceTemplateCatalog.find(params[:id])
     elsif x_active_tree == :ot_tree
       assert_privileges("orchestration_templates_view")
 
       @record ||= OrchestrationTemplate.find(params[:id])
     else
-      assert_privileges("st_catalog_view")
+      assert_privileges("svc_catalog_provision", "svc_catalog_archive", "svc_catalog_unarchive")
 
       identify_catalog(params[:id])
       @record ||= ServiceTemplateCatalog.find(params[:id])


### PR DESCRIPTION
Fixed permission errors that occur with the Service > Catalogs page.

When creating a user with a role that only has permissions for each specific tab of the Catalog explorer you run into permission errors.

Before:
Using a user account with a role that only has permissions for catalog items and clicking on the catalog items table produces this error:
<img width="1368" alt="Screenshot 2023-09-26 at 2 45 59 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/d2eeca36-31a1-4ab9-a0fa-cb5ad182cab1">

Using a user account with a role that only has permissions for service catalogs and clicking on the service catalogs table produces this error:
<img width="1379" alt="Screenshot 2023-09-26 at 2 44 36 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/01745583-4052-449f-863d-f03b14b2860e">

Using a user account with a role that only has permissions for catalogs and clicking on the catalogs table produces this error:
<img width="1371" alt="Screenshot 2023-09-26 at 2 47 53 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/320fa522-7586-4844-bb7f-5df6282cd1f2">

After:
Using a user account with a role that only has permissions for catalog items and clicking on the catalog items table produces this summary page:
<img width="1389" alt="CatalogItemsSummaryAfter" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/209cafe3-6dbc-4f0b-a201-b93b1ce07720">

Using a user account with a role that only has permissions for service catalogs and clicking on the service catalogs table produces this summary page:
<img width="1367" alt="ServiceCatalogsSummaryAfter" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/50f0c9b5-b419-4a24-a455-a6c97e66e395">

Using a user account with a role that only has permissions for catalogs and clicking on the catalogs table produces this summary page:
<img width="1350" alt="CatalogsSummaryAfter" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/42121e8b-ab86-4037-9c29-579ef63c6dfa">

