### PR TITLE
Default Disk Unit Fix in VM Reconfigure Form

### DIFF
--- a/app/javascript/components/reconfigure-vm-form/disk-form-fields.js
+++ b/app/javascript/components/reconfigure-vm-form/disk-form-fields.js
@@ -35,7 +35,7 @@ const unitField = (data) => ({
   id: 'unit',
   name: 'unit',
   label: __('Unit'),
-  initialValue: data.form.action === TYPES.RESIZE ? getCellData(data.editingRow, 'unit') : '',
+  initialValue: data.form.action === TYPES.RESIZE ? getCellData(data.editingRow, 'unit') : __('GB'),
   options: restructureOptions([__('GB'), __('MB')]),
 });
 
@@ -103,7 +103,7 @@ const bootableField = (data, roles) => ({
   offText: __('No'),
   isReadOnly: data.form.action !== 'add',
   hideField: !roles.isRedhat,
-  initialValue: data.form.action === TYPES.RESIZE ? getSwitchData(data.editingRow, 'bootable') : '',
+  initialValue: data.form.action === TYPES.RESIZE ? getSwitchData(data.editingRow, 'bootable') : false,
 });
 
 export const diskFormFields = (data, roles, options, memory) => ([

--- a/app/javascript/components/reconfigure-vm-form/reconfigure-form-fields.js
+++ b/app/javascript/components/reconfigure-vm-form/reconfigure-form-fields.js
@@ -146,7 +146,7 @@ const driveTable = (data, roles, setData, onCellClick) => ({
   onCellClick,
   addButton: false,
   formType: TYPES.DRIVE,
-  hideField: data.dataTable.drives.length === 0,
+  hideField: !data.dataTable.drives || data.dataTable.drives.length === 0,
 });
 
 const renderDatatables = (recordId, data, roles, setData, onCellClick, buttonClick) => {

--- a/app/javascript/spec/reconfigure-vm-form/__snapshots__/reconfigure-vm-form.spec.js.snap
+++ b/app/javascript/spec/reconfigure-vm-form/__snapshots__/reconfigure-vm-form.spec.js.snap
@@ -13005,7 +13005,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                   Object {
                     "component": "select",
                     "id": "unit",
-                    "initialValue": "",
+                    "initialValue": "GB",
                     "label": "Unit",
                     "name": "unit",
                     "options": Array [
@@ -13086,7 +13086,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                   Object {
                     "component": "switch",
                     "hideField": false,
-                    "initialValue": "",
+                    "initialValue": false,
                     "isReadOnly": false,
                     "label": "Bootable",
                     "name": "bootable",
@@ -13229,7 +13229,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                     Object {
                       "component": "select",
                       "id": "unit",
-                      "initialValue": "",
+                      "initialValue": "GB",
                       "label": "Unit",
                       "name": "unit",
                       "options": Array [
@@ -13310,7 +13310,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                     Object {
                       "component": "switch",
                       "hideField": false,
-                      "initialValue": "",
+                      "initialValue": false,
                       "isReadOnly": false,
                       "label": "Bootable",
                       "name": "bootable",
@@ -13446,7 +13446,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                       Object {
                         "component": "select",
                         "id": "unit",
-                        "initialValue": "",
+                        "initialValue": "GB",
                         "label": "Unit",
                         "name": "unit",
                         "options": Array [
@@ -13527,7 +13527,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                       Object {
                         "component": "switch",
                         "hideField": false,
-                        "initialValue": "",
+                        "initialValue": false,
                         "isReadOnly": false,
                         "label": "Bootable",
                         "name": "bootable",
@@ -13662,7 +13662,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                           Object {
                             "component": "select",
                             "id": "unit",
-                            "initialValue": "",
+                            "initialValue": "GB",
                             "label": "Unit",
                             "name": "unit",
                             "options": Array [
@@ -13743,7 +13743,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                           Object {
                             "component": "switch",
                             "hideField": false,
-                            "initialValue": "",
+                            "initialValue": false,
                             "isReadOnly": false,
                             "label": "Bootable",
                             "name": "bootable",
@@ -13825,7 +13825,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                           Object {
                             "component": "select",
                             "id": "unit",
-                            "initialValue": "",
+                            "initialValue": "GB",
                             "label": "Unit",
                             "name": "unit",
                             "options": Array [
@@ -13906,7 +13906,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                           Object {
                             "component": "switch",
                             "hideField": false,
-                            "initialValue": "",
+                            "initialValue": false,
                             "isReadOnly": false,
                             "label": "Bootable",
                             "name": "bootable",
@@ -13992,7 +13992,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                             Object {
                               "component": "select",
                               "id": "unit",
-                              "initialValue": "",
+                              "initialValue": "GB",
                               "label": "Unit",
                               "name": "unit",
                               "options": Array [
@@ -14073,7 +14073,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                             Object {
                               "component": "switch",
                               "hideField": false,
-                              "initialValue": "",
+                              "initialValue": false,
                               "isReadOnly": false,
                               "label": "Bootable",
                               "name": "bootable",
@@ -14156,7 +14156,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                             Object {
                               "component": "select",
                               "id": "unit",
-                              "initialValue": "",
+                              "initialValue": "GB",
                               "label": "Unit",
                               "name": "unit",
                               "options": Array [
@@ -14237,7 +14237,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                             Object {
                               "component": "switch",
                               "hideField": false,
-                              "initialValue": "",
+                              "initialValue": false,
                               "isReadOnly": false,
                               "label": "Bootable",
                               "name": "bootable",
@@ -14323,7 +14323,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                           Object {
                             "component": "select",
                             "id": "unit",
-                            "initialValue": "",
+                            "initialValue": "GB",
                             "label": "Unit",
                             "name": "unit",
                             "options": Array [
@@ -14404,7 +14404,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                           Object {
                             "component": "switch",
                             "hideField": false,
-                            "initialValue": "",
+                            "initialValue": false,
                             "isReadOnly": false,
                             "label": "Bootable",
                             "name": "bootable",
@@ -14480,7 +14480,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                               Object {
                                 "component": "select",
                                 "id": "unit",
-                                "initialValue": "",
+                                "initialValue": "GB",
                                 "label": "Unit",
                                 "name": "unit",
                                 "options": Array [
@@ -14561,7 +14561,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                               Object {
                                 "component": "switch",
                                 "hideField": false,
-                                "initialValue": "",
+                                "initialValue": false,
                                 "isReadOnly": false,
                                 "label": "Bootable",
                                 "name": "bootable",
@@ -14641,7 +14641,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                                 Object {
                                   "component": "select",
                                   "id": "unit",
-                                  "initialValue": "",
+                                  "initialValue": "GB",
                                   "label": "Unit",
                                   "name": "unit",
                                   "options": Array [
@@ -14722,7 +14722,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                                 Object {
                                   "component": "switch",
                                   "hideField": false,
-                                  "initialValue": "",
+                                  "initialValue": false,
                                   "isReadOnly": false,
                                   "label": "Bootable",
                                   "name": "bootable",
@@ -15357,7 +15357,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                             <SingleField
                               component="select"
                               id="unit"
-                              initialValue=""
+                              initialValue="GB"
                               key="unit"
                               label="Unit"
                               name="unit"
@@ -15379,7 +15379,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                                   Object {
                                     "component": "select",
                                     "id": "unit",
-                                    "initialValue": "",
+                                    "initialValue": "GB",
                                     "label": "Unit",
                                     "name": "unit",
                                     "options": Array [
@@ -15401,7 +15401,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                                   <SelectWithOnChange
                                     component="select"
                                     id="unit"
-                                    initialValue=""
+                                    initialValue="GB"
                                     label="Unit"
                                     name="unit"
                                     options={
@@ -15421,7 +15421,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                                     <Select
                                       component="select"
                                       id="unit"
-                                      initialValue=""
+                                      initialValue="GB"
                                       label="Unit"
                                       loadingMessage="Loading..."
                                       name="unit"
@@ -15469,7 +15469,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                                         placeholder="<Choose>"
                                         pluckSingleValue={true}
                                         simpleValue={false}
-                                        value=""
+                                        value="GB"
                                       >
                                         <ClearedSelect
                                           className=""
@@ -15500,7 +15500,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                                             ]
                                           }
                                           placeholder="<Choose>"
-                                          value=""
+                                          value="GB"
                                         >
                                           <Select
                                             className=""
@@ -15516,7 +15516,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                                             onBlur={[Function]}
                                             onChange={[Function]}
                                             onFocus={[Function]}
-                                            value=""
+                                            value="GB"
                                           >
                                             <div
                                               className="bx--form-item"
@@ -15541,7 +15541,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                                                     onBlur={[Function]}
                                                     onChange={[Function]}
                                                     onFocus={[Function]}
-                                                    value=""
+                                                    value="GB"
                                                   >
                                                     <SelectItem
                                                       disabled={false}
@@ -16434,7 +16434,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                             <SingleField
                               component="switch"
                               hideField={false}
-                              initialValue=""
+                              initialValue={false}
                               isReadOnly={false}
                               key="bootable"
                               label="Bootable"
@@ -16446,7 +16446,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                                 field={
                                   Object {
                                     "component": "switch",
-                                    "initialValue": "",
+                                    "initialValue": false,
                                     "isReadOnly": false,
                                     "label": "Bootable",
                                     "name": "bootable",
@@ -16460,7 +16460,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                                 >
                                   <Switch
                                     component="switch"
-                                    initialValue=""
+                                    initialValue={false}
                                     isReadOnly={false}
                                     label="Bootable"
                                     name="bootable"


### PR DESCRIPTION
When trying to add a new disk in the VM reconfigure form, the default values for the Unit and Bootable fields were incorrectly being set to empty strings. This meant that if the user never directly changed these fields it would only look like they were setting them to `GB` and `false` respectively.
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/61494dc6-4acd-4b23-8272-5beec6f75cfe)

Later when submitting the form, these blank values would be set to defaults by the api, which was causing "GB" to be changed to "MB" in the reconfigure request.
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/97f355c9-8a30-4434-8303-5d895feaad71)

This change fixes this.