### PR TITLE
Fix table header accessibility issues

### DIFF
--- a/app/javascript/components/miq-data-table/index.jsx
+++ b/app/javascript/components/miq-data-table/index.jsx
@@ -89,10 +89,15 @@ const MiqDataTable = ({
   /** Function to render the header cells. */
   const renderHeaders = (getHeaderProps) => (headers.map((header) => {
     const { sortHeader, sortDirection } = headerSortingData(header);
+    let isSortable = true;
+    if (header.header.split('_')[0] === DefaultKey) {
+      isSortable = false;
+    }
     return (
       <TableHeader
         {...getHeaderProps({ header, isSortHeader: { sortable } })}
         onClick={() => sortable && onSort(header)}
+        isSortable={isSortable}
         isSortHeader={sortHeader}
         sortDirection={sortDirection}
         className={classNames('miq-data-table-header', (header.contentButton ? 'header-button' : ''))}

--- a/app/javascript/spec/reconfigure-vm-form/__snapshots__/reconfigure-vm-form.spec.js.snap
+++ b/app/javascript/spec/reconfigure-vm-form/__snapshots__/reconfigure-vm-form.spec.js.snap
@@ -5604,7 +5604,7 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="name"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -5612,20 +5612,100 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-236"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Name
+                                                                Click to sort rows by Name header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-236"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Name
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="type"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -5633,20 +5713,100 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-237"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Type
+                                                                Click to sort rows by Type header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-237"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Type
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="size"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -5654,20 +5814,100 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-238"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Size
+                                                                Click to sort rows by Size header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-238"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Size
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="unit"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -5675,20 +5915,100 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-239"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Unit
+                                                                Click to sort rows by Unit header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-239"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Unit
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="mode"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -5696,20 +6016,100 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-240"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Mode
+                                                                Click to sort rows by Mode header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-240"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Mode
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="controller"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -5717,20 +6117,100 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-241"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Controller Type
+                                                                Click to sort rows by Controller Type header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-241"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Controller Type
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="dependent"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -5738,20 +6218,100 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-242"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Dependent
+                                                                Click to sort rows by Dependent header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-242"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Dependent
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="backing"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -5759,20 +6319,100 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-243"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Delete Backing
+                                                                Click to sort rows by Delete Backing header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-243"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Delete Backing
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="bootable"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -5780,20 +6420,100 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-244"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Bootable
+                                                                Click to sort rows by Bootable header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-244"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Bootable
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="resize"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -5801,20 +6521,100 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-245"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Resize
+                                                                Click to sort rows by Resize header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-245"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Resize
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header header-button"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="action"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -5822,14 +6622,94 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header header-button"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-246"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Action
+                                                                Click to sort rows by Action header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-246"
+                                                                className="miq-data-table-header header-button bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Action
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                         </tr>
@@ -8553,7 +9433,7 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="name"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -8561,20 +9441,100 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-250"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Name
+                                                                Click to sort rows by Name header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-250"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Name
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="mac"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -8582,20 +9542,100 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-251"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                MAC address
+                                                                Click to sort rows by MAC address header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-251"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    MAC address
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="vlan"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -8603,20 +9643,100 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-252"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                vLan
+                                                                Click to sort rows by vLan header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-252"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    vLan
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header header-button"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="edit"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -8624,20 +9744,100 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header header-button"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-253"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Edit
+                                                                Click to sort rows by Edit header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-253"
+                                                                className="miq-data-table-header header-button bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Edit
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header header-button"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="action"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -8645,14 +9845,94 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header header-button"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-254"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Action
+                                                                Click to sort rows by Action header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-254"
+                                                                className="miq-data-table-header header-button bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Action
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                         </tr>
@@ -9011,7 +10291,7 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="name"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -9019,20 +10299,100 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-255"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Name
+                                                                Click to sort rows by Name header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-255"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Name
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="hostFile"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -9040,20 +10400,100 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-256"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Host File
+                                                                Click to sort rows by Host File header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-256"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Host File
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="disconnect"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -9061,20 +10501,100 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-257"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Disconnect
+                                                                Click to sort rows by Disconnect header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-257"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Disconnect
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="action"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -9082,14 +10602,94 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-258"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Actions
+                                                                Click to sort rows by Actions header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-258"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Actions
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                         </tr>
@@ -27361,7 +28961,7 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="name"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -27369,20 +28969,100 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-2"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Name
+                                                                Click to sort rows by Name header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-2"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Name
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="type"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -27390,20 +29070,100 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-3"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Type
+                                                                Click to sort rows by Type header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-3"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Type
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="size"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -27411,20 +29171,100 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-4"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Size
+                                                                Click to sort rows by Size header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-4"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Size
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="unit"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -27432,20 +29272,100 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-5"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Unit
+                                                                Click to sort rows by Unit header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-5"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Unit
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="mode"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -27453,20 +29373,100 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-6"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Mode
+                                                                Click to sort rows by Mode header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-6"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Mode
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="controller"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -27474,20 +29474,100 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-7"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Controller Type
+                                                                Click to sort rows by Controller Type header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-7"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Controller Type
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="dependent"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -27495,20 +29575,100 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-8"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Dependent
+                                                                Click to sort rows by Dependent header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-8"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Dependent
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="backing"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -27516,20 +29676,100 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-9"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Delete Backing
+                                                                Click to sort rows by Delete Backing header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-9"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Delete Backing
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="bootable"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -27537,20 +29777,100 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-10"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Bootable
+                                                                Click to sort rows by Bootable header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-10"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Bootable
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="resize"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -27558,20 +29878,100 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-11"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Resize
+                                                                Click to sort rows by Resize header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-11"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Resize
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header header-button"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="action"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -27579,14 +29979,94 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header header-button"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-12"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Action
+                                                                Click to sort rows by Action header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-12"
+                                                                className="miq-data-table-header header-button bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Action
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                         </tr>
@@ -30443,7 +32923,7 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="name"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -30451,20 +32931,100 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-16"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Name
+                                                                Click to sort rows by Name header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-16"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Name
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="mac"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -30472,20 +33032,100 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-17"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                MAC address
+                                                                Click to sort rows by MAC address header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-17"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    MAC address
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="vlan"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -30493,20 +33133,100 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-18"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                vLan
+                                                                Click to sort rows by vLan header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-18"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    vLan
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header header-button"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="edit"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -30514,20 +33234,100 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header header-button"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-19"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Edit
+                                                                Click to sort rows by Edit header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-19"
+                                                                className="miq-data-table-header header-button bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Edit
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header header-button"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="action"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -30535,14 +33335,94 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header header-button"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-20"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Action
+                                                                Click to sort rows by Action header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-20"
+                                                                className="miq-data-table-header header-button bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Action
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                         </tr>
@@ -31497,7 +34377,7 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                             <TableHeader
                                                               className="miq-data-table-header"
                                                               isSortHeader={false}
-                                                              isSortable={false}
+                                                              isSortable={true}
                                                               key="name"
                                                               onClick={[Function]}
                                                               scope="col"
@@ -31505,20 +34385,100 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                               translateWithId={[Function]}
                                                             >
                                                               <th
+                                                                aria-sort="none"
                                                                 className="miq-data-table-header"
                                                                 scope="col"
                                                               >
                                                                 <div
-                                                                  className="bx--table-header-label"
+                                                                  id="table-sort-23"
+                                                                  style={
+                                                                    Object {
+                                                                      "display": "none",
+                                                                    }
+                                                                  }
                                                                 >
-                                                                  Name
+                                                                  Click to sort rows by Name header in ascending order
                                                                 </div>
+                                                                <button
+                                                                  aria-describedby="table-sort-23"
+                                                                  className="miq-data-table-header bx--table-sort"
+                                                                  onClick={[Function]}
+                                                                  type="button"
+                                                                >
+                                                                  <span
+                                                                    className="bx--table-sort__flex"
+                                                                  >
+                                                                    <div
+                                                                      className="bx--table-header-label"
+                                                                    >
+                                                                      Name
+                                                                    </div>
+                                                                    <ForwardRef(ArrowUp20)
+                                                                      className="bx--table-sort__icon"
+                                                                    >
+                                                                      <Icon
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <svg
+                                                                          aria-hidden={true}
+                                                                          className="bx--table-sort__icon"
+                                                                          fill="currentColor"
+                                                                          focusable="false"
+                                                                          height={20}
+                                                                          preserveAspectRatio="xMidYMid meet"
+                                                                          viewBox="0 0 32 32"
+                                                                          width={20}
+                                                                          xmlns="http://www.w3.org/2000/svg"
+                                                                        >
+                                                                          <path
+                                                                            d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                          />
+                                                                        </svg>
+                                                                      </Icon>
+                                                                    </ForwardRef(ArrowUp20)>
+                                                                    <ForwardRef(ArrowsVertical20)
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                    >
+                                                                      <Icon
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <svg
+                                                                          aria-hidden={true}
+                                                                          className="bx--table-sort__icon-unsorted"
+                                                                          fill="currentColor"
+                                                                          focusable="false"
+                                                                          height={20}
+                                                                          preserveAspectRatio="xMidYMid meet"
+                                                                          viewBox="0 0 32 32"
+                                                                          width={20}
+                                                                          xmlns="http://www.w3.org/2000/svg"
+                                                                        >
+                                                                          <path
+                                                                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                          />
+                                                                        </svg>
+                                                                      </Icon>
+                                                                    </ForwardRef(ArrowsVertical20)>
+                                                                  </span>
+                                                                </button>
                                                               </th>
                                                             </TableHeader>
                                                             <TableHeader
                                                               className="miq-data-table-header"
                                                               isSortHeader={false}
-                                                              isSortable={false}
+                                                              isSortable={true}
                                                               key="hostFile"
                                                               onClick={[Function]}
                                                               scope="col"
@@ -31526,20 +34486,100 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                               translateWithId={[Function]}
                                                             >
                                                               <th
+                                                                aria-sort="none"
                                                                 className="miq-data-table-header"
                                                                 scope="col"
                                                               >
                                                                 <div
-                                                                  className="bx--table-header-label"
+                                                                  id="table-sort-24"
+                                                                  style={
+                                                                    Object {
+                                                                      "display": "none",
+                                                                    }
+                                                                  }
                                                                 >
-                                                                  Host File
+                                                                  Click to sort rows by Host File header in ascending order
                                                                 </div>
+                                                                <button
+                                                                  aria-describedby="table-sort-24"
+                                                                  className="miq-data-table-header bx--table-sort"
+                                                                  onClick={[Function]}
+                                                                  type="button"
+                                                                >
+                                                                  <span
+                                                                    className="bx--table-sort__flex"
+                                                                  >
+                                                                    <div
+                                                                      className="bx--table-header-label"
+                                                                    >
+                                                                      Host File
+                                                                    </div>
+                                                                    <ForwardRef(ArrowUp20)
+                                                                      className="bx--table-sort__icon"
+                                                                    >
+                                                                      <Icon
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <svg
+                                                                          aria-hidden={true}
+                                                                          className="bx--table-sort__icon"
+                                                                          fill="currentColor"
+                                                                          focusable="false"
+                                                                          height={20}
+                                                                          preserveAspectRatio="xMidYMid meet"
+                                                                          viewBox="0 0 32 32"
+                                                                          width={20}
+                                                                          xmlns="http://www.w3.org/2000/svg"
+                                                                        >
+                                                                          <path
+                                                                            d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                          />
+                                                                        </svg>
+                                                                      </Icon>
+                                                                    </ForwardRef(ArrowUp20)>
+                                                                    <ForwardRef(ArrowsVertical20)
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                    >
+                                                                      <Icon
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <svg
+                                                                          aria-hidden={true}
+                                                                          className="bx--table-sort__icon-unsorted"
+                                                                          fill="currentColor"
+                                                                          focusable="false"
+                                                                          height={20}
+                                                                          preserveAspectRatio="xMidYMid meet"
+                                                                          viewBox="0 0 32 32"
+                                                                          width={20}
+                                                                          xmlns="http://www.w3.org/2000/svg"
+                                                                        >
+                                                                          <path
+                                                                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                          />
+                                                                        </svg>
+                                                                      </Icon>
+                                                                    </ForwardRef(ArrowsVertical20)>
+                                                                  </span>
+                                                                </button>
                                                               </th>
                                                             </TableHeader>
                                                             <TableHeader
                                                               className="miq-data-table-header"
                                                               isSortHeader={false}
-                                                              isSortable={false}
+                                                              isSortable={true}
                                                               key="disconnect"
                                                               onClick={[Function]}
                                                               scope="col"
@@ -31547,20 +34587,100 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                               translateWithId={[Function]}
                                                             >
                                                               <th
+                                                                aria-sort="none"
                                                                 className="miq-data-table-header"
                                                                 scope="col"
                                                               >
                                                                 <div
-                                                                  className="bx--table-header-label"
+                                                                  id="table-sort-25"
+                                                                  style={
+                                                                    Object {
+                                                                      "display": "none",
+                                                                    }
+                                                                  }
                                                                 >
-                                                                  Disconnect
+                                                                  Click to sort rows by Disconnect header in ascending order
                                                                 </div>
+                                                                <button
+                                                                  aria-describedby="table-sort-25"
+                                                                  className="miq-data-table-header bx--table-sort"
+                                                                  onClick={[Function]}
+                                                                  type="button"
+                                                                >
+                                                                  <span
+                                                                    className="bx--table-sort__flex"
+                                                                  >
+                                                                    <div
+                                                                      className="bx--table-header-label"
+                                                                    >
+                                                                      Disconnect
+                                                                    </div>
+                                                                    <ForwardRef(ArrowUp20)
+                                                                      className="bx--table-sort__icon"
+                                                                    >
+                                                                      <Icon
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <svg
+                                                                          aria-hidden={true}
+                                                                          className="bx--table-sort__icon"
+                                                                          fill="currentColor"
+                                                                          focusable="false"
+                                                                          height={20}
+                                                                          preserveAspectRatio="xMidYMid meet"
+                                                                          viewBox="0 0 32 32"
+                                                                          width={20}
+                                                                          xmlns="http://www.w3.org/2000/svg"
+                                                                        >
+                                                                          <path
+                                                                            d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                          />
+                                                                        </svg>
+                                                                      </Icon>
+                                                                    </ForwardRef(ArrowUp20)>
+                                                                    <ForwardRef(ArrowsVertical20)
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                    >
+                                                                      <Icon
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <svg
+                                                                          aria-hidden={true}
+                                                                          className="bx--table-sort__icon-unsorted"
+                                                                          fill="currentColor"
+                                                                          focusable="false"
+                                                                          height={20}
+                                                                          preserveAspectRatio="xMidYMid meet"
+                                                                          viewBox="0 0 32 32"
+                                                                          width={20}
+                                                                          xmlns="http://www.w3.org/2000/svg"
+                                                                        >
+                                                                          <path
+                                                                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                          />
+                                                                        </svg>
+                                                                      </Icon>
+                                                                    </ForwardRef(ArrowsVertical20)>
+                                                                  </span>
+                                                                </button>
                                                               </th>
                                                             </TableHeader>
                                                             <TableHeader
                                                               className="miq-data-table-header"
                                                               isSortHeader={false}
-                                                              isSortable={false}
+                                                              isSortable={true}
                                                               key="action"
                                                               onClick={[Function]}
                                                               scope="col"
@@ -31568,14 +34688,94 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                               translateWithId={[Function]}
                                                             >
                                                               <th
+                                                                aria-sort="none"
                                                                 className="miq-data-table-header"
                                                                 scope="col"
                                                               >
                                                                 <div
-                                                                  className="bx--table-header-label"
+                                                                  id="table-sort-26"
+                                                                  style={
+                                                                    Object {
+                                                                      "display": "none",
+                                                                    }
+                                                                  }
                                                                 >
-                                                                  Actions
+                                                                  Click to sort rows by Actions header in ascending order
                                                                 </div>
+                                                                <button
+                                                                  aria-describedby="table-sort-26"
+                                                                  className="miq-data-table-header bx--table-sort"
+                                                                  onClick={[Function]}
+                                                                  type="button"
+                                                                >
+                                                                  <span
+                                                                    className="bx--table-sort__flex"
+                                                                  >
+                                                                    <div
+                                                                      className="bx--table-header-label"
+                                                                    >
+                                                                      Actions
+                                                                    </div>
+                                                                    <ForwardRef(ArrowUp20)
+                                                                      className="bx--table-sort__icon"
+                                                                    >
+                                                                      <Icon
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <svg
+                                                                          aria-hidden={true}
+                                                                          className="bx--table-sort__icon"
+                                                                          fill="currentColor"
+                                                                          focusable="false"
+                                                                          height={20}
+                                                                          preserveAspectRatio="xMidYMid meet"
+                                                                          viewBox="0 0 32 32"
+                                                                          width={20}
+                                                                          xmlns="http://www.w3.org/2000/svg"
+                                                                        >
+                                                                          <path
+                                                                            d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                          />
+                                                                        </svg>
+                                                                      </Icon>
+                                                                    </ForwardRef(ArrowUp20)>
+                                                                    <ForwardRef(ArrowsVertical20)
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                    >
+                                                                      <Icon
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <svg
+                                                                          aria-hidden={true}
+                                                                          className="bx--table-sort__icon-unsorted"
+                                                                          fill="currentColor"
+                                                                          focusable="false"
+                                                                          height={20}
+                                                                          preserveAspectRatio="xMidYMid meet"
+                                                                          viewBox="0 0 32 32"
+                                                                          width={20}
+                                                                          xmlns="http://www.w3.org/2000/svg"
+                                                                        >
+                                                                          <path
+                                                                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                          />
+                                                                        </svg>
+                                                                      </Icon>
+                                                                    </ForwardRef(ArrowsVertical20)>
+                                                                  </span>
+                                                                </button>
                                                               </th>
                                                             </TableHeader>
                                                           </tr>
@@ -38077,7 +41277,7 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="name"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -38085,20 +41285,100 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-184"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Name
+                                                                Click to sort rows by Name header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-184"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Name
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="type"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -38106,20 +41386,100 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-185"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Type
+                                                                Click to sort rows by Type header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-185"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Type
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="size"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -38127,20 +41487,100 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-186"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Size
+                                                                Click to sort rows by Size header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-186"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Size
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="unit"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -38148,20 +41588,100 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-187"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Unit
+                                                                Click to sort rows by Unit header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-187"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Unit
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="mode"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -38169,20 +41689,100 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-188"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Mode
+                                                                Click to sort rows by Mode header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-188"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Mode
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="controller"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -38190,20 +41790,100 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-189"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Controller Type
+                                                                Click to sort rows by Controller Type header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-189"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Controller Type
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="dependent"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -38211,20 +41891,100 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-190"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Dependent
+                                                                Click to sort rows by Dependent header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-190"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Dependent
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="backing"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -38232,20 +41992,100 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-191"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Delete Backing
+                                                                Click to sort rows by Delete Backing header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-191"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Delete Backing
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="bootable"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -38253,20 +42093,100 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-192"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Bootable
+                                                                Click to sort rows by Bootable header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-192"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Bootable
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="resize"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -38274,20 +42194,100 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-193"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Resize
+                                                                Click to sort rows by Resize header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-193"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Resize
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header header-button"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="action"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -38295,14 +42295,94 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header header-button"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-194"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Action
+                                                                Click to sort rows by Action header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-194"
+                                                                className="miq-data-table-header header-button bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Action
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                         </tr>
@@ -41013,7 +45093,7 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="name"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -41021,20 +45101,100 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-198"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Name
+                                                                Click to sort rows by Name header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-198"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Name
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="mac"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -41042,20 +45202,100 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-199"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                MAC address
+                                                                Click to sort rows by MAC address header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-199"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    MAC address
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="vlan"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -41063,20 +45303,100 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-200"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                vLan
+                                                                Click to sort rows by vLan header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-200"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    vLan
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header header-button"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="edit"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -41084,20 +45404,100 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header header-button"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-201"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Edit
+                                                                Click to sort rows by Edit header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-201"
+                                                                className="miq-data-table-header header-button bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Edit
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header header-button"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="action"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -41105,14 +45505,94 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header header-button"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-202"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Action
+                                                                Click to sort rows by Action header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-202"
+                                                                className="miq-data-table-header header-button bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Action
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                         </tr>
@@ -41471,7 +45951,7 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="name"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -41479,20 +45959,100 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-203"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Name
+                                                                Click to sort rows by Name header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-203"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Name
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="hostFile"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -41500,20 +46060,100 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-204"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Host File
+                                                                Click to sort rows by Host File header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-204"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Host File
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="disconnect"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -41521,20 +46161,100 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-205"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Disconnect
+                                                                Click to sort rows by Disconnect header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-205"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Disconnect
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                           <TableHeader
                                                             className="miq-data-table-header"
                                                             isSortHeader={false}
-                                                            isSortable={false}
+                                                            isSortable={true}
                                                             key="action"
                                                             onClick={[Function]}
                                                             scope="col"
@@ -41542,14 +46262,94 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                             translateWithId={[Function]}
                                                           >
                                                             <th
+                                                              aria-sort="none"
                                                               className="miq-data-table-header"
                                                               scope="col"
                                                             >
                                                               <div
-                                                                className="bx--table-header-label"
+                                                                id="table-sort-206"
+                                                                style={
+                                                                  Object {
+                                                                    "display": "none",
+                                                                  }
+                                                                }
                                                               >
-                                                                Actions
+                                                                Click to sort rows by Actions header in ascending order
                                                               </div>
+                                                              <button
+                                                                aria-describedby="table-sort-206"
+                                                                className="miq-data-table-header bx--table-sort"
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <span
+                                                                  className="bx--table-sort__flex"
+                                                                >
+                                                                  <div
+                                                                    className="bx--table-header-label"
+                                                                  >
+                                                                    Actions
+                                                                  </div>
+                                                                  <ForwardRef(ArrowUp20)
+                                                                    className="bx--table-sort__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowUp20)>
+                                                                  <ForwardRef(ArrowsVertical20)
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                  >
+                                                                    <Icon
+                                                                      className="bx--table-sort__icon-unsorted"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 32 32"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="bx--table-sort__icon-unsorted"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        viewBox="0 0 32 32"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowsVertical20)>
+                                                                </span>
+                                                              </button>
                                                             </th>
                                                           </TableHeader>
                                                         </tr>

--- a/app/javascript/spec/settings-compan-categories/__snapshots__/settings-company-categories.spec.js.snap
+++ b/app/javascript/spec/settings-compan-categories/__snapshots__/settings-company-categories.spec.js.snap
@@ -597,7 +597,7 @@ exports[`SettingsCompanyCategories component should render a SettingsCompanyCate
                       <TableHeader
                         className="miq-data-table-header"
                         isSortHeader={false}
-                        isSortable={false}
+                        isSortable={true}
                         key="name"
                         onClick={[Function]}
                         scope="col"
@@ -605,20 +605,100 @@ exports[`SettingsCompanyCategories component should render a SettingsCompanyCate
                         translateWithId={[Function]}
                       >
                         <th
+                          aria-sort="none"
                           className="miq-data-table-header"
                           scope="col"
                         >
                           <div
-                            className="bx--table-header-label"
+                            id="table-sort-2"
+                            style={
+                              Object {
+                                "display": "none",
+                              }
+                            }
                           >
-                            <Component />
+                            Click to sort rows by Name header in ascending order
                           </div>
+                          <button
+                            aria-describedby="table-sort-2"
+                            className="miq-data-table-header bx--table-sort"
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <span
+                              className="bx--table-sort__flex"
+                            >
+                              <div
+                                className="bx--table-header-label"
+                              >
+                                <Component />
+                              </div>
+                              <ForwardRef(ArrowUp20)
+                                className="bx--table-sort__icon"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowUp20)>
+                              <ForwardRef(ArrowsVertical20)
+                                className="bx--table-sort__icon-unsorted"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon-unsorted"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon-unsorted"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowsVertical20)>
+                            </span>
+                          </button>
                         </th>
                       </TableHeader>
                       <TableHeader
                         className="miq-data-table-header"
                         isSortHeader={false}
-                        isSortable={false}
+                        isSortable={true}
                         key="descripton"
                         onClick={[Function]}
                         scope="col"
@@ -626,20 +706,100 @@ exports[`SettingsCompanyCategories component should render a SettingsCompanyCate
                         translateWithId={[Function]}
                       >
                         <th
+                          aria-sort="none"
                           className="miq-data-table-header"
                           scope="col"
                         >
                           <div
-                            className="bx--table-header-label"
+                            id="table-sort-3"
+                            style={
+                              Object {
+                                "display": "none",
+                              }
+                            }
                           >
-                            <Component />
+                            Click to sort rows by Description header in ascending order
                           </div>
+                          <button
+                            aria-describedby="table-sort-3"
+                            className="miq-data-table-header bx--table-sort"
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <span
+                              className="bx--table-sort__flex"
+                            >
+                              <div
+                                className="bx--table-header-label"
+                              >
+                                <Component />
+                              </div>
+                              <ForwardRef(ArrowUp20)
+                                className="bx--table-sort__icon"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowUp20)>
+                              <ForwardRef(ArrowsVertical20)
+                                className="bx--table-sort__icon-unsorted"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon-unsorted"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon-unsorted"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowsVertical20)>
+                            </span>
+                          </button>
                         </th>
                       </TableHeader>
                       <TableHeader
                         className="miq-data-table-header"
                         isSortHeader={false}
-                        isSortable={false}
+                        isSortable={true}
                         key="show"
                         onClick={[Function]}
                         scope="col"
@@ -647,20 +807,100 @@ exports[`SettingsCompanyCategories component should render a SettingsCompanyCate
                         translateWithId={[Function]}
                       >
                         <th
+                          aria-sort="none"
                           className="miq-data-table-header"
                           scope="col"
                         >
                           <div
-                            className="bx--table-header-label"
+                            id="table-sort-4"
+                            style={
+                              Object {
+                                "display": "none",
+                              }
+                            }
                           >
-                            <Component />
+                            Click to sort rows by Show in Console header in ascending order
                           </div>
+                          <button
+                            aria-describedby="table-sort-4"
+                            className="miq-data-table-header bx--table-sort"
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <span
+                              className="bx--table-sort__flex"
+                            >
+                              <div
+                                className="bx--table-header-label"
+                              >
+                                <Component />
+                              </div>
+                              <ForwardRef(ArrowUp20)
+                                className="bx--table-sort__icon"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowUp20)>
+                              <ForwardRef(ArrowsVertical20)
+                                className="bx--table-sort__icon-unsorted"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon-unsorted"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon-unsorted"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowsVertical20)>
+                            </span>
+                          </button>
                         </th>
                       </TableHeader>
                       <TableHeader
                         className="miq-data-table-header"
                         isSortHeader={false}
-                        isSortable={false}
+                        isSortable={true}
                         key="single_value"
                         onClick={[Function]}
                         scope="col"
@@ -668,20 +908,100 @@ exports[`SettingsCompanyCategories component should render a SettingsCompanyCate
                         translateWithId={[Function]}
                       >
                         <th
+                          aria-sort="none"
                           className="miq-data-table-header"
                           scope="col"
                         >
                           <div
-                            className="bx--table-header-label"
+                            id="table-sort-5"
+                            style={
+                              Object {
+                                "display": "none",
+                              }
+                            }
                           >
-                            <Component />
+                            Click to sort rows by Single Value header in ascending order
                           </div>
+                          <button
+                            aria-describedby="table-sort-5"
+                            className="miq-data-table-header bx--table-sort"
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <span
+                              className="bx--table-sort__flex"
+                            >
+                              <div
+                                className="bx--table-header-label"
+                              >
+                                <Component />
+                              </div>
+                              <ForwardRef(ArrowUp20)
+                                className="bx--table-sort__icon"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowUp20)>
+                              <ForwardRef(ArrowsVertical20)
+                                className="bx--table-sort__icon-unsorted"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon-unsorted"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon-unsorted"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowsVertical20)>
+                            </span>
+                          </button>
                         </th>
                       </TableHeader>
                       <TableHeader
                         className="miq-data-table-header"
                         isSortHeader={false}
-                        isSortable={false}
+                        isSortable={true}
                         key="perf_by_tag"
                         onClick={[Function]}
                         scope="col"
@@ -689,20 +1009,100 @@ exports[`SettingsCompanyCategories component should render a SettingsCompanyCate
                         translateWithId={[Function]}
                       >
                         <th
+                          aria-sort="none"
                           className="miq-data-table-header"
                           scope="col"
                         >
                           <div
-                            className="bx--table-header-label"
+                            id="table-sort-6"
+                            style={
+                              Object {
+                                "display": "none",
+                              }
+                            }
                           >
-                            <Component />
+                            Click to sort rows by Capture C & U Data header in ascending order
                           </div>
+                          <button
+                            aria-describedby="table-sort-6"
+                            className="miq-data-table-header bx--table-sort"
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <span
+                              className="bx--table-sort__flex"
+                            >
+                              <div
+                                className="bx--table-header-label"
+                              >
+                                <Component />
+                              </div>
+                              <ForwardRef(ArrowUp20)
+                                className="bx--table-sort__icon"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowUp20)>
+                              <ForwardRef(ArrowsVertical20)
+                                className="bx--table-sort__icon-unsorted"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon-unsorted"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon-unsorted"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowsVertical20)>
+                            </span>
+                          </button>
                         </th>
                       </TableHeader>
                       <TableHeader
                         className="miq-data-table-header"
                         isSortHeader={false}
-                        isSortable={false}
+                        isSortable={true}
                         key="default"
                         onClick={[Function]}
                         scope="col"
@@ -710,20 +1110,100 @@ exports[`SettingsCompanyCategories component should render a SettingsCompanyCate
                         translateWithId={[Function]}
                       >
                         <th
+                          aria-sort="none"
                           className="miq-data-table-header"
                           scope="col"
                         >
                           <div
-                            className="bx--table-header-label"
+                            id="table-sort-7"
+                            style={
+                              Object {
+                                "display": "none",
+                              }
+                            }
                           >
-                            <Component />
+                            Click to sort rows by Default header in ascending order
                           </div>
+                          <button
+                            aria-describedby="table-sort-7"
+                            className="miq-data-table-header bx--table-sort"
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <span
+                              className="bx--table-sort__flex"
+                            >
+                              <div
+                                className="bx--table-header-label"
+                              >
+                                <Component />
+                              </div>
+                              <ForwardRef(ArrowUp20)
+                                className="bx--table-sort__icon"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowUp20)>
+                              <ForwardRef(ArrowsVertical20)
+                                className="bx--table-sort__icon-unsorted"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon-unsorted"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon-unsorted"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowsVertical20)>
+                            </span>
+                          </button>
                         </th>
                       </TableHeader>
                       <TableHeader
                         className="miq-data-table-header"
                         isSortHeader={false}
-                        isSortable={false}
+                        isSortable={true}
                         key="actions"
                         onClick={[Function]}
                         scope="col"
@@ -731,14 +1211,94 @@ exports[`SettingsCompanyCategories component should render a SettingsCompanyCate
                         translateWithId={[Function]}
                       >
                         <th
+                          aria-sort="none"
                           className="miq-data-table-header"
                           scope="col"
                         >
                           <div
-                            className="bx--table-header-label"
+                            id="table-sort-8"
+                            style={
+                              Object {
+                                "display": "none",
+                              }
+                            }
                           >
-                            <Component />
+                            Click to sort rows by Actions header in ascending order
                           </div>
+                          <button
+                            aria-describedby="table-sort-8"
+                            className="miq-data-table-header bx--table-sort"
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <span
+                              className="bx--table-sort__flex"
+                            >
+                              <div
+                                className="bx--table-header-label"
+                              >
+                                <Component />
+                              </div>
+                              <ForwardRef(ArrowUp20)
+                                className="bx--table-sort__icon"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowUp20)>
+                              <ForwardRef(ArrowsVertical20)
+                                className="bx--table-sort__icon-unsorted"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon-unsorted"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon-unsorted"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowsVertical20)>
+                            </span>
+                          </button>
                         </th>
                       </TableHeader>
                     </tr>

--- a/app/javascript/spec/settings-label-tag-mapping/__snapshots__/settings-label-tag-mapping.spec.js.snap
+++ b/app/javascript/spec/settings-label-tag-mapping/__snapshots__/settings-label-tag-mapping.spec.js.snap
@@ -460,7 +460,7 @@ exports[`SettingsLabelTagMapping component should render a SettingsLabelTagMappi
                       <TableHeader
                         className="miq-data-table-header"
                         isSortHeader={false}
-                        isSortable={false}
+                        isSortable={true}
                         key="resource_entity"
                         onClick={[Function]}
                         scope="col"
@@ -468,20 +468,100 @@ exports[`SettingsLabelTagMapping component should render a SettingsLabelTagMappi
                         translateWithId={[Function]}
                       >
                         <th
+                          aria-sort="none"
                           className="miq-data-table-header"
                           scope="col"
                         >
                           <div
-                            className="bx--table-header-label"
+                            id="table-sort-11"
+                            style={
+                              Object {
+                                "display": "none",
+                              }
+                            }
                           >
-                            Resource Entity
+                            Click to sort rows by Resource Entity header in ascending order
                           </div>
+                          <button
+                            aria-describedby="table-sort-11"
+                            className="miq-data-table-header bx--table-sort"
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <span
+                              className="bx--table-sort__flex"
+                            >
+                              <div
+                                className="bx--table-header-label"
+                              >
+                                Resource Entity
+                              </div>
+                              <ForwardRef(ArrowUp20)
+                                className="bx--table-sort__icon"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowUp20)>
+                              <ForwardRef(ArrowsVertical20)
+                                className="bx--table-sort__icon-unsorted"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon-unsorted"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon-unsorted"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowsVertical20)>
+                            </span>
+                          </button>
                         </th>
                       </TableHeader>
                       <TableHeader
                         className="miq-data-table-header"
                         isSortHeader={false}
-                        isSortable={false}
+                        isSortable={true}
                         key="resource_label"
                         onClick={[Function]}
                         scope="col"
@@ -489,20 +569,100 @@ exports[`SettingsLabelTagMapping component should render a SettingsLabelTagMappi
                         translateWithId={[Function]}
                       >
                         <th
+                          aria-sort="none"
                           className="miq-data-table-header"
                           scope="col"
                         >
                           <div
-                            className="bx--table-header-label"
+                            id="table-sort-12"
+                            style={
+                              Object {
+                                "display": "none",
+                              }
+                            }
                           >
-                            Resource Label
+                            Click to sort rows by Resource Label header in ascending order
                           </div>
+                          <button
+                            aria-describedby="table-sort-12"
+                            className="miq-data-table-header bx--table-sort"
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <span
+                              className="bx--table-sort__flex"
+                            >
+                              <div
+                                className="bx--table-header-label"
+                              >
+                                Resource Label
+                              </div>
+                              <ForwardRef(ArrowUp20)
+                                className="bx--table-sort__icon"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowUp20)>
+                              <ForwardRef(ArrowsVertical20)
+                                className="bx--table-sort__icon-unsorted"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon-unsorted"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon-unsorted"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowsVertical20)>
+                            </span>
+                          </button>
                         </th>
                       </TableHeader>
                       <TableHeader
                         className="miq-data-table-header"
                         isSortHeader={false}
-                        isSortable={false}
+                        isSortable={true}
                         key="tag_category"
                         onClick={[Function]}
                         scope="col"
@@ -510,20 +670,100 @@ exports[`SettingsLabelTagMapping component should render a SettingsLabelTagMappi
                         translateWithId={[Function]}
                       >
                         <th
+                          aria-sort="none"
                           className="miq-data-table-header"
                           scope="col"
                         >
                           <div
-                            className="bx--table-header-label"
+                            id="table-sort-13"
+                            style={
+                              Object {
+                                "display": "none",
+                              }
+                            }
                           >
-                            Tag Category
+                            Click to sort rows by Tag Category header in ascending order
                           </div>
+                          <button
+                            aria-describedby="table-sort-13"
+                            className="miq-data-table-header bx--table-sort"
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <span
+                              className="bx--table-sort__flex"
+                            >
+                              <div
+                                className="bx--table-header-label"
+                              >
+                                Tag Category
+                              </div>
+                              <ForwardRef(ArrowUp20)
+                                className="bx--table-sort__icon"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowUp20)>
+                              <ForwardRef(ArrowsVertical20)
+                                className="bx--table-sort__icon-unsorted"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon-unsorted"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon-unsorted"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowsVertical20)>
+                            </span>
+                          </button>
                         </th>
                       </TableHeader>
                       <TableHeader
                         className="miq-data-table-header"
                         isSortHeader={false}
