### PR TITLE
Fix incorrect settings tab aria-labelledby id

### DIFF
--- a/app/views/configuration/_ui_4.html.haml
+++ b/app/views/configuration/_ui_4.html.haml
@@ -1,5 +1,5 @@
 = render :partial => "layouts/flash_msg"
-%div{:id => @labels[2], 'role' => 'tabpanel', 'aria-labelledby' => '3'}
+%div{:id => @labels[2], 'role' => 'tabpanel', 'aria-labelledby' => '4'}
   %div{:style => "padding-top:10px"}
     - if @timeprofiles.empty?
       = render :partial => 'layouts/info_msg', :locals => {:message => _("No Records Found.")}


### PR DESCRIPTION
Fix incorrect settings tab aria-labelledby id caused by this pr: https://github.com/ManageIQ/manageiq-ui-classic/pull/8956