### PR TITLE
Fix utilization accessibility issues

### DIFF
--- a/app/views/layouts/_perf_charts.html.haml
+++ b/app/views/layouts/_perf_charts.html.haml
@@ -1,4 +1,4 @@
-%div{:id => "#{chart_set}_charts_div", :onmousedown => "if (typeof miqMenu != 'undefined') miqMenu.hideContextMenu();"}
+%div{:id => "#{chart_set}_charts_div", :role => '', :onmousedown => "if (typeof miqMenu != 'undefined') miqMenu.hideContextMenu();"}
   - if @charts || @perf_options[:chart_type] != :performance
     - perf_options ||= @perf_options
     - single_chart_view = !!perf_options[:index] || chart_data.count == 1

--- a/app/views/utilization/_utilization_options.html.haml
+++ b/app/views/utilization/_utilization_options.html.haml
@@ -1,36 +1,38 @@
 - cap_type ||= "details"
 - url = url_for_only_path(:action => 'chart_chooser', :id => @record.id)
-%div{:id => "capacity_#{cap_type}_options_div", :onclick => "if (typeof miqMenu != 'undefined') miqMenu.hideContextMenu();"}
+%div{:id => "capacity_#{cap_type}_options_div", :role => '', :onclick => "if (typeof miqMenu != 'undefined') miqMenu.hideContextMenu();"}
   %h3
     = _('Options')
   .form-horizontal
     .form-group
-      %label.control-label.col-md-2
+      %label.control-label.col-md-2{:id => "#{cap_type}_trends_label"}
         = _('Trends for past')
       .col-md-10
         = select_tag("#{cap_type}_days",
           options_for_select(ViewHelper::WEEK_CHOICES.map {|k, v| [_(v), k]}.sort, @sb[:options][:days].to_i),
-          "class"               => "selectpicker")
+          "class"               => "selectpicker",
+          "aria-labelledby"     => "#{cap_type}_trends_label")
         :javascript
           miqInitSelectPicker();
           miqSelectPickerEvent("#{cap_type}_days", "#{url}", {beforeSend: true});
 
   .form-horizontal
     .form-group
-      %label.control-label.col-md-2
+      %label.control-label.col-md-2{:id => "#{cap_type}_classification_label"}
         = _('Classification')
       .col-md-10
         - options = [["<#{_('None')}>", "<None>"]] + (@sb[:tags] ? @sb[:tags].invert.sort : [])
         = select_tag("#{cap_type}_tag",
           options_for_select(options, @sb[:options][:tag]),
-          "class"               => "selectpicker")
+          "class"               => "selectpicker",
+          "aria-labelledby"     => "#{cap_type}_classification_label")
         :javascript
           miqInitSelectPicker();
           miqSelectPickerEvent("#{cap_type}_tag", "#{url}", {beforeSend: true});
 
   .form-horizontal
     .form-group
-      %label.control-label.col-md-2
+      %label.control-label.col-md-2{:id => "#{cap_type}_time_profile_label"}
         = _('Time Profile')
       .col-md-10
         - if session[:time_profiles].blank?
@@ -42,18 +44,20 @@
           = select_tag("#{cap_type}_time_profile",
             options_for_select(Array(session[:time_profiles].invert).sort_by(&:first),
             @sb[:options][:time_profile]),
-            "class"               => "selectpicker")
+            "class"               => "selectpicker",
+            "aria-labelledby"     => "#{cap_type}_time_profile_label")
           :javascript
             miqInitSelectPicker();
             miqSelectPickerEvent("#{cap_type}_time_profile", "#{url}", {beforeSend: true});
     - if %w(summ report).include?(cap_type)
       - date_id = cap_type == "summ" ? "1" : "2"
       .form-group
-        %label.control-label.col-md-2
+        %label.control-label.col-md-2{:id => "#{cap_type}_day_label"}
           = _('Selected Day')
         .col-md-10
           = datepicker_input_tag("miq_date_#{date_id}",
             @sb[:options][:chart_date],
             :readonly               => "true",
             "data-miq_sparkle_on"   => true,
-            "data-miq_observe_date" => {:url => url}.to_json)
+            "data-miq_observe_date" => {:url => url}.to_json,
+            "aria-labelledby"       => "#{cap_type}_day_label")


### PR DESCRIPTION
Fix accessibility violations in the Accessibility Assessment Scanner for the Overview > Utilization page. The last remaining violation is due to the explorer tree and will exist until the explorer screens are removed.

Before:
<img width="1673" alt="Screenshot 2023-12-01 at 1 49 11 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/081fc17a-c3f2-41ed-880e-089f638c6924">
<img width="1706" alt="Screenshot 2023-12-01 at 1 49 29 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/a1aa308c-0c87-4dcb-b819-017429131a5c">
<img width="1694" alt="Screenshot 2023-12-01 at 1 49 45 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/c289329f-f446-4168-8277-11a03badd2f7">

After:
<img width="1637" alt="Screenshot 2023-12-01 at 1 43 56 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/eae1b7e2-9db4-4dd7-9bcf-995449887139">
<img width="1717" alt="Screenshot 2023-12-01 at 1 44 36 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/6edb6e71-68cc-4e60-bd9b-fc2ebc1bbfac">
<img width="1719" alt="Screenshot 2023-12-01 at 1 45 25 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/d3b24ca8-3aae-4b0b-b43e-c9a20b197f06">
