### PR TITLE
Fix for missing toast notifications

### DIFF
--- a/app/javascript/components/toast-list/toast-item.jsx
+++ b/app/javascript/components/toast-list/toast-item.jsx
@@ -1,0 +1,51 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { ToastNotification, Link } from 'carbon-components-react';
+import { useDispatch } from 'react-redux';
+import { markNotificationRead, MARK_NOTIFICATION_READ } from '../../miq-redux/actions/notifications-actions';
+
+const notificationTimerDelay = 8000;
+const EMPTY = '';
+
+/** Component to render the toast notification.
+ *  The toastNotification is removed from the list after the time mentioned in notificationTimerDelay. */
+const ToastItem = ({ toastNotification }) => {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      // This filters out this toastNotification from the toastNotification's array. No API is called.
+      dispatch({
+        type: MARK_NOTIFICATION_READ,
+        payload: toastNotification.id,
+      });
+    }, notificationTimerDelay);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <ToastNotification
+      key={toastNotification.id}
+      kind={toastNotification.type}
+      lowContrast
+      title={EMPTY}
+      caption={EMPTY}
+      subtitle={toastNotification.message}
+      onClick={() => dispatch(markNotificationRead(toastNotification))}
+    >
+      {toastNotification.data.link && (
+        <div className="pull-right toast-pf-action">
+          <Link href={toastNotification.data.link}>{__('View details')}</Link>
+        </div>
+      )}
+      <span>{toastNotification.messages}</span>
+    </ToastNotification>
+  );
+};
+
+export default ToastItem;
+
+ToastItem.propTypes = {
+  toastNotification: PropTypes.objectOf(PropTypes.any).isRequired,
+};

