### PR TITLE
Fixed explorer tree accessibility violations

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1127,11 +1127,12 @@ module ApplicationHelper
   end
 
   def miq_tab_header(id, active = nil, options = {}, &_block)
-    tag_options = {:class => "#{options[:class]} #{active == id ? 'active' : ''}",
-                   'role' => 'tab',
+    tag_options = {:class          => "#{options[:class]} #{active == id ? 'active' : ''}",
+                   'role'          => 'tab',
+                   'tabindex'      => 0,
                    'aria-selected' => "#{active == id ? 'true' : 'false'}",
                    'aria-controls' => "#{id}",
-                   :id    => "#{id}_tab"}.merge!(options)
+                   :id             => "#{id}_tab"}.merge!(options)
 
     content_tag(:li, tag_options) do
       content_tag(:a, :href => "##{id}", 'data-toggle' => 'tab') do

--- a/app/helpers/application_helper/listnav.rb
+++ b/app/helpers/application_helper/listnav.rb
@@ -223,7 +223,7 @@ module ApplicationHelper
       id = valid_html_id(id)
       control_id = "control_#{id}"
       content_tag(:div, :class => "panel panel-default") do
-        out = content_tag(:div, :class => "panel-heading", 'role' => 'tab', :id => control_id) do
+        out = content_tag(:div, :class => "panel-heading", 'role' => 'tab', 'tabindex' => 0, :id => control_id) do
           content_tag(:h4, :class => "panel-title") do
             link_to(title, "##{id}",
                     'aria-controls' => id,

--- a/app/views/layouts/listnav/_explorer.html.haml
+++ b/app/views/layouts/listnav/_explorer.html.haml
@@ -1,5 +1,5 @@
 - if @accords
-  #accordion.panel-group{'ng-controller' => 'treeViewController as vm'}
+  #accordion.panel-group{'role' => 'tablist', 'ng-controller' => 'treeViewController as vm'}
     -# Set the first accordion as selected if there is no active_accord in the sandbox
     - selected = @accords.find(-> { @accords.first }) { |accord| accord[:name].to_sym == @sb[:active_accord] }
     - @accords.each do |accord|

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1002,7 +1002,7 @@ describe ApplicationHelper do
       let(:active) { true }
 
       it 'renders an active accordion' do
-        expect(subject).to eq("<div class=\"panel panel-default\"><div class=\"panel-heading\" role=\"tab\" id=\"control_identifier\"><h4 class=\"panel-title\"><a aria-controls=\"identifier\" data-parent=\"#accordion\" data-toggle=\"collapse\" class=\"\" tabindex=\"0\" href=\"#identifier\">title</a></h4></div><div id=\"identifier\" aria-labelledby=\"control_identifier\" role=\"tabpanel\" class=\"panel-collapse collapse in\"><div class=\"panel-body\">content</div></div></div>")
+        expect(subject).to eq("<div class=\"panel panel-default\"><div class=\"panel-heading\" role=\"tab\" tabindex=\"0\" id=\"control_identifier\"><h4 class=\"panel-title\"><a aria-controls=\"identifier\" data-parent=\"#accordion\" data-toggle=\"collapse\" class=\"\" tabindex=\"0\" href=\"#identifier\">title</a></h4></div><div id=\"identifier\" aria-labelledby=\"control_identifier\" role=\"tabpanel\" class=\"panel-collapse collapse in\"><div class=\"panel-body\">content</div></div></div>")
       end
     end
 
@@ -1010,7 +1010,7 @@ describe ApplicationHelper do
       let(:active) { false }
 
       it 'renders an active accordion' do
-        expect(subject).to eq("<div class=\"panel panel-default\"><div class=\"panel-heading\" role=\"tab\" id=\"control_identifier\"><h4 class=\"panel-title\"><a aria-controls=\"identifier\" data-parent=\"#accordion\" data-toggle=\"collapse\" class=\"collapsed\" tabindex=\"0\" href=\"#identifier\">title</a></h4></div><div id=\"identifier\" aria-labelledby=\"control_identifier\" role=\"tabpanel\" class=\"panel-collapse collapse \"><div class=\"panel-body\">content</div></div></div>")
+        expect(subject).to eq("<div class=\"panel panel-default\"><div class=\"panel-heading\" role=\"tab\" tabindex=\"0\" id=\"control_identifier\"><h4 class=\"panel-title\"><a aria-controls=\"identifier\" data-parent=\"#accordion\" data-toggle=\"collapse\" class=\"collapsed\" tabindex=\"0\" href=\"#identifier\">title</a></h4></div><div id=\"identifier\" aria-labelledby=\"control_identifier\" role=\"tabpanel\" class=\"panel-collapse collapse \"><div class=\"panel-body\">content</div></div></div>")
       end
     end
   end


### PR DESCRIPTION
Fixed explorer tree accessibility violations to reduce the number of violations that appear when running the accessibility scan  on pages that have an explorer tree.

Before:
<img width="1642" alt="Screenshot 2023-11-03 at 9 47 36 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/6da6084c-a906-442e-b917-cc9606ca5989">

After:
<img width="1651" alt="Screenshot 2023-11-03 at 9 51 31 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/893b28c5-1d97-4be6-909b-01a7650ca6d5">
