### PR TITLE
Fix my settings error screen

### DIFF
--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -360,6 +360,11 @@ class ConfigurationController < ApplicationController
         :key     => 'config_edit__ui4',
       }
       show_timeprofiles
+    else
+      @edit = {
+        :current => {},
+        :key     => '',
+      }
     end
     @edit[:new] = copy_hash(@edit[:current])
     session[:edit] = @edit


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/8979

Before an error screen is displayed when a user without any Modify permissions for Settings > My Settings visits the My Settings page. Now we display a blank screen instead. This is by design since without any Modify permissions no tabs will be rendered.

Before:
<img width="1211" alt="Screenshot 2023-11-28 at 8 43 58 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/66da4bb5-5c5b-40db-b816-87fe18642294">

After:
<img width="1270" alt="Screenshot 2023-11-29 at 2 22 44 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/7eacf9b5-8b07-4048-95bd-f7dc3e9a556d">
