### PR TITLE
Remove Id from Host Endpoint When Submitting Form

### DIFF
--- a/app/javascript/components/host-edit-form/host-edit-form.jsx
+++ b/app/javascript/components/host-edit-form/host-edit-form.jsx
@@ -77,13 +77,12 @@ const HostEditForm = ({ ids }) => {
       action: 'edit',
       resources,
     };
-    const selectedHostId = ids.length === 1 ? ids[0] : values.host_validate_against;
-    const request = API.post(`/api/hosts/${selectedHostId}`, payload);
+    const request = API.post(`/api/hosts/`, payload);
 
     request.then(() => {
       const message = ids.length === 1 ? sprintf(__('Modification of Host %s has been successfully queued.'), values.name)
         : __('Modification of multiple Hosts has been successfully queued.');
-      miqRedirectBack(message, 'success', `/host/show/${selectedHostId}`);
+      miqRedirectBack(message, 'success', ids.length === 1 ? `/host/show/${ids[0]}` : `/host/show_list`);
     }).catch(miqSparkleOff);
   };
 


### PR DESCRIPTION
The Host Edit form lets you edit either a single host or multiple at a time. This lead to a bug when submitting the payload where the form was calling `/api/hosts/{id}` but submitting edits to one or more hosts In the payload. The payload also included the id of the hosts inside which caused another error.

This change makes it so that the form just calls `/api/hosts/` instead while still keeping the id in the payload. Also changed the form redirect after submitting, to depend on whether your editing one or more hosts.