### PR TITLE
Return Username Field to "LDAP Group Look Up" Section

### DIFF
--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -96,7 +96,17 @@
                                :class             => "form-control",
                                "data-miq_observe" => {:interval => '.5',
                                                       :url      => url}.to_json)
-
+          - unless mode == "httpd"
+            .form-group#user_name_form_group
+              %label.col-md-2.control-label
+                = _("Username")
+              .col-md-8
+                = text_field_tag("user_id",
+                                  @edit[:new][:user_id],
+                                  :maxlength         => 255,
+                                  :class             => "form-control",
+                                  "data-miq_observe" => {:interval => '.5',
+                                                        :url      => url}.to_json)
             .form-group#user_password_form_group
               %label.col-md-2.control-label
                 = _("Password")


### PR DESCRIPTION
The Username field was accidentally removed in https://github.com/ManageIQ/manageiq-ui-classic/pull/8723 and was causing a `Username must be entered to perform LDAP Group Look Up` error. This change brings the field back.

Before:
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/4e3c1bc3-9677-41de-ac69-de133db032b3)

After:
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/feda185a-954b-4c11-bee9-97f6bcd161e5)
 