### PR TITLE
Fix missing customization_templates list

### DIFF
--- a/app/helpers/request_info_helper.rb
+++ b/app/helpers/request_info_helper.rb
@@ -149,7 +149,7 @@ module RequestInfoHelper
     edit = data[:edit]
     headers, count = prov_grid_header(edit, data[:type])
     rows = [prov_row_item(data[:none_index], none_cells(count))]
-    if data[:template]
+    if data[:templates]
       rows += data[:templates].map do |template|
         prov_row_item(template.id.to_s, prov_template_cells(template))
       end


### PR DESCRIPTION
We were checking two different keys in the `data` hash, first was simply a typo.  The result was that there were never any customization_templates being displayed.

Introduced by https://github.com/ManageIQ/manageiq-ui-classic/pull/8748/files#diff-49fa91f9c8b1007440a2abba8b2c7e63b6d0deadc75fdf28b8b894216e59a065R152

Before:
![Screenshot from 2023-10-18 16-12-23](https://github.com/ManageIQ/manageiq-ui-classic/assets/12851112/46b816c4-fe7e-4dda-bab5-abc531a6a672)

After:
![Screenshot from 2023-10-18 16-11-21](https://github.com/ManageIQ/manageiq-ui-classic/assets/12851112/3ddb67a9-8dd1-427d-8c06-8d5712f1614f)

Fixes https://github.com/ManageIQ/manageiq/issues/22746