### PR TITLE
Fix trailing space for hostname in container provider form

### DIFF
--- a/app/javascript/components/provider-form/helper.js
+++ b/app/javascript/components/provider-form/helper.js
@@ -1,0 +1,25 @@
+/** Field names that needs to be trimmed. */
+const trimFields = ['hostname'];
+
+/** Function to trim a field's value.
+ * If the nested data object contains the key which includes in variable 'trimFields',
+ * then, trim the spaces from the value before sending to API.
+ */
+export const trimFieldValue = (resource) => {
+  const keys = Object.keys(resource);
+
+  keys.find((key) => {
+    const value = resource[key];
+
+    if (trimFields.includes(key)) {
+      resource[key] = resource[key] ? resource[key].trim() : '';
+      return true;
+    } if (typeof value === 'object' && value !== null) {
+      return trimFieldValue(value) !== undefined;
+    }
+
+    return false;
+  });
+
+  return { ...resource };
+};

--- a/app/javascript/components/provider-form/index.jsx
+++ b/app/javascript/components/provider-form/index.jsx
@@ -13,6 +13,7 @@ import ProviderCredentials from './provider-credentials';
 import ValidateProviderCredentials from './validate-provider-credentials';
 import DetectButton from './detect-button';
 import validateName from '../../helpers/storage_manager/validate-names';
+import { trimFieldValue } from './helper';
 
 const findSkipSubmits = (schema, items) => {
   const found = schema.skipSubmit && items.includes(schema.name) ? [schema.name] : [];
@@ -175,7 +176,7 @@ const ProviderForm = ({
       // Construct the full form data with all the necessary items
       const data = {
         ...rest,
-        endpoints,
+        endpoints: trimFieldValue(endpoints),
         authentications,
         ...(edit ? undefined : { type }),
         ddf: true,

--- a/app/javascript/components/provider-form/validate-provider-credentials.jsx
+++ b/app/javascript/components/provider-form/validate-provider-credentials.jsx
@@ -4,6 +4,7 @@ import { pick } from 'lodash';
 
 import AsyncCredentials from '../async-credentials/async-credentials';
 import EditingContext from './editing-context';
+import { trimFieldValue } from './helper';
 
 const ValidateProviderCredentials = ({ ...props }) => {
   const { providerId } = useContext(EditingContext);
@@ -11,8 +12,9 @@ const ValidateProviderCredentials = ({ ...props }) => {
   const asyncValidate = (fields, fieldNames) => new Promise((resolve, reject) => {
     const url = providerId ? `/api/providers/${providerId}` : '/api/providers';
     const resource = pick(fields, fieldNames);
+    const updatedResource = trimFieldValue(resource);
 
-    API.post(url, { action: 'verify_credentials', resource }).then(({ results: [result] = [], ...single }) => {
+    API.post(url, { action: 'verify_credentials', resource: updatedResource }).then(({ results: [result] = [], ...single }) => {
       // eslint-disable-next-line camelcase
       const { task_id, success } = result || single;
       // The request here can either create a background task or fail


### PR DESCRIPTION
The `Hostname` field in the UI has spaces before and after the actual value.

Before - `hostname` has spaces before and after the value
<img width="1273" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/df528a55-5b02-40f2-b0b5-1e8910b4229c">

After - Space trimmed from `hostname`
<img width="1274" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/ce3b8aa3-02bb-4682-b1ce-aff0049406c6">


