### PR TITLE
Change ui to display max alert description length

### DIFF
--- a/app/javascript/components/miq-alert-set-form/miq-alert-set-form.schema.js
+++ b/app/javascript/components/miq-alert-set-form/miq-alert-set-form.schema.js
@@ -27,7 +27,7 @@ function createSchema(fieldss, recordId, emsId, mode, loadSchema, alertState, al
           name: 'description',
           label: __('Description'),
           isRequired: true,
-          maxLength: 50,
+          maxLength: 255,
         },
         {
           component: componentTypes.SELECT,

--- a/app/javascript/spec/miq-alert-set-form/__snapshots__/miq-alert-set-form.spec.js.snap
+++ b/app/javascript/spec/miq-alert-set-form/__snapshots__/miq-alert-set-form.spec.js.snap
@@ -21,7 +21,7 @@ exports[`Alert Profile Form Component should render correctly 1`] = `
               "id": "description",
               "isRequired": true,
               "label": "Description",
-              "maxLength": 50,
+              "maxLength": 255,
               "name": "description",
             },
             Object {


### PR DESCRIPTION
Displaying the database length limit in the ui
(Just trying to get pen tests fixed)

I thought the model's values would be displayed in the UI.
Looks like this is manually entered in 2 places

https://github.com/ManageIQ/manageiq/pull/21921

These limits are arbitrary. We changed a limit of 50 to 100 and then to 255
The UI was not fixed. So testers trying 70 (larger than 50) thought that no limit took place

This fixes the UI so testers can ensure the limits are met

## Before

![alert_profile_length-antes](https://github.com/ManageIQ/manageiq-ui-classic/assets/1930/fc69ef3b-150d-4b81-8449-966bf433607b)

## After

![alert_profile_length-despues](https://github.com/ManageIQ/manageiq-ui-classic/assets/1930/dfa019df-a1cc-4bb2-bd00-db66b8bc307e)