-                        isSortable={false}
+                        isSortable={true}
                         key="actions"
                         onClick={[Function]}
                         scope="col"
@@ -531,14 +771,94 @@ exports[`SettingsLabelTagMapping component should render a SettingsLabelTagMappi
                         translateWithId={[Function]}
                       >
                         <th
+                          aria-sort="none"
                           className="miq-data-table-header"
                           scope="col"
                         >
                           <div
-                            className="bx--table-header-label"
+                            id="table-sort-14"
+                            style={
+                              Object {
+                                "display": "none",
+                              }
+                            }
                           >
-                            Actions
+                            Click to sort rows by Actions header in ascending order
                           </div>
+                          <button
+                            aria-describedby="table-sort-14"
+                            className="miq-data-table-header bx--table-sort"
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <span
+                              className="bx--table-sort__flex"
+                            >
+                              <div
+                                className="bx--table-header-label"
+                              >
+                                Actions
+                              </div>
+                              <ForwardRef(ArrowUp20)
+                                className="bx--table-sort__icon"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowUp20)>
+                              <ForwardRef(ArrowsVertical20)
+                                className="bx--table-sort__icon-unsorted"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon-unsorted"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon-unsorted"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowsVertical20)>
+                            </span>
+                          </button>
                         </th>
                       </TableHeader>
                     </tr>
@@ -3059,7 +3379,7 @@ exports[`SettingsLabelTagMapping component should render a SettingsLabelTagMappi
                       <TableHeader
                         className="miq-data-table-header"
                         isSortHeader={false}
-                        isSortable={false}
+                        isSortable={true}
                         key="resource_entity"
                         onClick={[Function]}
                         scope="col"
@@ -3067,20 +3387,100 @@ exports[`SettingsLabelTagMapping component should render a SettingsLabelTagMappi
                         translateWithId={[Function]}
                       >
                         <th
+                          aria-sort="none"
                           className="miq-data-table-header"
                           scope="col"
                         >
                           <div
-                            className="bx--table-header-label"
+                            id="table-sort-2"
+                            style={
+                              Object {
+                                "display": "none",
+                              }
+                            }
                           >
-                            Resource Entity
+                            Click to sort rows by Resource Entity header in ascending order
                           </div>
+                          <button
+                            aria-describedby="table-sort-2"
+                            className="miq-data-table-header bx--table-sort"
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <span
+                              className="bx--table-sort__flex"
+                            >
+                              <div
+                                className="bx--table-header-label"
+                              >
+                                Resource Entity
+                              </div>
+                              <ForwardRef(ArrowUp20)
+                                className="bx--table-sort__icon"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowUp20)>
+                              <ForwardRef(ArrowsVertical20)
+                                className="bx--table-sort__icon-unsorted"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon-unsorted"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon-unsorted"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowsVertical20)>
+                            </span>
+                          </button>
                         </th>
                       </TableHeader>
                       <TableHeader
                         className="miq-data-table-header"
                         isSortHeader={false}
-                        isSortable={false}
+                        isSortable={true}
                         key="resource_label"
                         onClick={[Function]}
                         scope="col"
@@ -3088,20 +3488,100 @@ exports[`SettingsLabelTagMapping component should render a SettingsLabelTagMappi
                         translateWithId={[Function]}
                       >
                         <th
+                          aria-sort="none"
                           className="miq-data-table-header"
                           scope="col"
                         >
                           <div
-                            className="bx--table-header-label"
+                            id="table-sort-3"
+                            style={
+                              Object {
+                                "display": "none",
+                              }
+                            }
                           >
-                            Resource Label
+                            Click to sort rows by Resource Label header in ascending order
                           </div>
+                          <button
+                            aria-describedby="table-sort-3"
+                            className="miq-data-table-header bx--table-sort"
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <span
+                              className="bx--table-sort__flex"
+                            >
+                              <div
+                                className="bx--table-header-label"
+                              >
+                                Resource Label
+                              </div>
+                              <ForwardRef(ArrowUp20)
+                                className="bx--table-sort__icon"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowUp20)>
+                              <ForwardRef(ArrowsVertical20)
+                                className="bx--table-sort__icon-unsorted"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon-unsorted"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon-unsorted"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowsVertical20)>
+                            </span>
+                          </button>
                         </th>
                       </TableHeader>
                       <TableHeader
                         className="miq-data-table-header"
                         isSortHeader={false}
