### PR TITLE
Fixed Service Reconfigure Form and Request Summary Pages

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -33,6 +33,8 @@ class ServiceController < ApplicationController
       service_retire
     when 'service_retire_now'
       service_retire_now
+    when 'service_reconfigure'
+      javascript_redirect(:action => 'service_reconfigure', :id => params[:id])
     when "custom_button"
       @display == 'generic_objects' ? generic_object_custom_buttons : custom_buttons
     else
@@ -74,16 +76,18 @@ class ServiceController < ApplicationController
     checked[0] = params[:id] if checked.blank? && params[:id]
     @service = find_record_with_rbac(Service, checked[0])
     @in_a_form = true
-    drop_breadcrumb(:name => _("Edit Service\"%{name}\"") % {:name => @service.name}, :url => "/service/edit/#{@service.id}")
+    drop_breadcrumb(:name => _("Edit Service \"%{name}\"") % {:name => @service.name}, :url => "/service/edit/#{@service.id}")
   end
 
   def service_reconfigure
-    service = Service.find_by(:id => params[:id])
+    assert_privileges('service_reconfigure')
+
+    service = find_record_with_rbac(Service, params[:id])
     service_template = service.service_template
     resource_action = service_template.resource_actions.find_by(:action => 'Reconfigure') if service_template
-
-    @right_cell_text = _("Reconfigure Service \"%{name}\"") % {:name => service.name}
-    dialog_locals = {:resource_action_id => resource_action.id, :target_id => service.id}
+    @dialog_locals = {:resource_action_id => resource_action.id, :target_id => service.id}
+    @in_a_form = true
+    drop_breadcrumb(:name => _("Reconfigure Service \"%{name}\"") % {:name => service.name}, :url => "/service/service_reconfigure/#{service.id}")
   end
 
   def service_form_fields

--- a/app/views/miq_request/_service_reconfigure_show.html.haml
+++ b/app/views/miq_request/_service_reconfigure_show.html.haml
@@ -4,11 +4,30 @@
   - ra = st.resource_actions.find_by_action('Reconfigure') if st
   - if ra && ra.dialog
     - values = @miq_request.options[:dialog]
-    - opts = {}
+    - opts = {:reconfigure => true}
+    - wf = ResourceActionWorkflow.new(values, current_user, ra, opts)
     %fieldset
       %h3
         = _("Dialog Options")
       .row
         .col-md-12.col-lg-12
-          = render :partial => "shared/dialogs/dialog_provision",
-                   :locals  => {:wf => ResourceActionWorkflow.new(values, current_user, ra, opts)}
+          #dialog_tabs
+            %ul.nav.nav-tabs{'role' => 'tablist'}
+              - wf.dialog.dialog_tabs.each_with_index do |tab, tab_index|
+                - options = tab_index == 0 ? {:class => "active"} : {}
+                = miq_tab_header(tab.id, nil, options) do
+                  = _(tab.label)
+            .tab-content
+              - wf.dialog.dialog_tabs.each_with_index do |tab, tab_index|
+                - options = tab_index == 0 ? {:class => "active"} : {}
+                = miq_tab_content(tab.id, nil, options) do
+                  - tab.dialog_groups.each do |group|
+                    %div{:id => "group_#{group.id}_div"}
+                      %h3{:title => "#{group.description}"}
+                        = _(group.label)
+                      - unless group.dialog_fields.empty?
+                        .form-horizontal
+                          - group.dialog_fields.each do |field|
+                            = render :partial => "miq_request/request_dialog_details",
+                                     :locals => {:wf => wf, :field => field}
+                      %hr

--- a/app/views/service/service_reconfigure.html.haml
+++ b/app/views/service/service_reconfigure.html.haml
@@ -1,0 +1,1 @@
+= render :partial => "shared/dialogs/reconfigure_dialog"

--- a/app/views/shared/dialogs/_reconfigure_dialog.html.haml
+++ b/app/views/shared/dialogs/_reconfigure_dialog.html.haml
@@ -20,6 +20,6 @@
                     'on-click' => "vm.cancelClicked($event)"}
 
   :javascript
-    ManageIQ.angular.app.value('resourceActionId', '#{resource_action_id}');
-    ManageIQ.angular.app.value('targetId', '#{target_id}');
+    ManageIQ.angular.app.value('resourceActionId', '#{@dialog_locals[:resource_action_id]}');
+    ManageIQ.angular.app.value('targetId', '#{@dialog_locals[:target_id]}');
     miq_bootstrap('.wrapper');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2776,6 +2776,7 @@ Rails.application.routes.draw do
       :get  => %w[
         dialog_load
         download_data
+        service_reconfigure
         reconfigure_form_fields
         retire
         button


### PR DESCRIPTION
Continuation Of: https://github.com/ManageIQ/manageiq-ui-classic/pull/8428

Returns the reconfigure service functionality accidentally removed in #8229. Also fixes an issue with the reconfigure service request summary page that was preventing the "Dialog Options" section from displaying correctly.

**Preview:**
Service Summary Page:
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/3368df2a-b1b3-4702-824e-c5e3c9e9863a)
Reconfigure Page:
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/b7008b03-3dff-429a-b12f-e1d48e8eba24)
Request Summary Page:
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/33262cae-15aa-4541-bda0-0f8ec87f66f8)

Note: https://github.com/ManageIQ/manageiq-ui-classic/pull/8951 will eventually convert these pages over to react