### PR TITLE
Fix copy time profile error

### DIFF
--- a/app/views/configuration/_timeprofile_form.html.haml
+++ b/app/views/configuration/_timeprofile_form.html.haml
@@ -1,3 +1,3 @@
-- if @initial_reports_table_data.length() > 0
+- if @initial_reports_table_data.present?
   %h3= _('Reports Currently Using This Time Profile')
   = react('TimeProfileReportsTable', {:initialData => @initial_reports_table_data})


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/8966

Fixes an issue of an error screen being presented when trying to copy a new time profile.

Before:
<img width="1425" alt="Screenshot 2023-11-16 at 3 34 46 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/a80eb5d5-9b2b-4863-87ce-da05ce4534fe">

After:
<img width="1417" alt="Screenshot 2023-11-16 at 3 42 47 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/55d166fb-0826-44f9-a81f-dd973ec33616">

