### PR TITLE
Fix settings permissions

### DIFF
--- a/app/javascript/components/visual-settings-form/index.jsx
+++ b/app/javascript/components/visual-settings-form/index.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import MiqFormRenderer from '@@ddf';
 import createSchema from './visual-settings-form.schema';
 
-const VisualSettingsForm = ({ recordId, changeSettings }) => {
+const VisualSettingsForm = ({ recordId }) => {
   const [{ initialValues, timezoneOptions, isLoading }, setState] = useState({ isLoading: true });
 
   useEffect(() => {
@@ -24,17 +24,13 @@ const VisualSettingsForm = ({ recordId, changeSettings }) => {
   }, [recordId]);
 
   const onSubmit = (settings) => {
-    if (changeSettings) {
-      settings.perpage.list = parseInt(settings.perpage.list, 10);
-      settings.perpage.reports = parseInt(settings.perpage.reports, 10);
-      miqSparkleOn();
-      API.patch(`/api/users/${recordId}`, { settings }).then(() => {
-        window.location.reload();
-        add_flash(__('User Interface settings saved'), 'success');
-      }).catch(miqSparkleOff);
-    } else {
-      add_flash(__('The user is not authorized for this task or item.'), 'error');
-    }
+    settings.perpage.list = parseInt(settings.perpage.list, 10);
+    settings.perpage.reports = parseInt(settings.perpage.reports, 10);
+    miqSparkleOn();
+    API.patch(`/api/users/${recordId}`, { settings }).then(() => {
+      window.location.reload();
+      add_flash(__('User Interface settings saved'), 'success');
+    }).catch(miqSparkleOff);
   };
 
   return !isLoading && (
@@ -49,7 +45,6 @@ const VisualSettingsForm = ({ recordId, changeSettings }) => {
 
 VisualSettingsForm.propTypes = {
   recordId: PropTypes.string.isRequired,
-  changeSettings: PropTypes.bool.isRequired,
 };
 
 export default VisualSettingsForm;

--- a/app/javascript/components/visual-settings-form/index.jsx
+++ b/app/javascript/components/visual-settings-form/index.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import MiqFormRenderer from '@@ddf';
 import createSchema from './visual-settings-form.schema';
 
-const VisualSettingsForm = ({ recordId }) => {
+const VisualSettingsForm = ({ recordId, changeSettings }) => {
   const [{ initialValues, timezoneOptions, isLoading }, setState] = useState({ isLoading: true });
 
   useEffect(() => {
@@ -24,13 +24,17 @@ const VisualSettingsForm = ({ recordId }) => {
   }, [recordId]);
 
   const onSubmit = (settings) => {
-    settings.perpage.list = parseInt(settings.perpage.list, 10);
-    settings.perpage.reports = parseInt(settings.perpage.reports, 10);
-    miqSparkleOn();
-    API.patch(`/api/users/${recordId}`, { settings }).then(() => {
-      window.location.reload();
-      add_flash(__('User Interface settings saved'), 'success');
-    }).catch(miqSparkleOff);
+    if (changeSettings) {
+      settings.perpage.list = parseInt(settings.perpage.list, 10);
+      settings.perpage.reports = parseInt(settings.perpage.reports, 10);
+      miqSparkleOn();
+      API.patch(`/api/users/${recordId}`, { settings }).then(() => {
+        window.location.reload();
+        add_flash(__('User Interface settings saved'), 'success');
+      }).catch(miqSparkleOff);
+    } else {
+      add_flash(__('The user is not authorized for this task or item.'), 'error');
+    }
   };
 
   return !isLoading && (
@@ -45,6 +49,7 @@ const VisualSettingsForm = ({ recordId }) => {
 
 VisualSettingsForm.propTypes = {
   recordId: PropTypes.string.isRequired,
+  changeSettings: PropTypes.bool.isRequired,
 };
 
 export default VisualSettingsForm;

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -231,7 +231,7 @@ module Menu
 
       def settings_menu_section
         Menu::Section.new(:set, N_("Settings"), 'carbon--Settings', [
-          Menu::Item.new('configuration', N_('My Settings'), 'my_settings', {:feature => 'my_settings', :any => true}, '/configuration/index'),
+          Menu::Item.new('configuration', N_('My Settings'), 'my_settings', {:feature => 'my_settings_view', :any => true}, '/configuration/index'),
           Menu::Item.new('ops_explorer', N_('Application Settings'), 'ops_explorer', {:feature => 'ops_explorer', :any => true}, '/ops/explorer'),
           Menu::Item.new('my_tasks', N_('Tasks'), 'tasks', {:feature => 'tasks', :any => true}, '/miq_task/index?jobs_tab=tasks'),
           help_documentation,

--- a/app/views/configuration/_ui_3.html.haml
+++ b/app/views/configuration/_ui_3.html.haml
@@ -1,5 +1,5 @@
 = render :partial => "layouts/flash_msg"
-%div{:id => @tabs[1][1].split(" ")[0], 'role' => 'tabpanel', 'aria-labelledby' =>"#{@tabs[1][1].split(" ")[0]}_tab"}
+%div{:id => @labels[1], 'role' => 'tabpanel', 'aria-labelledby' =>"#{@labels[1]}_tab"}
   = form_tag({:action => 'update'},
              :id     => "config_form",
              :method => :post) do

--- a/app/views/configuration/_ui_4.html.haml
+++ b/app/views/configuration/_ui_4.html.haml
@@ -1,6 +1,5 @@
 = render :partial => "layouts/flash_msg"
-
-%div{:id => @tabs[2][1].split(" ")[0], 'role' => 'tabpanel', 'aria-labelledby' =>"#{@tabs[2][1].split(" ")[0]}_tab"}
+%div{:id => @labels[2], 'role' => 'tabpanel', 'aria-labelledby' => "#{@labels[2]}_tab"}
   %div{:style => "padding-top:10px"}
     - if @timeprofiles.empty?
       = render :partial => 'layouts/info_msg', :locals => {:message => _("No Records Found.")}

--- a/app/views/configuration/show.html.haml
+++ b/app/views/configuration/show.html.haml
@@ -1,9 +1,9 @@
 #main_div
   - case @tabform
   - when 'ui_1'
-    %div{:id => @tabs[0][1], 'role' => 'tabpanel', 'aria-labelledby' =>"#{@tabs[0][1]}_tab"}
+    %div{:id => @labels[0], 'role' => 'tabpanel', 'aria-labelledby' =>"#{@labels[0]}_tab"}
       = render :partial => "layouts/flash_msg"
-      = react 'VisualSettingsForm', {:recordId => current_user.id.to_s, :changeSettings => @change_settings}
+      = react 'VisualSettingsForm', :recordId => current_user.id.to_s
   - when 'ui_3'
     = render :partial => 'ui_3'
   - when 'ui_4'

--- a/app/views/configuration/show.html.haml
+++ b/app/views/configuration/show.html.haml
@@ -3,7 +3,7 @@
   - when 'ui_1'
     %div{:id => @tabs[0][1], 'role' => 'tabpanel', 'aria-labelledby' =>"#{@tabs[0][1]}_tab"}
       = render :partial => "layouts/flash_msg"
-      = react 'VisualSettingsForm', :recordId => current_user.id.to_s
+      = react 'VisualSettingsForm', {:recordId => current_user.id.to_s, :changeSettings => @change_settings}
   - when 'ui_3'
     = render :partial => 'ui_3'
   - when 'ui_4'


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/8970

Fixes various issues with the settings pages and their permissions.

1) My Settings menu item is now not displayed when Settings > View permissions are off.
<img width="517" alt="Screenshot 2023-11-28 at 10 15 12 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/08829aea-6b95-4908-9e4b-1ca059679e19">

2) Default Filters tab is now correctly displayed with no authentication error when missing at least 1 of the other Settings > Modify permissions.
<img width="1270" alt="Screenshot 2023-11-28 at 10 16 56 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/9803aa3f-6a3e-40e1-92b6-9b159112ff12">

3) Time Profiles tab is now correctly displayed with no authentication error when missing at least 1 of the other Settings > Modify permissions.
<img width="1276" alt="Screenshot 2023-11-28 at 10 19 13 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/47a71a8f-cd0b-4b02-a5f3-2fdd43f27d0e">

4) Default Filters tab is now correctly displayed with no error screen when only Settings > View and Settings > Modify > Default Filters permissions are on.
<img width="1283" alt="Screenshot 2023-11-28 at 10 24 58 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/ba44a66d-3d1a-48a1-8e4c-9e204af968c7">

5) Time Profiles tab is now correctly displayed with no error screen when only Settings > View and Settings > Modify > Time Profiles permissions are on.
<img width="1277" alt="Screenshot 2023-11-28 at 10 26 05 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/e636cd25-2476-4014-8fab-d2f35b3c7b09">
