### PR TITLE
filter vms displayed in tree lan

### DIFF
--- a/app/presenters/tree_builder_network.rb
+++ b/app/presenters/tree_builder_network.rb
@@ -27,18 +27,15 @@ class TreeBuilderNetwork < TreeBuilder
   end
 
   def x_get_tree_roots
-    @root.switches.empty? ? [] : count_only_or_objects(false, @root.switches)
+    Rbac.filtered(@root.switches)
   end
 
   def x_get_tree_switch_kids(parent, count_only)
-    objects = []
-    objects.concat(parent.guest_devices) unless parent.guest_devices.empty?
-    objects.concat(parent.lans) unless parent.lans.empty?
-    count_only_or_objects(count_only, objects)
+    count_only_or_objects_filtered(count_only, parent.guest_devices) + count_only_or_objects_filtered(count_only, parent.lans)
   end
 
   def x_get_tree_lan_kids(parent, count_only)
-    if parent.respond_to?("vms_and_templates")
+    if parent.respond_to?(:vms_and_templates)
       count_only_or_objects_filtered(count_only, parent.vms_and_templates, "name")
     else
       count_only ? 0 : []

--- a/app/presenters/tree_builder_network.rb
+++ b/app/presenters/tree_builder_network.rb
@@ -38,10 +38,10 @@ class TreeBuilderNetwork < TreeBuilder
   end
 
   def x_get_tree_lan_kids(parent, count_only)
-    kids = count_only ? 0 : []
-    if parent.respond_to?("vms_and_templates") && parent.vms_and_templates.present?
-      kids = count_only_or_objects(count_only, parent.vms_and_templates, "name")
+    if parent.respond_to?("vms_and_templates")
+      count_only_or_objects_filtered(count_only, parent.vms_and_templates, "name")
+    else
+      count_only ? 0 : []
     end
-    kids
   end
 end

--- a/spec/presenters/tree_builder_network_spec.rb
+++ b/spec/presenters/tree_builder_network_spec.rb
@@ -37,6 +37,7 @@ describe TreeBuilderNetwork do
     end
 
     it 'returns Vm as Lan child' do
+      EvmSpecHelper.local_miq_server
       parent = @network_tree.send(:x_get_tree_roots).first.lans.first
       kid = @network_tree.send(:x_get_tree_lan_kids, parent, false)
       expect(kid.first).to be_a_kind_of(Vm)

--- a/spec/presenters/tree_builder_network_spec.rb
+++ b/spec/presenters/tree_builder_network_spec.rb
@@ -1,6 +1,7 @@
 describe TreeBuilderNetwork do
   context 'TreeBuilderNetwork' do
     before do
+      EvmSpecHelper.local_miq_server
       role = MiqUserRole.find_by(:name => "EvmRole-operator")
       @group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "Network Group")
       login_as FactoryBot.create(:user, :userid => 'network_wilma', :miq_groups => [@group])


### PR DESCRIPTION
only display vms that are visible to customers

Before
======

![host_network_before](https://github.com/ManageIQ/manageiq-ui-classic/assets/1930/03dfea94-e157-4393-aa8c-03d68443285d)


After
=====

![host_network_after](https://github.com/ManageIQ/manageiq-ui-classic/assets/1930/eb63b6db-1534-4b95-879e-a7a0844e9c43)
