### PR TITLE
Fixed accessibility issues with the server settings authentication page

### DIFF
--- a/app/views/ops/_settings_authentication_tab.html.haml
+++ b/app/views/ops/_settings_authentication_tab.html.haml
@@ -23,7 +23,7 @@
           miqSelectPickerEvent('session_timeout_mins', "#{url}")
         %span m
     .form-group
-      %label.col-md-2.control-label
+      %label.col-md-2.control-label{"for" => "authentication_mode"}
         = _("Mode")
       .col-md-8
         = select_tag('authentication_mode',
@@ -38,7 +38,7 @@
     %h3= _("Amazon Primary AWS Account Settings for IAM")
     .form-horizontal
       .form-group
-        %label.col-md-2.control-label
+        %label.col-md-2.control-label{"for" => "authentication_amazon_key"}
           = _("Access Key")
         .col-md-8
           = text_field_tag("authentication_amazon_key",
@@ -47,7 +47,7 @@
                             :class => "form-control",
                             "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
       .form-group
-        %label.col-md-2.control-label
+        %label.col-md-2.control-label{"for" => "authentication_amazon_secret"}
           = _("Secret Key")
         .col-md-8
           = password_field_tag("authentication_amazon_secret", '',
@@ -62,7 +62,7 @@
       = _("Role Settings")
     .form-horizontal
       .form-group
-        %label.col-md-2.control-label
+        %label.col-md-2.control-label{"for" => "amazon_role"}
           = _("Get User Groups from Amazon")
         .col-md-8
           = check_box_tag("amazon_role", "1",
@@ -78,13 +78,12 @@
       = _("External Authentication (httpd) Settings")
     .form-horizontal
       .form-group
-        %label.col-md-2.control-label
+        %label.col-md-2.control-label{"for" => "sso_enabled"}
           = _("Enable Single Sign-On")
         .col-md-8
           = check_box_tag("sso_enabled", "1",
                           @edit[:new][:authentication][:sso_enabled],
                           "data-miq_observe_checkbox" => {:url => url}.to_json)
-    %h3
     .form-horizontal
       .form-group
         %label.control-label.col-md-2
@@ -93,7 +92,7 @@
           %label
             %input{:type              => 'radio',
                    :name              => 'provider_type',
-                   :id                => 'provider_type',
+                   :id                => 'provider_type_none',
                    :value             => 'none',
                    "data-miq_observe" => {:url => url}.to_json,
                    :checked           => @edit[:new][:authentication][:provider_type] == "none"}
@@ -102,7 +101,7 @@
           %label
             %input{:type              => 'radio',
                    :name              => 'provider_type',
-                   :id                => 'provider_type',
+                   :id                => 'provider_type_saml',
                    :value             => 'saml',
                    "data-miq_observe" => {:url => url}.to_json,
                    :checked           => @edit[:new][:authentication][:provider_type] == "saml"}
@@ -111,7 +110,7 @@
           %label
             %input{:type              => 'radio',
                    :name              => 'provider_type',
-                   :id                => 'provider_type',
+                   :id                => 'provider_type_oidc',
                    :value             => 'oidc',
                    "data-miq_observe" => {:url => url}.to_json,
                    :checked           => @edit[:new][:authentication][:provider_type] == "oidc"}
@@ -119,7 +118,7 @@
 
       = hidden_div_if(@edit[:new][:authentication][:provider_type] == "none", :id => "none_local_login_div") do
         .form-group
-          %label.col-md-2.control-label
+          %label.col-md-2.control-label{"for" => "local_login_disabled"}
             = _("Disable Local Login")
           .col-md-4
             = check_box_tag("local_login_disabled", "1",
@@ -132,7 +131,7 @@
       = _("Role Settings")
     .form-horizontal
       .form-group
-        %label.col-md-2.control-label
+        %label.col-md-2.control-label{"for" => "httpd_role"}
           = _("Get User Groups from External Authentication (httpd)")
         .col-md-8
           = check_box_tag("httpd_role", "1",


### PR DESCRIPTION
Fixed most accessibility issues with the Server Settings Authentication Page. Some of remaining violations need to be fixed by converting the page to react which can be done in a follow up PR. The rest of the violations are due to the explorer screen which will exist on every page that has the explorer tree and will not be fixed until all the explorer pages are removed.

Before:
<img width="1654" alt="Screenshot 2023-11-03 at 9 48 44 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/194f2a0a-6081-436c-83fd-7d02212fdfe9">

After:
<img width="1680" alt="Screenshot 2023-11-03 at 10 30 53 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/87407f60-5039-4a0c-b6f7-b11631258732">