-                        isSortable={false}
+                        isSortable={true}
                         key="tag_category"
                         onClick={[Function]}
                         scope="col"
@@ -3109,20 +3589,100 @@ exports[`SettingsLabelTagMapping component should render a SettingsLabelTagMappi
                         translateWithId={[Function]}
                       >
                         <th
+                          aria-sort="none"
                           className="miq-data-table-header"
                           scope="col"
                         >
                           <div
-                            className="bx--table-header-label"
+                            id="table-sort-4"
+                            style={
+                              Object {
+                                "display": "none",
+                              }
+                            }
                           >
-                            Tag Category
+                            Click to sort rows by Tag Category header in ascending order
                           </div>
+                          <button
+                            aria-describedby="table-sort-4"
+                            className="miq-data-table-header bx--table-sort"
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <span
+                              className="bx--table-sort__flex"
+                            >
+                              <div
+                                className="bx--table-header-label"
+                              >
+                                Tag Category
+                              </div>
+                              <ForwardRef(ArrowUp20)
+                                className="bx--table-sort__icon"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowUp20)>
+                              <ForwardRef(ArrowsVertical20)
+                                className="bx--table-sort__icon-unsorted"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon-unsorted"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon-unsorted"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowsVertical20)>
+                            </span>
+                          </button>
                         </th>
                       </TableHeader>
                       <TableHeader
                         className="miq-data-table-header"
                         isSortHeader={false}
-                        isSortable={false}
+                        isSortable={true}
                         key="actions"
                         onClick={[Function]}
                         scope="col"
@@ -3130,14 +3690,94 @@ exports[`SettingsLabelTagMapping component should render a SettingsLabelTagMappi
                         translateWithId={[Function]}
                       >
                         <th
+                          aria-sort="none"
                           className="miq-data-table-header"
                           scope="col"
                         >
                           <div
-                            className="bx--table-header-label"
+                            id="table-sort-5"
+                            style={
+                              Object {
+                                "display": "none",
+                              }
+                            }
                           >
-                            Actions
+                            Click to sort rows by Actions header in ascending order
                           </div>
+                          <button
+                            aria-describedby="table-sort-5"
+                            className="miq-data-table-header bx--table-sort"
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <span
+                              className="bx--table-sort__flex"
+                            >
+                              <div
+                                className="bx--table-header-label"
+                              >
+                                Actions
+                              </div>
+                              <ForwardRef(ArrowUp20)
+                                className="bx--table-sort__icon"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowUp20)>
+                              <ForwardRef(ArrowsVertical20)
+                                className="bx--table-sort__icon-unsorted"
+                              >
+                                <Icon
+                                  className="bx--table-sort__icon-unsorted"
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="bx--table-sort__icon-unsorted"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowsVertical20)>
+                            </span>
+                          </button>
                         </th>
                       </TableHeader>
                     </tr>

