### PR TITLE
Fixed provision custom specifications table

### DIFF
--- a/app/helpers/request_info_helper.rb
+++ b/app/helpers/request_info_helper.rb
@@ -163,8 +163,8 @@ module RequestInfoHelper
     rows = []
     unless data[:spec_required]
       rows += [prov_row_item(data[:none_index], none_cells(count))]
-      if data[:vc]
-        rows += data[:vc].map do |vc|
+      if data[:vcs]
+        rows += data[:vcs].map do |vc|
           prov_row_item(vc.id.to_s, prov_vc_cells(vc))
         end
       end
@@ -314,10 +314,11 @@ module RequestInfoHelper
   end
 
   def prov_vc_cells(data)
-    cells = []
-    edit[:vcs].each do |col|
-      cells += prov_cell_data(data.send(col))
-    end
+    [
+      prov_cell_data(data.name),
+      prov_cell_data(data.description),
+      prov_cell_data(data.last_update_time),
+    ]
   end
 
   def prov_window_image_cells(data)


### PR DESCRIPTION
Issue was introduced by this pr: https://github.com/ManageIQ/manageiq-ui-classic/pull/8517.

Fixed an issue where the VM Provision custom specifications table was not displaying data correctly.

Before:
<img width="1125" alt="Screenshot 2023-10-17 at 3 57 08 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/ddc8c851-3773-405a-a1ae-22bf93b6128a">

After:
<img width="1124" alt="Screenshot 2023-10-17 at 3 52 30 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/694b024a-248d-493d-87a2-26f036f6437a">

Fixes https://github.com/ManageIQ/manageiq/issues/22746