--- a/app/javascript/components/toast-list/toast-list.jsx
+++ b/app/javascript/components/toast-list/toast-list.jsx
@@ -1,39 +1,16 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import React from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { ToastNotification, Link } from 'carbon-components-react';
-import { markNotificationRead } from '../../miq-redux/actions/notifications-actions';
-
-const notificationTimerDelay = 8000;
-const EMPTY = '';
+import { useSelector } from 'react-redux';
+import ToastItem from './toast-item';
 
 const ToastList = () => {
-  const dispatch = useDispatch();
   const toastNotifications = useSelector(({ notificationReducer: { toastNotifications } }) => toastNotifications);
 
   return (
     toastNotifications.length > 0 ? (
       <div id="toastnotification" className="toast-notification">
-        {toastNotifications.map((toastNotification) => (
-          <ToastNotification
-            key={toastNotification.id}
-            kind={toastNotification.type}
-            lowContrast
-            title={EMPTY}
-            caption={EMPTY}
-            subtitle={toastNotification.message}
-            onClick={() => {
-                return dispatch(markNotificationRead(toastNotification));
-            }}
-            timeout={notificationTimerDelay}
-          >
-            {toastNotification.data.link && (
-              <div className="pull-right toast-pf-action">
-                <Link href={toastNotification.data.link}>{__('View details')}</Link>
-              </div>
-            )}
-            <span>{toastNotification.messages}</span>
-          </ToastNotification>
+        {toastNotifications.slice(-3).map((toastNotification) => (
+          <ToastItem toastNotification={toastNotification} key={toastNotification.id} />
         ))}
       </div>
     ) : null

--- a/app/javascript/miq-redux/notification-reducer.js
+++ b/app/javascript/miq-redux/notification-reducer.js
@@ -37,7 +37,7 @@ export const notificationReducer = (state = notificationInitialState, action) =>
         notifications,
         unreadCount: notifications.filter(notification => notification.unread).length,
         totalNotificationsCount: state.totalNotificationsCount + 1,
-        toastNotifications: [action.payload, ...state.toastNotifications].slice(0, 3),
+        toastNotifications: [action.payload, ...state.toastNotifications],
       };
 
     case TOGGLE_DRAWER_VISIBILITY:

--- a/app/javascript/spec/toast-list/__snapshots__/toast-list.spec.js.snap
+++ b/app/javascript/spec/toast-list/__snapshots__/toast-list.spec.js.snap
@@ -18,322 +18,356 @@ exports[`Toast list tests should render correctly with notifications 1`] = `
       className="toast-notification"
       id="toastnotification"
     >
-      <FeatureToggle(ToastNotification)
-        caption=""
+      <ToastItem
         key="10000000003625"
-        kind="error"
-        lowContrast={true}
-        onClick={[Function]}
-        subtitle="Plan has completed with errors"
-        timeout={8000}
-        title=""
+        toastNotification={
+          Object {
+            "data": Object {
+              "link": "http://localhost:3000/api/notifications/10000000003624",
+            },
+            "href": "http://localhost:3000/api/notifications/10000000003625",
+            "id": "10000000003625",
+            "message": "Plan has completed with errors",
+            "notificationType": "event",
+            "timeStamp": "",
+            "type": "error",
+            "unread": true,
+          }
+        }
       >
-        <ToastNotification
+        <FeatureToggle(ToastNotification)
           caption=""
-          hideCloseButton={false}
-          iconDescription="closes notification"
+          key="10000000003625"
           kind="error"
           lowContrast={true}
-          notificationType="toast"
           onClick={[Function]}
-          onCloseButtonClick={[Function]}
-          role="alert"
           subtitle="Plan has completed with errors"
-          timeout={8000}
           title=""
         >
-          <div
-            className="bx--toast-notification bx--toast-notification--low-contrast bx--toast-notification--error"
+          <ToastNotification
+            caption=""
+            hideCloseButton={false}
+            iconDescription="closes notification"
             kind="error"
+            lowContrast={true}
+            notificationType="toast"
             onClick={[Function]}
+            onCloseButtonClick={[Function]}
             role="alert"
+            subtitle="Plan has completed with errors"
+            timeout={0}
+            title=""
           >
-            <NotificationIcon
-              iconDescription="error icon"
+            <div
+              className="bx--toast-notification bx--toast-notification--low-contrast bx--toast-notification--error"
               kind="error"
-              notificationType="toast"
+              onClick={[Function]}
+              role="alert"
             >
-              <ForwardRef(ErrorFilled20)
-                className="bx--toast-notification__icon"
+              <NotificationIcon
+                iconDescription="error icon"
+                kind="error"
+                notificationType="toast"
               >
-                <Icon
+                <ForwardRef(ErrorFilled20)
                   className="bx--toast-notification__icon"
-                  fill="currentColor"
-                  height={20}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 20 20"
-                  width={20}
-                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  <svg
-                    aria-hidden={true}
+                  <Icon
                     className="bx--toast-notification__icon"
                     fill="currentColor"
-                    focusable="false"
                     height={20}
                     preserveAspectRatio="xMidYMid meet"
                     viewBox="0 0 20 20"
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <path
-                      d="M10,1c-5,0-9,4-9,9s4,9,9,9s9-4,9-9S15,1,10,1z M13.5,14.5l-8-8l1-1l8,8L13.5,14.5z"
-                    />
-                    <path
-                      d="M13.5,14.5l-8-8l1-1l8,8L13.5,14.5z"
-                      data-icon-path="inner-path"
-                      opacity="0"
-                    />
-                    <title>
-                      error icon
-                    </title>
-                  </svg>
-                </Icon>
-              </ForwardRef(ErrorFilled20)>
-            </NotificationIcon>
-            <NotificationTextDetails
-              caption=""
-              notificationType="toast"
-              subtitle="Plan has completed with errors"
-              title=""
-            >
-              <div
-                className="bx--toast-notification__details"
-              >
-                <h3
-                  className="bx--toast-notification__title"
-                />
-                <div
-                  className="bx--toast-notification__subtitle"
-                >
-                  Plan has completed with errors
-                </div>
-                <div
-                  className="pull-right toast-pf-action"
-                >
-                  <Link
-                    href="http://localhost:3000/api/notifications/10000000003624"
-                  >
-                    <a
-                      className="bx--link"
-                      href="http://localhost:3000/api/notifications/10000000003624"
-                      rel={null}
-                    >
-                      View details
-                    </a>
-                  </Link>
-                </div>
-                <span />
-              </div>
-            </NotificationTextDetails>
-            <NotificationButton
-              ariaLabel="close notification"
-              iconDescription="closes notification"
-              notificationType="toast"
-              onClick={[Function]}
-              renderIcon={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "render": [Function],
-                }
-              }
-              type="button"
-            >
-              <button
-                aria-label="closes notification"
-                className="bx--toast-notification__close-button"
-                onClick={[Function]}
-                title="closes notification"
-                type="button"
-              >
-                <ForwardRef(Close20)
-                  aria-label="close notification"
-                  className="bx--toast-notification__close-icon"
-                >
-                  <Icon
-                    aria-label="close notification"
-                    className="bx--toast-notification__close-icon"
-                    fill="currentColor"
-                    height={20}
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width={20}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
                     <svg
-                      aria-label="close notification"
-                      className="bx--toast-notification__close-icon"
+                      aria-hidden={true}
+                      className="bx--toast-notification__icon"
                       fill="currentColor"
                       focusable="false"
                       height={20}
                       preserveAspectRatio="xMidYMid meet"
-                      role="img"
-                      viewBox="0 0 32 32"
+                      viewBox="0 0 20 20"
                       width={20}
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                        d="M10,1c-5,0-9,4-9,9s4,9,9,9s9-4,9-9S15,1,10,1z M13.5,14.5l-8-8l1-1l8,8L13.5,14.5z"
                       />
+                      <path
+                        d="M13.5,14.5l-8-8l1-1l8,8L13.5,14.5z"
+                        data-icon-path="inner-path"
+                        opacity="0"
+                      />
+                      <title>
+                        error icon
+                      </title>
                     </svg>
                   </Icon>
-                </ForwardRef(Close20)>
-              </button>
-            </NotificationButton>
-          </div>
-        </ToastNotification>
-      </FeatureToggle(ToastNotification)>
-      <FeatureToggle(ToastNotification)
-        caption=""
+                </ForwardRef(ErrorFilled20)>
+              </NotificationIcon>
+              <NotificationTextDetails
+                caption=""
+                notificationType="toast"
+                subtitle="Plan has completed with errors"
+                title=""
+              >
+                <div
+                  className="bx--toast-notification__details"
+                >
+                  <h3
+                    className="bx--toast-notification__title"
+                  />
+                  <div
+                    className="bx--toast-notification__subtitle"
+                  >
+                    Plan has completed with errors
+                  </div>
+                  <div
+                    className="pull-right toast-pf-action"
+                  >
+                    <Link
+                      href="http://localhost:3000/api/notifications/10000000003624"
+                    >
+                      <a
+                        className="bx--link"
+                        href="http://localhost:3000/api/notifications/10000000003624"
+                        rel={null}
+                      >
+                        View details
+                      </a>
+                    </Link>
+                  </div>
+                  <span />
+                </div>
+              </NotificationTextDetails>
+              <NotificationButton
+                ariaLabel="close notification"
+                iconDescription="closes notification"
+                notificationType="toast"
+                onClick={[Function]}
+                renderIcon={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "render": [Function],
+                  }
+                }
+                type="button"
+              >
+                <button
+                  aria-label="closes notification"
+                  className="bx--toast-notification__close-button"
+                  onClick={[Function]}
+                  title="closes notification"
+                  type="button"
+                >
+                  <ForwardRef(Close20)
+                    aria-label="close notification"
+                    className="bx--toast-notification__close-icon"
+                  >
+                    <Icon
+                      aria-label="close notification"
+                      className="bx--toast-notification__close-icon"
+                      fill="currentColor"
+                      height={20}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={20}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <svg
+                        aria-label="close notification"
+                        className="bx--toast-notification__close-icon"
+                        fill="currentColor"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                        />
+                      </svg>
+                    </Icon>
+                  </ForwardRef(Close20)>
+                </button>
+              </NotificationButton>
+            </div>
+          </ToastNotification>
+        </FeatureToggle(ToastNotification)>
+      </ToastItem>
+      <ToastItem
         key="10000000003624"
-        kind="success"
-        lowContrast={true}
-        onClick={[Function]}
-        subtitle="Plan has completed successfully"
-        timeout={8000}
-        title=""
+        toastNotification={
+          Object {
+            "data": Object {
+              "link": null,
+            },
+            "href": "http://localhost:3000/api/notifications/10000000003624",
+            "id": "10000000003624",
+            "message": "Plan has completed successfully",
+            "notificationType": "event",
+            "timeStamp": "",
+            "type": "success",
+            "unread": true,
+          }
+        }
       >
-        <ToastNotification
+        <FeatureToggle(ToastNotification)
           caption=""
-          hideCloseButton={false}
-          iconDescription="closes notification"
+          key="10000000003624"
           kind="success"
           lowContrast={true}
-          notificationType="toast"
           onClick={[Function]}
-          onCloseButtonClick={[Function]}
-          role="alert"
           subtitle="Plan has completed successfully"
-          timeout={8000}
           title=""
         >
-          <div
-            className="bx--toast-notification bx--toast-notification--low-contrast bx--toast-notification--success"
+          <ToastNotification
+            caption=""
+            hideCloseButton={false}
+            iconDescription="closes notification"
             kind="success"
+            lowContrast={true}
+            notificationType="toast"
             onClick={[Function]}
+            onCloseButtonClick={[Function]}
             role="alert"
+            subtitle="Plan has completed successfully"
+            timeout={0}
+            title=""
           >
-            <NotificationIcon
-              iconDescription="success icon"
+            <div
+              className="bx--toast-notification bx--toast-notification--low-contrast bx--toast-notification--success"
               kind="success"
-              notificationType="toast"
+              onClick={[Function]}
+              role="alert"
             >
-              <ForwardRef(CheckmarkFilled20)
-                className="bx--toast-notification__icon"
+              <NotificationIcon
+                iconDescription="success icon"
+                kind="success"
+                notificationType="toast"
               >
-                <Icon
+                <ForwardRef(CheckmarkFilled20)
                   className="bx--toast-notification__icon"
-                  fill="currentColor"
-                  height={20}
-                  preserveAspectRatio="xMidYMid meet"
-                  viewBox="0 0 20 20"
-                  width={20}
-                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  <svg
-                    aria-hidden={true}
+                  <Icon
                     className="bx--toast-notification__icon"
                     fill="currentColor"
-                    focusable="false"
                     height={20}
                     preserveAspectRatio="xMidYMid meet"
                     viewBox="0 0 20 20"
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <path
-                      d="M10,1c-4.9,0-9,4.1-9,9s4.1,9,9,9s9-4,9-9S15,1,10,1z M8.7,13.5l-3.2-3.2l1-1l2.2,2.2l4.8-4.8l1,1L8.7,13.5z"
-                    />
-                    <path
-                      d="M8.7,13.5l-3.2-3.2l1-1l2.2,2.2l4.8-4.8l1,1L8.7,13.5z"
-                      data-icon-path="inner-path"
-                      fill="none"
-                      opacity="0"
-                    />
-                    <title>
-                      success icon
-                    </title>
-                  </svg>
-                </Icon>
-              </ForwardRef(CheckmarkFilled20)>
-            </NotificationIcon>
-            <NotificationTextDetails
-              caption=""
-              notificationType="toast"
-              subtitle="Plan has completed successfully"
-              title=""
-            >
-              <div
-                className="bx--toast-notification__details"
-              >
-                <h3
-                  className="bx--toast-notification__title"
-                />
-                <div
-                  className="bx--toast-notification__subtitle"
-                >
-                  Plan has completed successfully
-                </div>
-                <span />
-              </div>
-            </NotificationTextDetails>
-            <NotificationButton
-              ariaLabel="close notification"
-              iconDescription="closes notification"
-              notificationType="toast"
-              onClick={[Function]}
-              renderIcon={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "render": [Function],
-                }
-              }
-              type="button"
-            >
-              <button
-                aria-label="closes notification"
-                className="bx--toast-notification__close-button"
-                onClick={[Function]}
-                title="closes notification"
-                type="button"
-              >
-                <ForwardRef(Close20)
-                  aria-label="close notification"
-                  className="bx--toast-notification__close-icon"
-                >
-                  <Icon
-                    aria-label="close notification"
-                    className="bx--toast-notification__close-icon"
-                    fill="currentColor"
-                    height={20}
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width={20}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
                     <svg
-                      aria-label="close notification"
-                      className="bx--toast-notification__close-icon"
+                      aria-hidden={true}
+                      className="bx--toast-notification__icon"
                       fill="currentColor"
                       focusable="false"
                       height={20}
                       preserveAspectRatio="xMidYMid meet"
-                      role="img"
-                      viewBox="0 0 32 32"
+                      viewBox="0 0 20 20"
                       width={20}
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                        d="M10,1c-4.9,0-9,4.1-9,9s4.1,9,9,9s9-4,9-9S15,1,10,1z M8.7,13.5l-3.2-3.2l1-1l2.2,2.2l4.8-4.8l1,1L8.7,13.5z"
                       />
+                      <path
+                        d="M8.7,13.5l-3.2-3.2l1-1l2.2,2.2l4.8-4.8l1,1L8.7,13.5z"
+                        data-icon-path="inner-path"
+                        fill="none"
+                        opacity="0"
+                      />
+                      <title>
+                        success icon
+                      </title>
                     </svg>
                   </Icon>
-                </ForwardRef(Close20)>
-              </button>
-            </NotificationButton>
-          </div>
-        </ToastNotification>
-      </FeatureToggle(ToastNotification)>
+                </ForwardRef(CheckmarkFilled20)>
+              </NotificationIcon>
+              <NotificationTextDetails
+                caption=""
+                notificationType="toast"
+                subtitle="Plan has completed successfully"
+                title=""
+              >
+                <div
+                  className="bx--toast-notification__details"
+                >
+                  <h3
+                    className="bx--toast-notification__title"
+                  />
+                  <div
+                    className="bx--toast-notification__subtitle"
+                  >
+                    Plan has completed successfully
+                  </div>
+                  <span />
+                </div>
+              </NotificationTextDetails>
+              <NotificationButton
+                ariaLabel="close notification"
+                iconDescription="closes notification"
+                notificationType="toast"
+                onClick={[Function]}
+                renderIcon={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "render": [Function],
+                  }
+                }
+                type="button"
+              >
+                <button
+                  aria-label="closes notification"
+                  className="bx--toast-notification__close-button"
+                  onClick={[Function]}
+                  title="closes notification"
+                  type="button"
+                >
+                  <ForwardRef(Close20)
+                    aria-label="close notification"
+                    className="bx--toast-notification__close-icon"
+                  >
+                    <Icon
+                      aria-label="close notification"
+                      className="bx--toast-notification__close-icon"
+                      fill="currentColor"
+                      height={20}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={20}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <svg
+                        aria-label="close notification"
+                        className="bx--toast-notification__close-icon"
+                        fill="currentColor"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                        />
+                      </svg>
+                    </Icon>
+                  </ForwardRef(Close20)>
+                </button>
+              </NotificationButton>
+            </div>
+          </ToastNotification>
+        </FeatureToggle(ToastNotification)>
+      </ToastItem>
     </div>
   </ToastList>
 </Provider>


### PR DESCRIPTION
Not every toast notification was rendered. only the recent 3 will be rendered.

**Before**

- 7/10 toast notifications were not being rendered.
- The `timeout` props were just hiding the `toastNotification` using the carbon component feature.
- The close button will mark the notification as read by removing the notification from the array + API call (no change here)

https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/be504c55-ee43-489a-8893-efea13eb12a0

**After**

- This PR renders 3 notifications at a time, till all are displayed
- All `toastNotification` will be displayed with a timeout feature.
- When timed-out, the notification will be marked as read and the notification will be removed from the list

https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/0bef7bd3-0fcf-4c69-8623-88ca759b0c03

**For testing**
`15.times {|count| Notification.create(:type => :vm_snapshot_failure, :options => options(count))}
`
```
def options(count)
{:snapshot_op=>"delete", :subject=>"Message-1", :error=>"test error"} 
end
```