### PR TITLE
Fix for custom button action events

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -203,7 +203,7 @@ module ApplicationController::Buttons
     @sb[:action] if features_in_action.include?(@sb[:action])
   end
 
-  BASE_MODEL_EXPLORER_CLASSES = [MiqGroup, MiqTemplate, Service, Tenant, User, Vm].freeze
+  BASE_MODEL_EXPLORER_CLASSES = [MiqGroup, MiqTemplate, Tenant, User, Vm].freeze
 
   def custom_button_done
     external_url = ExternalUrl.find_by(

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -33,7 +33,21 @@ class ServiceController < ApplicationController
       service_retire
     when 'service_retire_now'
       service_retire_now
+    when "custom_button"
+      @display == 'generic_objects' ? generic_object_custom_buttons : custom_buttons
+    else
+      add_flash(_("Invalid button action!"), :error)
+      render_flash
     end
+  end
+
+  def generic_object_custom_buttons
+    display_options = {}
+    ids = @lastaction == 'generic_object' ? @sb[:rec_id] : 'LIST'
+    display_options[:display] = @display
+    display_options[:record_id] = parse_nodetype_and_id(x_node).last
+    display_options[:display_id] = params[:id] if @lastaction == 'generic_object'
+    custom_buttons(ids, display_options)
   end
 
   def title

--- a/spec/controllers/application_controller/buttons_spec.rb
+++ b/spec/controllers/application_controller/buttons_spec.rb
@@ -94,7 +94,7 @@ describe ApplicationController do
 
         controller.send(:custom_buttons)
         expect(assigns(:right_cell_text)).to include(service.name)
-        expect(controller.instance_variable_get(:@explorer)).to be_truthy
+        expect(controller.instance_variable_get(:@explorer)).to be_falsy
       end
     end
 


### PR DESCRIPTION
Before
When we hit the custom buttons from the Service#show page, there was no action.
<img width="1554" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/14529110-c700-4954-864d-470b176421d0">

After
The custom button actions are now working and being redirected to another page...
<img width="1558" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/506d761d-3905-4e0e-b333-e9d4db5a6a56">

