### PR TITLE
Fix .camelize after a &. safe navigation

### DIFF
--- a/app/views/catalog/_provision_entry_point.html.haml
+++ b/app/views/catalog/_provision_entry_point.html.haml
@@ -10,7 +10,7 @@
       = text_field_tag("fqname",
                         edit_new[:fqname],
                         :class             => "form-control long_text entry_point_text",
-                        :placeholder       => type&.gsub('_',' ').camelize,
+                        :placeholder       => type&.gsub('_',' ')&.camelize,
                         "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
       %span.input-group-btn
         #fqname_div

--- a/app/views/catalog/_reconfigure_entry_point.html.haml
+++ b/app/views/catalog/_reconfigure_entry_point.html.haml
@@ -10,7 +10,7 @@
       = text_field_tag("reconfigure_fqname",
                         edit_new[:reconfigure_fqname],
                         :class             => "form-control long_text entry_point_text",
-                        :placeholder       => type&.gsub('_',' ').camelize,
+                        :placeholder       => type&.gsub('_',' ')&.camelize,
                         "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
       %span.input-group-btn
         #reconfigure_fqname_div

--- a/app/views/catalog/_retire_entry_point.html.haml
+++ b/app/views/catalog/_retire_entry_point.html.haml
@@ -10,7 +10,7 @@
       = text_field_tag("retire_fqname",
                         edit_new[:retire_fqname],
                         :class             => "form-control long_text entry_point_text",
-                        :placeholder       => type&.gsub('_',' ').camelize,
+                        :placeholder       => type&.gsub('_',' ')&.camelize,
                         "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
       %span.input-group-btn
         #retire_fqname_div


### PR DESCRIPTION
Fix for
```
     Failure/Error: = text_field_tag("fqname",
     
     ActionView::Template::Error:
       undefined method `camelize' for nil:NilClass
```

It appears to have started failing here https://github.com/ManageIQ/manageiq-ui-classic/actions/runs/6343793822/job/17261288587#step:8:688

I tried checking out the last green UI commit paired with a core commit from the same time and the test is still failing.