--- a/app/javascript/spec/tenant-quota-form/__snapshots__/tenant-quota-form.spec.js.snap
+++ b/app/javascript/spec/tenant-quota-form/__snapshots__/tenant-quota-form.spec.js.snap
@@ -254,7 +254,7 @@ exports[`Tenant Quota Form Component should render the manage quotas form for a 
                           <TableHeader
                             className="miq-data-table-header"
                             isSortHeader={false}
-                            isSortable={false}
+                            isSortable={true}
                             key="Enforced"
                             onClick={[Function]}
                             scope="col"
@@ -262,20 +262,100 @@ exports[`Tenant Quota Form Component should render the manage quotas form for a 
                             translateWithId={[Function]}
                           >
                             <th
+                              aria-sort="none"
                               className="miq-data-table-header"
                               scope="col"
                             >
                               <div
-                                className="bx--table-header-label"
+                                id="table-sort-1"
+                                style={
+                                  Object {
+                                    "display": "none",
+                                  }
+                                }
                               >
-                                Enforced
+                                Click to sort rows by Enforced header in ascending order
                               </div>
+                              <button
+                                aria-describedby="table-sort-1"
+                                className="miq-data-table-header bx--table-sort"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="bx--table-sort__flex"
+                                >
+                                  <div
+                                    className="bx--table-header-label"
+                                  >
+                                    Enforced
+                                  </div>
+                                  <ForwardRef(ArrowUp20)
+                                    className="bx--table-sort__icon"
+                                  >
+                                    <Icon
+                                      className="bx--table-sort__icon"
+                                      fill="currentColor"
+                                      height={20}
+                                      preserveAspectRatio="xMidYMid meet"
+                                      viewBox="0 0 32 32"
+                                      width={20}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="bx--table-sort__icon"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height={20}
+                                        preserveAspectRatio="xMidYMid meet"
+                                        viewBox="0 0 32 32"
+                                        width={20}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                        />
+                                      </svg>
+                                    </Icon>
+                                  </ForwardRef(ArrowUp20)>
+                                  <ForwardRef(ArrowsVertical20)
+                                    className="bx--table-sort__icon-unsorted"
+                                  >
+                                    <Icon
+                                      className="bx--table-sort__icon-unsorted"
+                                      fill="currentColor"
+                                      height={20}
+                                      preserveAspectRatio="xMidYMid meet"
+                                      viewBox="0 0 32 32"
+                                      width={20}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="bx--table-sort__icon-unsorted"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height={20}
+                                        preserveAspectRatio="xMidYMid meet"
+                                        viewBox="0 0 32 32"
+                                        width={20}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                        />
+                                      </svg>
+                                    </Icon>
+                                  </ForwardRef(ArrowsVertical20)>
+                                </span>
+                              </button>
                             </th>
                           </TableHeader>
                           <TableHeader
                             className="miq-data-table-header"
                             isSortHeader={false}
-                            isSortable={false}
+                            isSortable={true}
                             key="Description"
                             onClick={[Function]}
                             scope="col"
@@ -283,20 +363,100 @@ exports[`Tenant Quota Form Component should render the manage quotas form for a 
                             translateWithId={[Function]}
                           >
                             <th
+                              aria-sort="none"
                               className="miq-data-table-header"
                               scope="col"
                             >
                               <div
-                                className="bx--table-header-label"
+                                id="table-sort-2"
+                                style={
+                                  Object {
+                                    "display": "none",
+                                  }
+                                }
                               >
-                                Description
+                                Click to sort rows by Description header in ascending order
                               </div>
+                              <button
+                                aria-describedby="table-sort-2"
+                                className="miq-data-table-header bx--table-sort"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="bx--table-sort__flex"
+                                >
+                                  <div
+                                    className="bx--table-header-label"
+                                  >
+                                    Description
+                                  </div>
+                                  <ForwardRef(ArrowUp20)
+                                    className="bx--table-sort__icon"
+                                  >
+                                    <Icon
+                                      className="bx--table-sort__icon"
+                                      fill="currentColor"
+                                      height={20}
+                                      preserveAspectRatio="xMidYMid meet"
+                                      viewBox="0 0 32 32"
+                                      width={20}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="bx--table-sort__icon"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height={20}
+                                        preserveAspectRatio="xMidYMid meet"
+                                        viewBox="0 0 32 32"
+                                        width={20}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                        />
+                                      </svg>
+                                    </Icon>
+                                  </ForwardRef(ArrowUp20)>
+                                  <ForwardRef(ArrowsVertical20)
+                                    className="bx--table-sort__icon-unsorted"
+                                  >
+                                    <Icon
+                                      className="bx--table-sort__icon-unsorted"
+                                      fill="currentColor"
+                                      height={20}
+                                      preserveAspectRatio="xMidYMid meet"
+                                      viewBox="0 0 32 32"
+                                      width={20}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="bx--table-sort__icon-unsorted"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height={20}
+                                        preserveAspectRatio="xMidYMid meet"
+                                        viewBox="0 0 32 32"
+                                        width={20}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                        />
+                                      </svg>
+                                    </Icon>
+                                  </ForwardRef(ArrowsVertical20)>
+                                </span>
+                              </button>
                             </th>
                           </TableHeader>
                           <TableHeader
                             className="miq-data-table-header"
                             isSortHeader={false}
-                            isSortable={false}
+                            isSortable={true}
                             key="Value"
                             onClick={[Function]}
                             scope="col"
@@ -304,20 +464,100 @@ exports[`Tenant Quota Form Component should render the manage quotas form for a 
                             translateWithId={[Function]}
                           >
                             <th
+                              aria-sort="none"
                               className="miq-data-table-header"
                               scope="col"
                             >
                               <div
-                                className="bx--table-header-label"
+                                id="table-sort-3"
+                                style={
+                                  Object {
+                                    "display": "none",
+                                  }
+                                }
                               >
-                                Value
+                                Click to sort rows by Value header in ascending order
                               </div>
+                              <button
+                                aria-describedby="table-sort-3"
+                                className="miq-data-table-header bx--table-sort"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="bx--table-sort__flex"
+                                >
+                                  <div
+                                    className="bx--table-header-label"
+                                  >
+                                    Value
+                                  </div>
+                                  <ForwardRef(ArrowUp20)
+                                    className="bx--table-sort__icon"
+                                  >
+                                    <Icon
+                                      className="bx--table-sort__icon"
+                                      fill="currentColor"
+                                      height={20}
+                                      preserveAspectRatio="xMidYMid meet"
+                                      viewBox="0 0 32 32"
+                                      width={20}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="bx--table-sort__icon"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height={20}
+                                        preserveAspectRatio="xMidYMid meet"
+                                        viewBox="0 0 32 32"
+                                        width={20}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                        />
+                                      </svg>
+                                    </Icon>
+                                  </ForwardRef(ArrowUp20)>
+                                  <ForwardRef(ArrowsVertical20)
+                                    className="bx--table-sort__icon-unsorted"
+                                  >
+                                    <Icon
+                                      className="bx--table-sort__icon-unsorted"
+                                      fill="currentColor"
+                                      height={20}
+                                      preserveAspectRatio="xMidYMid meet"
+                                      viewBox="0 0 32 32"
+                                      width={20}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="bx--table-sort__icon-unsorted"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height={20}
+                                        preserveAspectRatio="xMidYMid meet"
+                                        viewBox="0 0 32 32"
+                                        width={20}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                        />
+                                      </svg>
+                                    </Icon>
+                                  </ForwardRef(ArrowsVertical20)>
+                                </span>
+                              </button>
                             </th>
                           </TableHeader>
                           <TableHeader
                             className="miq-data-table-header"
                             isSortHeader={false}
-                            isSortable={false}
+                            isSortable={true}
                             key="Units"
                             onClick={[Function]}
                             scope="col"
@@ -325,14 +565,94 @@ exports[`Tenant Quota Form Component should render the manage quotas form for a 
                             translateWithId={[Function]}
                           >
                             <th
+                              aria-sort="none"
                               className="miq-data-table-header"
                               scope="col"
                             >
                               <div
-                                className="bx--table-header-label"
+                                id="table-sort-4"
+                                style={
+                                  Object {
+                                    "display": "none",
+                                  }
+                                }
                               >
-                                Units
+                                Click to sort rows by Units header in ascending order
                               </div>
+                              <button
+                                aria-describedby="table-sort-4"
+                                className="miq-data-table-header bx--table-sort"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="bx--table-sort__flex"
+                                >
+                                  <div
+                                    className="bx--table-header-label"
+                                  >
+                                    Units
+                                  </div>
+                                  <ForwardRef(ArrowUp20)
+                                    className="bx--table-sort__icon"
+                                  >
+                                    <Icon
+                                      className="bx--table-sort__icon"
+                                      fill="currentColor"
+                                      height={20}
+                                      preserveAspectRatio="xMidYMid meet"
+                                      viewBox="0 0 32 32"
+                                      width={20}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="bx--table-sort__icon"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height={20}
+                                        preserveAspectRatio="xMidYMid meet"
+                                        viewBox="0 0 32 32"
+                                        width={20}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                        />
+                                      </svg>
+                                    </Icon>
+                                  </ForwardRef(ArrowUp20)>
+                                  <ForwardRef(ArrowsVertical20)
+                                    className="bx--table-sort__icon-unsorted"
+                                  >
+                                    <Icon
+                                      className="bx--table-sort__icon-unsorted"
+                                      fill="currentColor"
+                                      height={20}
+                                      preserveAspectRatio="xMidYMid meet"
+                                      viewBox="0 0 32 32"
+                                      width={20}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="bx--table-sort__icon-unsorted"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height={20}
+                                        preserveAspectRatio="xMidYMid meet"
+                                        viewBox="0 0 32 32"
+                                        width={20}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                        />
+                                      </svg>
+                                    </Icon>
+                                  </ForwardRef(ArrowsVertical20)>
+                                </span>
+                              </button>
                             </th>
                           </TableHeader>
                         </tr>
@@ -2066,7 +2386,7 @@ exports[`Tenant Quota Form Component should render the manage quotas form for a 
                           <TableHeader
                             className="miq-data-table-header"
                             isSortHeader={false}
-                            isSortable={false}
+                            isSortable={true}
                             key="Enforced"
                             onClick={[Function]}
                             scope="col"
@@ -2074,20 +2394,100 @@ exports[`Tenant Quota Form Component should render the manage quotas form for a 
                             translateWithId={[Function]}
                           >
                             <th
+                              aria-sort="none"
                               className="miq-data-table-header"
                               scope="col"
                             >
                               <div
-                                className="bx--table-header-label"
+                                id="table-sort-8"
+                                style={
+                                  Object {
+                                    "display": "none",
+                                  }
+                                }
                               >
-                                Enforced
+                                Click to sort rows by Enforced header in ascending order
                               </div>
+                              <button
+                                aria-describedby="table-sort-8"
+                                className="miq-data-table-header bx--table-sort"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="bx--table-sort__flex"
+                                >
+                                  <div
+                                    className="bx--table-header-label"
+                                  >
+                                    Enforced
+                                  </div>
+                                  <ForwardRef(ArrowUp20)
+                                    className="bx--table-sort__icon"
+                                  >
+                                    <Icon
+                                      className="bx--table-sort__icon"
+                                      fill="currentColor"
+                                      height={20}
+                                      preserveAspectRatio="xMidYMid meet"
+                                      viewBox="0 0 32 32"
+                                      width={20}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="bx--table-sort__icon"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height={20}
+                                        preserveAspectRatio="xMidYMid meet"
+                                        viewBox="0 0 32 32"
+                                        width={20}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                        />
+                                      </svg>
+                                    </Icon>
+                                  </ForwardRef(ArrowUp20)>
+                                  <ForwardRef(ArrowsVertical20)
+                                    className="bx--table-sort__icon-unsorted"
+                                  >
+                                    <Icon
+                                      className="bx--table-sort__icon-unsorted"
+                                      fill="currentColor"
+                                      height={20}
+                                      preserveAspectRatio="xMidYMid meet"
+                                      viewBox="0 0 32 32"
+                                      width={20}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="bx--table-sort__icon-unsorted"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height={20}
+                                        preserveAspectRatio="xMidYMid meet"
+                                        viewBox="0 0 32 32"
+                                        width={20}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                        />
+                                      </svg>
+                                    </Icon>
+                                  </ForwardRef(ArrowsVertical20)>
+                                </span>
+                              </button>
                             </th>
                           </TableHeader>
                           <TableHeader
                             className="miq-data-table-header"
                             isSortHeader={false}
-                            isSortable={false}
+                            isSortable={true}
                             key="Description"
                             onClick={[Function]}
                             scope="col"
@@ -2095,20 +2495,100 @@ exports[`Tenant Quota Form Component should render the manage quotas form for a 
                             translateWithId={[Function]}
                           >
                             <th
+                              aria-sort="none"
                               className="miq-data-table-header"
                               scope="col"
                             >
                               <div
-                                className="bx--table-header-label"
+                                id="table-sort-9"
+                                style={
+                                  Object {
+                                    "display": "none",
+                                  }
+                                }
                               >
-                                Description
+                                Click to sort rows by Description header in ascending order
                               </div>
+                              <button
+                                aria-describedby="table-sort-9"
+                                className="miq-data-table-header bx--table-sort"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="bx--table-sort__flex"
+                                >
+                                  <div
+                                    className="bx--table-header-label"
+                                  >
+                                    Description
+                                  </div>
+                                  <ForwardRef(ArrowUp20)
+                                    className="bx--table-sort__icon"
+                                  >
+                                    <Icon
+                                      className="bx--table-sort__icon"
+                                      fill="currentColor"
+                                      height={20}
+                                      preserveAspectRatio="xMidYMid meet"
+                                      viewBox="0 0 32 32"
+                                      width={20}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="bx--table-sort__icon"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height={20}
+                                        preserveAspectRatio="xMidYMid meet"
+                                        viewBox="0 0 32 32"
+                                        width={20}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                        />
+                                      </svg>
+                                    </Icon>
+                                  </ForwardRef(ArrowUp20)>
+                                  <ForwardRef(ArrowsVertical20)
+                                    className="bx--table-sort__icon-unsorted"
+                                  >
+                                    <Icon
+                                      className="bx--table-sort__icon-unsorted"
+                                      fill="currentColor"
+                                      height={20}
+                                      preserveAspectRatio="xMidYMid meet"
+                                      viewBox="0 0 32 32"
+                                      width={20}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="bx--table-sort__icon-unsorted"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height={20}
+                                        preserveAspectRatio="xMidYMid meet"
+                                        viewBox="0 0 32 32"
+                                        width={20}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                        />
+                                      </svg>
+                                    </Icon>
+                                  </ForwardRef(ArrowsVertical20)>
+                                </span>
+                              </button>
                             </th>
                           </TableHeader>
                           <TableHeader
                             className="miq-data-table-header"
                             isSortHeader={false}
-                            isSortable={false}
+                            isSortable={true}
                             key="Value"
                             onClick={[Function]}
                             scope="col"
@@ -2116,20 +2596,100 @@ exports[`Tenant Quota Form Component should render the manage quotas form for a 
                             translateWithId={[Function]}
                           >
                             <th
+                              aria-sort="none"
                               className="miq-data-table-header"
                               scope="col"
                             >
                               <div
-                                className="bx--table-header-label"
+                                id="table-sort-10"
+                                style={
+                                  Object {
+                                    "display": "none",
+                                  }
+                                }
                               >
-                                Value
+                                Click to sort rows by Value header in ascending order
                               </div>
+                              <button
+                                aria-describedby="table-sort-10"
+                                className="miq-data-table-header bx--table-sort"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="bx--table-sort__flex"
+                                >
+                                  <div
+                                    className="bx--table-header-label"
+                                  >
+                                    Value
+                                  </div>
+                                  <ForwardRef(ArrowUp20)
+                                    className="bx--table-sort__icon"
+                                  >
+                                    <Icon
+                                      className="bx--table-sort__icon"
+                                      fill="currentColor"
+                                      height={20}
+                                      preserveAspectRatio="xMidYMid meet"
+                                      viewBox="0 0 32 32"
+                                      width={20}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="bx--table-sort__icon"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height={20}
+                                        preserveAspectRatio="xMidYMid meet"
+                                        viewBox="0 0 32 32"
+                                        width={20}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                        />
+                                      </svg>
+                                    </Icon>
+                                  </ForwardRef(ArrowUp20)>
+                                  <ForwardRef(ArrowsVertical20)
+                                    className="bx--table-sort__icon-unsorted"
+                                  >
+                                    <Icon
+                                      className="bx--table-sort__icon-unsorted"
+                                      fill="currentColor"
+                                      height={20}
+                                      preserveAspectRatio="xMidYMid meet"
+                                      viewBox="0 0 32 32"
+                                      width={20}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="bx--table-sort__icon-unsorted"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height={20}
+                                        preserveAspectRatio="xMidYMid meet"
+                                        viewBox="0 0 32 32"
+                                        width={20}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                        />
+                                      </svg>
+                                    </Icon>
+                                  </ForwardRef(ArrowsVertical20)>
+                                </span>
+                              </button>
                             </th>
                           </TableHeader>
                           <TableHeader
                             className="miq-data-table-header"
                             isSortHeader={false}
-                            isSortable={false}
+                            isSortable={true}
                             key="Units"
                             onClick={[Function]}
                             scope="col"
@@ -2137,14 +2697,94 @@ exports[`Tenant Quota Form Component should render the manage quotas form for a 
                             translateWithId={[Function]}
                           >
                             <th
+                              aria-sort="none"
                               className="miq-data-table-header"
                               scope="col"
                             >
                               <div
-                                className="bx--table-header-label"
+                                id="table-sort-11"
+                                style={
+                                  Object {
+                                    "display": "none",
+                                  }
+                                }
                               >
-                                Units
+                                Click to sort rows by Units header in ascending order
                               </div>
+                              <button
+                                aria-describedby="table-sort-11"
+                                className="miq-data-table-header bx--table-sort"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="bx--table-sort__flex"
+                                >
+                                  <div
+                                    className="bx--table-header-label"
+                                  >
+                                    Units
+                                  </div>
+                                  <ForwardRef(ArrowUp20)
+                                    className="bx--table-sort__icon"
+                                  >
+                                    <Icon
+                                      className="bx--table-sort__icon"
+                                      fill="currentColor"
+                                      height={20}
+                                      preserveAspectRatio="xMidYMid meet"
+                                      viewBox="0 0 32 32"
+                                      width={20}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="bx--table-sort__icon"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height={20}
+                                        preserveAspectRatio="xMidYMid meet"
+                                        viewBox="0 0 32 32"
+                                        width={20}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                        />
+                                      </svg>
+                                    </Icon>
+                                  </ForwardRef(ArrowUp20)>
+                                  <ForwardRef(ArrowsVertical20)
+                                    className="bx--table-sort__icon-unsorted"
+                                  >
+                                    <Icon
+                                      className="bx--table-sort__icon-unsorted"
+                                      fill="currentColor"
+                                      height={20}
+                                      preserveAspectRatio="xMidYMid meet"
+                                      viewBox="0 0 32 32"
+                                      width={20}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="bx--table-sort__icon-unsorted"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height={20}
+                                        preserveAspectRatio="xMidYMid meet"
+                                        viewBox="0 0 32 32"
+                                        width={20}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                        />
+                                      </svg>
+                                    </Icon>
+                                  </ForwardRef(ArrowsVertical20)>
+                                </span>
+                              </button>
                             </th>
                           </TableHeader>
                         </tr>

--- a/app/javascript/spec/workflow-credential-mapping-form/__snapshots__/workflow-credential-mapping-form.spec.js.snap
+++ b/app/javascript/spec/workflow-credential-mapping-form/__snapshots__/workflow-credential-mapping-form.spec.js.snap
@@ -1878,7 +1878,7 @@ exports[`Workflow Credential Form Component should render mapping credentials to
                                                       <TableHeader
                                                         className="miq-data-table-header"
                                                         isSortHeader={false}
-                                                        isSortable={false}
+                                                        isSortable={true}
                                                         key="CredentialsIdentifier"
                                                         onClick={[Function]}
                                                         scope="col"
@@ -1886,20 +1886,100 @@ exports[`Workflow Credential Form Component should render mapping credentials to
                                                         translateWithId={[Function]}
                                                       >
                                                         <th
+                                                          aria-sort="none"
                                                           className="miq-data-table-header"
                                                           scope="col"
                                                         >
                                                           <div
-                                                            className="bx--table-header-label"
+                                                            id="table-sort-1"
+                                                            style={
+                                                              Object {
+                                                                "display": "none",
+                                                              }
+                                                            }
                                                           >
-                                                            Credentials Identifier
+                                                            Click to sort rows by Credentials Identifier header in ascending order
                                                           </div>
+                                                          <button
+                                                            aria-describedby="table-sort-1"
+                                                            className="miq-data-table-header bx--table-sort"
+                                                            onClick={[Function]}
+                                                            type="button"
+                                                          >
+                                                            <span
+                                                              className="bx--table-sort__flex"
+                                                            >
+                                                              <div
+                                                                className="bx--table-header-label"
+                                                              >
+                                                                Credentials Identifier
+                                                              </div>
+                                                              <ForwardRef(ArrowUp20)
+                                                                className="bx--table-sort__icon"
+                                                              >
+                                                                <Icon
+                                                                  className="bx--table-sort__icon"
+                                                                  fill="currentColor"
+                                                                  height={20}
+                                                                  preserveAspectRatio="xMidYMid meet"
+                                                                  viewBox="0 0 32 32"
+                                                                  width={20}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    className="bx--table-sort__icon"
+                                                                    fill="currentColor"
+                                                                    focusable="false"
+                                                                    height={20}
+                                                                    preserveAspectRatio="xMidYMid meet"
+                                                                    viewBox="0 0 32 32"
+                                                                    width={20}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <path
+                                                                      d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                    />
+                                                                  </svg>
+                                                                </Icon>
+                                                              </ForwardRef(ArrowUp20)>
+                                                              <ForwardRef(ArrowsVertical20)
+                                                                className="bx--table-sort__icon-unsorted"
+                                                              >
+                                                                <Icon
+                                                                  className="bx--table-sort__icon-unsorted"
+                                                                  fill="currentColor"
+                                                                  height={20}
+                                                                  preserveAspectRatio="xMidYMid meet"
+                                                                  viewBox="0 0 32 32"
+                                                                  width={20}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                    fill="currentColor"
+                                                                    focusable="false"
+                                                                    height={20}
+                                                                    preserveAspectRatio="xMidYMid meet"
+                                                                    viewBox="0 0 32 32"
+                                                                    width={20}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <path
+                                                                      d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                    />
+                                                                  </svg>
+                                                                </Icon>
+                                                              </ForwardRef(ArrowsVertical20)>
+                                                            </span>
+                                                          </button>
                                                         </th>
                                                       </TableHeader>
                                                       <TableHeader
                                                         className="miq-data-table-header"
                                                         isSortHeader={false}
-                                                        isSortable={false}
+                                                        isSortable={true}
                                                         key="CredentialRecord"
                                                         onClick={[Function]}
                                                         scope="col"
@@ -1907,20 +1987,100 @@ exports[`Workflow Credential Form Component should render mapping credentials to
                                                         translateWithId={[Function]}
                                                       >
                                                         <th
+                                                          aria-sort="none"
                                                           className="miq-data-table-header"
                                                           scope="col"
                                                         >
                                                           <div
-                                                            className="bx--table-header-label"
+                                                            id="table-sort-2"
+                                                            style={
+                                                              Object {
+                                                                "display": "none",
+                                                              }
+                                                            }
                                                           >
-                                                            Credential Record
+                                                            Click to sort rows by Credential Record header in ascending order
                                                           </div>
+                                                          <button
+                                                            aria-describedby="table-sort-2"
+                                                            className="miq-data-table-header bx--table-sort"
+                                                            onClick={[Function]}
+                                                            type="button"
+                                                          >
+                                                            <span
+                                                              className="bx--table-sort__flex"
+                                                            >
+                                                              <div
+                                                                className="bx--table-header-label"
+                                                              >
+                                                                Credential Record
+                                                              </div>
+                                                              <ForwardRef(ArrowUp20)
+                                                                className="bx--table-sort__icon"
+                                                              >
+                                                                <Icon
+                                                                  className="bx--table-sort__icon"
+                                                                  fill="currentColor"
+                                                                  height={20}
+                                                                  preserveAspectRatio="xMidYMid meet"
+                                                                  viewBox="0 0 32 32"
+                                                                  width={20}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    className="bx--table-sort__icon"
+                                                                    fill="currentColor"
+                                                                    focusable="false"
+                                                                    height={20}
+                                                                    preserveAspectRatio="xMidYMid meet"
+                                                                    viewBox="0 0 32 32"
+                                                                    width={20}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <path
+                                                                      d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                    />
+                                                                  </svg>
+                                                                </Icon>
+                                                              </ForwardRef(ArrowUp20)>
+                                                              <ForwardRef(ArrowsVertical20)
+                                                                className="bx--table-sort__icon-unsorted"
+                                                              >
+                                                                <Icon
+                                                                  className="bx--table-sort__icon-unsorted"
+                                                                  fill="currentColor"
+                                                                  height={20}
+                                                                  preserveAspectRatio="xMidYMid meet"
+                                                                  viewBox="0 0 32 32"
+                                                                  width={20}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                    fill="currentColor"
+                                                                    focusable="false"
+                                                                    height={20}
+                                                                    preserveAspectRatio="xMidYMid meet"
+                                                                    viewBox="0 0 32 32"
+                                                                    width={20}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <path
+                                                                      d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                    />
+                                                                  </svg>
+                                                                </Icon>
+                                                              </ForwardRef(ArrowsVertical20)>
+                                                            </span>
+                                                          </button>
                                                         </th>
                                                       </TableHeader>
                                                       <TableHeader
                                                         className="miq-data-table-header"
                                                         isSortHeader={false}
-                                                        isSortable={false}
+                                                        isSortable={true}
                                                         key="CredentialField"
                                                         onClick={[Function]}
                                                         scope="col"
@@ -1928,20 +2088,100 @@ exports[`Workflow Credential Form Component should render mapping credentials to
                                                         translateWithId={[Function]}
                                                       >
                                                         <th
+                                                          aria-sort="none"
                                                           className="miq-data-table-header"
                                                           scope="col"
                                                         >
                                                           <div
-                                                            className="bx--table-header-label"
+                                                            id="table-sort-3"
+                                                            style={
+                                                              Object {
+                                                                "display": "none",
+                                                              }
+                                                            }
                                                           >
-                                                            Credential Field
+                                                            Click to sort rows by Credential Field header in ascending order
                                                           </div>
+                                                          <button
+                                                            aria-describedby="table-sort-3"
+                                                            className="miq-data-table-header bx--table-sort"
+                                                            onClick={[Function]}
+                                                            type="button"
+                                                          >
+                                                            <span
+                                                              className="bx--table-sort__flex"
+                                                            >
+                                                              <div
+                                                                className="bx--table-header-label"
+                                                              >
+                                                                Credential Field
+                                                              </div>
+                                                              <ForwardRef(ArrowUp20)
+                                                                className="bx--table-sort__icon"
+                                                              >
+                                                                <Icon
+                                                                  className="bx--table-sort__icon"
+                                                                  fill="currentColor"
+                                                                  height={20}
+                                                                  preserveAspectRatio="xMidYMid meet"
+                                                                  viewBox="0 0 32 32"
+                                                                  width={20}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    className="bx--table-sort__icon"
+                                                                    fill="currentColor"
+                                                                    focusable="false"
+                                                                    height={20}
+                                                                    preserveAspectRatio="xMidYMid meet"
+                                                                    viewBox="0 0 32 32"
+                                                                    width={20}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <path
+                                                                      d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                    />
+                                                                  </svg>
+                                                                </Icon>
+                                                              </ForwardRef(ArrowUp20)>
+                                                              <ForwardRef(ArrowsVertical20)
+                                                                className="bx--table-sort__icon-unsorted"
+                                                              >
+                                                                <Icon
+                                                                  className="bx--table-sort__icon-unsorted"
+                                                                  fill="currentColor"
+                                                                  height={20}
+                                                                  preserveAspectRatio="xMidYMid meet"
+                                                                  viewBox="0 0 32 32"
+                                                                  width={20}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                    fill="currentColor"
+                                                                    focusable="false"
+                                                                    height={20}
+                                                                    preserveAspectRatio="xMidYMid meet"
+                                                                    viewBox="0 0 32 32"
+                                                                    width={20}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <path
+                                                                      d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                    />
+                                                                  </svg>
+                                                                </Icon>
+                                                              </ForwardRef(ArrowsVertical20)>
+                                                            </span>
+                                                          </button>
                                                         </th>
                                                       </TableHeader>
                                                       <TableHeader
                                                         className="miq-data-table-header"
                                                         isSortHeader={false}
-                                                        isSortable={false}
+                                                        isSortable={true}
                                                         key="Delete"
                                                         onClick={[Function]}
                                                         scope="col"
@@ -1949,14 +2189,94 @@ exports[`Workflow Credential Form Component should render mapping credentials to
                                                         translateWithId={[Function]}
                                                       >
                                                         <th
+                                                          aria-sort="none"
                                                           className="miq-data-table-header"
                                                           scope="col"
                                                         >
                                                           <div
-                                                            className="bx--table-header-label"
+                                                            id="table-sort-4"
+                                                            style={
+                                                              Object {
+                                                                "display": "none",
+                                                              }
+                                                            }
                                                           >
-                                                            Delete
+                                                            Click to sort rows by Delete header in ascending order
                                                           </div>
+                                                          <button
+                                                            aria-describedby="table-sort-4"
+                                                            className="miq-data-table-header bx--table-sort"
+                                                            onClick={[Function]}
+                                                            type="button"
+                                                          >
+                                                            <span
+                                                              className="bx--table-sort__flex"
+                                                            >
+                                                              <div
+                                                                className="bx--table-header-label"
+                                                              >
+                                                                Delete
+                                                              </div>
+                                                              <ForwardRef(ArrowUp20)
+                                                                className="bx--table-sort__icon"
+                                                              >
+                                                                <Icon
+                                                                  className="bx--table-sort__icon"
+                                                                  fill="currentColor"
+                                                                  height={20}
+                                                                  preserveAspectRatio="xMidYMid meet"
+                                                                  viewBox="0 0 32 32"
+                                                                  width={20}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    className="bx--table-sort__icon"
+                                                                    fill="currentColor"
+                                                                    focusable="false"
+                                                                    height={20}
+                                                                    preserveAspectRatio="xMidYMid meet"
+                                                                    viewBox="0 0 32 32"
+                                                                    width={20}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <path
+                                                                      d="M16 4L6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
+                                                                    />
+                                                                  </svg>
+                                                                </Icon>
+                                                              </ForwardRef(ArrowUp20)>
+                                                              <ForwardRef(ArrowsVertical20)
+                                                                className="bx--table-sort__icon-unsorted"
+                                                              >
+                                                                <Icon
+                                                                  className="bx--table-sort__icon-unsorted"
+                                                                  fill="currentColor"
+                                                                  height={20}
+                                                                  preserveAspectRatio="xMidYMid meet"
+                                                                  viewBox="0 0 32 32"
+                                                                  width={20}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    className="bx--table-sort__icon-unsorted"
+                                                                    fill="currentColor"
+                                                                    focusable="false"
+                                                                    height={20}
+                                                                    preserveAspectRatio="xMidYMid meet"
+                                                                    viewBox="0 0 32 32"
+                                                                    width={20}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <path
+                                                                      d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                                                                    />
+                                                                  </svg>
+                                                                </Icon>
+                                                              </ForwardRef(ArrowsVertical20)>
+                                                            </span>
+                                                          </button>
                                                         </th>
                                                       </TableHeader>
                                                     </tr>


### PR DESCRIPTION
Fixed table header accessibility issues for column headers without any text.

Before:
<img width="1670" alt="Screenshot 2023-11-03 at 4 39 42 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/9aa5c3c7-3031-475f-a0b9-bbcca415aa0f">

After:
<img width="1678" alt="Screenshot 2023-11-03 at 4 41 39 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/b12f5ef2-874e-43de-a8f2-b0d0f6ee20cc">
