### PR TITLE
Fixed optimization table translations

### DIFF
--- a/app/javascript/components/data-tables/optimization/helper.js
+++ b/app/javascript/components/data-tables/optimization/helper.js
@@ -5,12 +5,12 @@ const convertHeader = (headerItems) => headerItems.map((item) => ({ key: item[0]
 
 /** Attributes needed for a button. */
 const buttonData = (item) => ({
-  alt: 'Queue Report',
+  alt: __('Queue Report'),
   disabled: false,
   is_button: true,
   onclick: `miqQueueReport(${item.id});`,
-  text: 'Queue Report',
-  title: 'Queue Report',
+  text: __('Queue Report'),
+  title: __('Queue Report'),
 });
 
 /** Function to generate the values of the attribute cell for an item in rows.  */


### PR DESCRIPTION
Fixed the optimization table on the Overview > Optimization page missing translations for the 'Queue Report' button.

Before:
<img width="1382" alt="Before" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/a59da058-2af0-424d-bece-f74a35ec6e06">

After:
<img width="1378" alt="After" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/757e906e-99dc-4c4a-9266-6c27b883b1dc">