### PR TITLE
Fix ConfigurtionControllers failing rspec

### DIFF
--- a/spec/config/routes.pending.yml
+++ b/spec/config/routes.pending.yml
@@ -257,6 +257,7 @@ ConfigurationController:
 - report_data
 - show
 - tree_autoload
+- view_selected
 ConfigurationJobController:
 - download_data
 - download_summary_pdf


### PR DESCRIPTION
Before
<img width="1005" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/ac49f4b6-101f-4c96-9083-cd34194daa13">

