### PR TITLE
Fixed chargeback rates title missing translation

### DIFF
--- a/app/controllers/chargeback_assignment_controller.rb
+++ b/app/controllers/chargeback_assignment_controller.rb
@@ -14,7 +14,6 @@ class ChargebackAssignmentController < ApplicationController
   def index
     assert_privileges("chargeback_assignments")
 
-    @title = _("Chargeback Assignments")
     @tabform = ChargebackRate::VALID_CB_RATE_TYPES.include?(params[:tab]) ? params[:tab] : "Compute"
     session[:changed] = @changed = false
     build_tabs
@@ -78,6 +77,7 @@ class ChargebackAssignmentController < ApplicationController
 
   def build_tabs
     @breadcrumbs = []
+    @title = _("Chargeback Assignments")
     @active_tab = @tabform
     @tabs = [["Compute", _("Compute")], ["Storage", _("Storage")]]
   end


### PR DESCRIPTION
Fixed the missing translation for the 'Chargeback Assignments' title on the Overview > Chargeback > Assignments page Storage tab.

Before:
<img width="1361" alt="Before" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/81daf7cc-9524-499b-9c55-6a83db0c7c79">

After:
<img width="1372" alt="After" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/1775f506-7fbc-40c8-ab80-37cd2a18e07b">
