### PR TITLE
Fixed console warning for miq table cell button size

### DIFF
--- a/app/javascript/components/miq-data-table/miq-table-cell.jsx
+++ b/app/javascript/components/miq-data-table/miq-table-cell.jsx
@@ -121,7 +121,7 @@ const MiqTableCell = ({
         disabled={item.disabled}
         onKeyPress={(e) => cellButtonEvent(item, e)}
         tabIndex={0}
-        size={item.size ? item.size : ''}
+        size={item.size ? item.size : 'default'}
         title={item.title ? item.title : truncateText}
         kind={item.kind ? item.kind : 'primary'}
         className={classNames('miq-data-table-button', item.buttonClassName)}

--- a/app/javascript/spec/reconfigure-vm-form/__snapshots__/reconfigure-vm-form.spec.js.snap
+++ b/app/javascript/spec/reconfigure-vm-form/__snapshots__/reconfigure-vm-form.spec.js.snap
@@ -8005,7 +8005,7 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                                     kind="ghost"
                                                                     onClick={[Function]}
                                                                     onKeyPress={[Function]}
-                                                                    size=""
+                                                                    size="default"
                                                                     tabIndex={0}
                                                                     title="Resize"
                                                                   >
@@ -8246,7 +8246,7 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                                     kind="ghost"
                                                                     onClick={[Function]}
                                                                     onKeyPress={[Function]}
-                                                                    size=""
+                                                                    size="default"
                                                                     tabIndex={0}
                                                                     title="Delete"
                                                                   >
@@ -9464,7 +9464,7 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                                     kind="ghost"
                                                                     onClick={[Function]}
                                                                     onKeyPress={[Function]}
-                                                                    size=""
+                                                                    size="default"
                                                                     tabIndex={0}
                                                                     title="Cancel Disconnect"
                                                                   >
@@ -9613,7 +9613,7 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                                     kind="ghost"
                                                                     onClick={[Function]}
                                                                     onKeyPress={[Function]}
-                                                                    size=""
+                                                                    size="default"
                                                                     tabIndex={0}
                                                                     title="Connect"
                                                                   >
@@ -29762,7 +29762,7 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                                     kind="ghost"
                                                                     onClick={[Function]}
                                                                     onKeyPress={[Function]}
-                                                                    size=""
+                                                                    size="default"
                                                                     tabIndex={0}
                                                                     title="Resize"
                                                                   >
@@ -30003,7 +30003,7 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                                     kind="ghost"
                                                                     onClick={[Function]}
                                                                     onKeyPress={[Function]}
-                                                                    size=""
+                                                                    size="default"
                                                                     tabIndex={0}
                                                                     title="Delete"
                                                                   >
@@ -31081,7 +31081,7 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                                     kind="ghost"
                                                                     onClick={[Function]}
                                                                     onKeyPress={[Function]}
-                                                                    size=""
+                                                                    size="default"
                                                                     tabIndex={0}
                                                                     title="Edit"
                                                                   >
@@ -31242,7 +31242,7 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                                     kind="ghost"
                                                                     onClick={[Function]}
                                                                     onKeyPress={[Function]}
-                                                                    size=""
+                                                                    size="default"
                                                                     tabIndex={0}
                                                                     title="Delete"
                                                                   >
@@ -40468,7 +40468,7 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                                     kind="ghost"
                                                                     onClick={[Function]}
                                                                     onKeyPress={[Function]}
-                                                                    size=""
+                                                                    size="default"
                                                                     tabIndex={0}
                                                                     title="Resize"
                                                                   >
@@ -40706,7 +40706,7 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                                     kind="ghost"
                                                                     onClick={[Function]}
                                                                     onKeyPress={[Function]}
-                                                                    size=""
+                                                                    size="default"
                                                                     tabIndex={0}
                                                                     title="Cancel Delete"
                                                                   >
@@ -41926,7 +41926,7 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                                     kind="ghost"
                                                                     onClick={[Function]}
                                                                     onKeyPress={[Function]}
-                                                                    size=""
+                                                                    size="default"
                                                                     tabIndex={0}
                                                                     title="Disconnect"
                                                                   >
@@ -42075,7 +42075,7 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                                     kind="ghost"
                                                                     onClick={[Function]}
                                                                     onKeyPress={[Function]}
-                                                                    size=""
+                                                                    size="default"
                                                                     tabIndex={0}
                                                                     title="Connect"
                                                                   >

--- a/app/javascript/spec/settings-compan-categories/__snapshots__/settings-company-categories.spec.js.snap
+++ b/app/javascript/spec/settings-compan-categories/__snapshots__/settings-company-categories.spec.js.snap
@@ -1871,7 +1871,7 @@ exports[`SettingsCompanyCategories component should render a SettingsCompanyCate
                                 kind="danger"
                                 onClick={[Function]}
                                 onKeyPress={[Function]}
-                                size=""
+                                size="default"
                                 tabIndex={0}
                                 title="Category cannot be deleted"
                               >
@@ -3030,7 +3030,7 @@ exports[`SettingsCompanyCategories component should render a SettingsCompanyCate
                                 kind="danger"
                                 onClick={[Function]}
                                 onKeyPress={[Function]}
-                                size=""
+                                size="default"
                                 tabIndex={0}
                                 title="Click to delete this category"
                               >
@@ -4189,7 +4189,7 @@ exports[`SettingsCompanyCategories component should render a SettingsCompanyCate
                                 kind="danger"
                                 onClick={[Function]}
                                 onKeyPress={[Function]}
-                                size=""
+                                size="default"
                                 tabIndex={0}
                                 title="Click to delete this category"
                               >
@@ -5348,7 +5348,7 @@ exports[`SettingsCompanyCategories component should render a SettingsCompanyCate
                                 kind="danger"
                                 onClick={[Function]}
                                 onKeyPress={[Function]}
-                                size=""
+                                size="default"
                                 tabIndex={0}
                                 title="Click to delete this category"
                               >

--- a/app/javascript/spec/settings-label-tag-mapping/__snapshots__/settings-label-tag-mapping.spec.js.snap
+++ b/app/javascript/spec/settings-label-tag-mapping/__snapshots__/settings-label-tag-mapping.spec.js.snap
@@ -1026,7 +1026,7 @@ exports[`SettingsLabelTagMapping component should render a SettingsLabelTagMappi
                                 kind="danger"
                                 onClick={[Function]}
                                 onKeyPress={[Function]}
-                                size=""
+                                size="default"
                                 tabIndex={0}
                                 title="Click to delete this mapping"
                               >
@@ -1540,7 +1540,7 @@ exports[`SettingsLabelTagMapping component should render a SettingsLabelTagMappi
                                 kind="danger"
                                 onClick={[Function]}
                                 onKeyPress={[Function]}
-                                size=""
+                                size="default"
                                 tabIndex={0}
                                 title="Click to delete this mapping"
                               >
@@ -2054,7 +2054,7 @@ exports[`SettingsLabelTagMapping component should render a SettingsLabelTagMappi
                                 kind="danger"
                                 onClick={[Function]}
                                 onKeyPress={[Function]}
-                                size=""
+                                size="default"
                                 tabIndex={0}
                                 title="Click to delete this mapping"
                               >
@@ -2568,7 +2568,7 @@ exports[`SettingsLabelTagMapping component should render a SettingsLabelTagMappi
                                 kind="danger"
                                 onClick={[Function]}
                                 onKeyPress={[Function]}
-                                size=""
+                                size="default"
                                 tabIndex={0}
                                 title="Click to delete this mapping"
                               >
@@ -3625,7 +3625,7 @@ exports[`SettingsLabelTagMapping component should render a SettingsLabelTagMappi
                                 kind="danger"
                                 onClick={[Function]}
                                 onKeyPress={[Function]}
-                                size=""
+                                size="default"
                                 tabIndex={0}
                                 title="Click to delete this mapping"
                               >
@@ -4139,7 +4139,7 @@ exports[`SettingsLabelTagMapping component should render a SettingsLabelTagMappi
                                 kind="danger"
                                 onClick={[Function]}
                                 onKeyPress={[Function]}
-                                size=""
+                                size="default"
                                 tabIndex={0}
                                 title="Click to delete this mapping"
                               >
@@ -4653,7 +4653,7 @@ exports[`SettingsLabelTagMapping component should render a SettingsLabelTagMappi
                                 kind="danger"
                                 onClick={[Function]}
                                 onKeyPress={[Function]}
-                                size=""
+                                size="default"
                                 tabIndex={0}
                                 title="Click to delete this mapping"
                               >
@@ -5167,7 +5167,7 @@ exports[`SettingsLabelTagMapping component should render a SettingsLabelTagMappi
                                 kind="danger"
                                 onClick={[Function]}
                                 onKeyPress={[Function]}
-                                size=""
+                                size="default"
                                 tabIndex={0}
                                 title="Click to delete this mapping"
                               >


### PR DESCRIPTION
Fixed console log warnings for miq table cell button size.

Before:
<img width="1786" alt="Screenshot 2023-10-20 at 12 30 56 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/9162d9c6-5bb7-41bf-9089-6ad40951d524">
<img width="1782" alt="Screenshot 2023-10-20 at 12 31 54 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/66a709ae-5a15-47b1-9625-2afd2e7db954">
<img width="1783" alt="Screenshot 2023-10-20 at 12 35 29 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/7a910c83-9c8a-4cf5-b5e3-69c45d77b05d">
<img width="1736" alt="Screenshot 2023-10-20 at 12 25 37 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/29627c45-b739-4c4f-80e7-7856ae48da66">


After:
<img width="1780" alt="Screenshot 2023-10-20 at 12 32 18 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/954fca60-93e1-4d90-a31c-8e5d6b1d0719">
<img width="1786" alt="Screenshot 2023-10-20 at 12 32 26 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/a4607b97-18b5-411d-91df-d4df450cd57d">
<img width="1782" alt="Screenshot 2023-10-20 at 12 34 38 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/ddc76e3b-d4ea-4bbf-953a-ed8b719320bf">
<img width="1790" alt="Screenshot 2023-10-20 at 12 25 11 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/1de3aa22-98fc-4d44-aba6-1511c9c7d8af">
