### PR TITLE
Convert Dashboard Widget Remove Modal to React

### DIFF
--- a/app/javascript/components/dashboard-widgets/widget-remove-modal/index.jsx
+++ b/app/javascript/components/dashboard-widgets/widget-remove-modal/index.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Modal } from 'carbon-components-react';
+import miqRedirectBack from '../../../helpers/miq-redirect-back';
+
+const WidgetRemoveModal = ({
+  showConfirm, setState, widgetTitle, href,
+}) => (
+  <Modal
+    open={showConfirm}
+    primaryButtonText={__('OK')}
+    secondaryButtonText={__('Cancel')}
+    onRequestClose={() => {
+      setState((state) => ({
+        ...state,
+        showConfirm: false,
+      }));
+    }}
+    onRequestSubmit={() => {
+      http.post(href, {}, { skipErrors: true })
+        .then((result) => {
+          miqRedirectBack(result.message, 'success', '/dashboard/');
+        })
+        .catch((result) => miqRedirectBack(result.message, 'warning', '/dashboard/'));
+    }}
+    onSecondarySubmit={() => {
+      setState((state) => ({
+        ...state,
+        showConfirm: false,
+      }));
+    }}
+  >
+    {sprintf(__(`Are you sure you want to remove %s from the Dashboard?`), widgetTitle)}
+  </Modal>
+);
+
+WidgetRemoveModal.propTypes = {
+  showConfirm: PropTypes.bool,
+  setState: PropTypes.func.isRequired,
+  widgetTitle: PropTypes.string.isRequired,
+  href: PropTypes.string,
+};
+
+WidgetRemoveModal.defaultProps = {
+  showConfirm: false,
+  href: '',
+};
+
+export default WidgetRemoveModal;

--- a/app/javascript/components/dashboard-widgets/widget-wrapper/helper.jsx
+++ b/app/javascript/components/dashboard-widgets/widget-wrapper/helper.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { OverflowMenuItem, Loading } from 'carbon-components-react';
 import classNames from 'classnames';
-import miqRedirectBack from '../../../helpers/miq-redirect-back';
 import WidgetChart from '../widget-chart';
 import WidgetError from '../widget-error';
 import WidgetFooter from '../widget-footer';
@@ -168,13 +167,11 @@ const menuItemOnClick = (menuItems, widgetId, dataMethod, href, buttonTitle, wid
   }
   // Handles remove button
   if (dataMethod === 'post') {
-    if (window.confirm(sprintf(__(`Are you sure you want to remove %s from the Dashboard?`), widgetTitle))) {
-      http.post(href, {}, { skipErrors: true })
-        .then((result) => {
-          miqRedirectBack(result.message, 'success', '/dashboard/');
-        })
-        .catch((result) => miqRedirectBack(result.message, 'warning', '/dashboard/'));
-    }
+    setState((state) => ({
+      ...state,
+      showConfirm: true,
+      href,
+    }));
   } else {
     // Handles print or export to PDF button
     if (buttonTitle === __('Print the full report (all rows) or export it as a PDF file')) {

--- a/app/javascript/components/dashboard-widgets/widget-wrapper/index.jsx
+++ b/app/javascript/components/dashboard-widgets/widget-wrapper/index.jsx
@@ -4,11 +4,14 @@ import PropTypes from 'prop-types';
 import { OverflowMenu } from 'carbon-components-react';
 import debouncePromise from '../../../helpers/promise-debounce';
 import { getOverflowButtons, getWidget } from './helper';
+import WidgetRemoveModal from '../widget-remove-modal';
 
 const WidgetWrapper = ({
   widgetId, widgetType, widgetButtons, widgetLastRun, widgetNextRun, widgetTitle,
 }) => {
-  const [{ widgetModel, isLoading, error }, setState] = useState({ isLoading: true, error: false });
+  const [{
+    widgetModel, href, isLoading, showConfirm, error,
+  }, setState] = useState({ isLoading: true, showConfirm: false, error: false });
   const widgetUrl = () => {
     const widgetTypeUrl = {
       menu: '/dashboard/widget_menu_data/',
@@ -97,6 +100,7 @@ const WidgetWrapper = ({
         </div>
       </div>
       {getWidget(widgetId, isLoading, widgetModel, widgetType, widgetLastRun, widgetNextRun, error)}
+      <WidgetRemoveModal showConfirm={showConfirm} setState={setState} widgetTitle={widgetTitle} href={href} />
     </div>
   );
 };

--- a/app/javascript/spec/widget-wrapper/__snapshots__/widget-wrapper.spec.js.snap
+++ b/app/javascript/spec/widget-wrapper/__snapshots__/widget-wrapper.spec.js.snap
@@ -186,6 +186,163 @@ exports[`Widget wrapper component should render a widget wrapper with a chart 1`
           </Loading>
         </div>
       </div>
+      <WidgetRemoveModal
+        href=""
+        setState={[Function]}
+        showConfirm={false}
+        widgetTitle="Guest OS Information"
+      >
+        <Modal
+          hasScrollingContent={false}
+          modalHeading=""
+          modalLabel=""
+          onKeyDown={[Function]}
+          onRequestClose={[Function]}
+          onRequestSubmit={[Function]}
+          onSecondarySubmit={[Function]}
+          open={false}
+          passiveModal={false}
+          preventCloseOnClickOutside={false}
+          primaryButtonDisabled={false}
+          primaryButtonText="OK"
+          secondaryButtonText="Cancel"
+          selectorPrimaryFocus="[data-modal-primary-focus]"
+        >
+          <div
+            className="bx--modal bx--modal-tall"
+            onBlur={[Function]}
+            onKeyDown={[Function]}
+            onMouseDown={[Function]}
+            role="presentation"
+          >
+            <span
+              className="bx--visually-hidden"
+              role="link"
+              tabIndex="0"
+            >
+              Focus sentinel
+            </span>
+            <div
+              aria-label=""
+              aria-modal="true"
+              className="bx--modal-container"
+              role="dialog"
+              tabIndex="-1"
+            >
+              <div
+                className="bx--modal-header"
+              >
+                <h3
+                  className="bx--modal-header__heading"
+                  id="bx--modal-header__heading--modal-3"
+                />
+                <button
+                  aria-label="close"
+                  className="bx--modal-close"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <ForwardRef(Close20)
+                    aria-hidden="true"
+                    className="bx--modal-close__icon"
+                    tabIndex="-1"
+                  >
+                    <Icon
+                      aria-hidden="true"
+                      className="bx--modal-close__icon"
+                      fill="currentColor"
+                      height={20}
+                      preserveAspectRatio="xMidYMid meet"
+                      tabIndex="-1"
+                      viewBox="0 0 32 32"
+                      width={20}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="bx--modal-close__icon"
+                        fill="currentColor"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                        />
+                      </svg>
+                    </Icon>
+                  </ForwardRef(Close20)>
+                </button>
+              </div>
+              <div
+                className="bx--modal-content"
+                id="bx--modal-body--modal-3"
+              >
+                Are you sure you want to remove Guest OS Information from the Dashboard?
+              </div>
+              <ButtonSet
+                className="bx--modal-footer"
+              >
+                <div
+                  className="bx--modal-footer bx--btn-set"
+                >
+                  <Button
+                    kind="secondary"
+                    onClick={[Function]}
+                  >
+                    <button
+                      aria-describedby={null}
+                      aria-pressed={null}
+                      className="bx--btn bx--btn--secondary"
+                      disabled={false}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      Cancel
+                    </button>
+                  </Button>
+                  <Button
+                    disabled={false}
+                    kind="primary"
+                    onClick={[Function]}
+                  >
+                    <button
+                      aria-describedby={null}
+                      aria-pressed={null}
+                      className="bx--btn bx--btn--primary"
+                      disabled={false}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      OK
+                    </button>
+                  </Button>
+                </div>
+              </ButtonSet>
+            </div>
+            <span
+              className="bx--visually-hidden"
+              role="link"
+              tabIndex="0"
+            >
+              Focus sentinel
+            </span>
+          </div>
+        </Modal>
+      </WidgetRemoveModal>
     </div>
   </WidgetWrapper>
 </Provider>
@@ -377,6 +534,163 @@ exports[`Widget wrapper component should render a widget wrapper with a menu 1`]
           </Loading>
         </div>
       </div>
+      <WidgetRemoveModal
+        href=""
+        setState={[Function]}
+        showConfirm={false}
+        widgetTitle="Links"
+      >
+        <Modal
+          hasScrollingContent={false}
+          modalHeading=""
+          modalLabel=""
+          onKeyDown={[Function]}
+          onRequestClose={[Function]}
+          onRequestSubmit={[Function]}
+          onSecondarySubmit={[Function]}
+          open={false}
+          passiveModal={false}
+          preventCloseOnClickOutside={false}
+          primaryButtonDisabled={false}
+          primaryButtonText="OK"
+          secondaryButtonText="Cancel"
+          selectorPrimaryFocus="[data-modal-primary-focus]"
+        >
+          <div
+            className="bx--modal bx--modal-tall"
+            onBlur={[Function]}
+            onKeyDown={[Function]}
+            onMouseDown={[Function]}
+            role="presentation"
+          >
+            <span
+              className="bx--visually-hidden"
+              role="link"
+              tabIndex="0"
+            >
+              Focus sentinel
+            </span>
+            <div
+              aria-label=""
+              aria-modal="true"
+              className="bx--modal-container"
+              role="dialog"
+              tabIndex="-1"
+            >
+              <div
+                className="bx--modal-header"
+              >
+                <h3
+                  className="bx--modal-header__heading"
+                  id="bx--modal-header__heading--modal-2"
+                />
+                <button
+                  aria-label="close"
+                  className="bx--modal-close"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <ForwardRef(Close20)
+                    aria-hidden="true"
+                    className="bx--modal-close__icon"
+                    tabIndex="-1"
+                  >
+                    <Icon
+                      aria-hidden="true"
+                      className="bx--modal-close__icon"
+                      fill="currentColor"
+                      height={20}
+                      preserveAspectRatio="xMidYMid meet"
+                      tabIndex="-1"
+                      viewBox="0 0 32 32"
+                      width={20}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="bx--modal-close__icon"
+                        fill="currentColor"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                        />
+                      </svg>
+                    </Icon>
+                  </ForwardRef(Close20)>
+                </button>
+              </div>
+              <div
+                className="bx--modal-content"
+                id="bx--modal-body--modal-2"
+              >
+                Are you sure you want to remove Links from the Dashboard?
+              </div>
+              <ButtonSet
+                className="bx--modal-footer"
+              >
+                <div
+                  className="bx--modal-footer bx--btn-set"
+                >
+                  <Button
+                    kind="secondary"
+                    onClick={[Function]}
+                  >
+                    <button
+                      aria-describedby={null}
+                      aria-pressed={null}
+                      className="bx--btn bx--btn--secondary"
+                      disabled={false}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      Cancel
+                    </button>
+                  </Button>
+                  <Button
+                    disabled={false}
+                    kind="primary"
+                    onClick={[Function]}
+                  >
+                    <button
+                      aria-describedby={null}
+                      aria-pressed={null}
+                      className="bx--btn bx--btn--primary"
+                      disabled={false}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      OK
+                    </button>
+                  </Button>
+                </div>
+              </ButtonSet>
+            </div>
+            <span
+              className="bx--visually-hidden"
+              role="link"
+              tabIndex="0"
+            >
+              Focus sentinel
+            </span>
+          </div>
+        </Modal>
+      </WidgetRemoveModal>
     </div>
   </WidgetWrapper>
 </Provider>
@@ -568,6 +882,163 @@ exports[`Widget wrapper component should render a widget wrapper with a report 1
           </Loading>
         </div>
       </div>
+      <WidgetRemoveModal
+        href=""
+        setState={[Function]}
+        showConfirm={false}
+        widgetTitle="EVM: Recently Discovered Hosts"
+      >
+        <Modal
+          hasScrollingContent={false}
+          modalHeading=""
+          modalLabel=""
+          onKeyDown={[Function]}
+          onRequestClose={[Function]}
+          onRequestSubmit={[Function]}
+          onSecondarySubmit={[Function]}
+          open={false}
+          passiveModal={false}
+          preventCloseOnClickOutside={false}
+          primaryButtonDisabled={false}
+          primaryButtonText="OK"
+          secondaryButtonText="Cancel"
+          selectorPrimaryFocus="[data-modal-primary-focus]"
+        >
+          <div
+            className="bx--modal bx--modal-tall"
+            onBlur={[Function]}
+            onKeyDown={[Function]}
+            onMouseDown={[Function]}
+            role="presentation"
+          >
+            <span
+              className="bx--visually-hidden"
+              role="link"
+              tabIndex="0"
+            >
+              Focus sentinel
+            </span>
+            <div
+              aria-label=""
+              aria-modal="true"
+              className="bx--modal-container"
+              role="dialog"
+              tabIndex="-1"
+            >
+              <div
+                className="bx--modal-header"
+              >
+                <h3
+                  className="bx--modal-header__heading"
+                  id="bx--modal-header__heading--modal-1"
+                />
+                <button
+                  aria-label="close"
+                  className="bx--modal-close"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <ForwardRef(Close20)
+                    aria-hidden="true"
+                    className="bx--modal-close__icon"
+                    tabIndex="-1"
+                  >
+                    <Icon
+                      aria-hidden="true"
+                      className="bx--modal-close__icon"
+                      fill="currentColor"
+                      height={20}
+                      preserveAspectRatio="xMidYMid meet"
+                      tabIndex="-1"
+                      viewBox="0 0 32 32"
+                      width={20}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="bx--modal-close__icon"
+                        fill="currentColor"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                        />
+                      </svg>
+                    </Icon>
+                  </ForwardRef(Close20)>
+                </button>
+              </div>
+              <div
+                className="bx--modal-content"
+                id="bx--modal-body--modal-1"
+              >
+                Are you sure you want to remove EVM: Recently Discovered Hosts from the Dashboard?
+              </div>
+              <ButtonSet
+                className="bx--modal-footer"
+              >
+                <div
+                  className="bx--modal-footer bx--btn-set"
+                >
+                  <Button
+                    kind="secondary"
+                    onClick={[Function]}
+                  >
+                    <button
+                      aria-describedby={null}
+                      aria-pressed={null}
+                      className="bx--btn bx--btn--secondary"
+                      disabled={false}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      Cancel
+                    </button>
+                  </Button>
+                  <Button
+                    disabled={false}
+                    kind="primary"
+                    onClick={[Function]}
+                  >
+                    <button
+                      aria-describedby={null}
+                      aria-pressed={null}
+                      className="bx--btn bx--btn--primary"
+                      disabled={false}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      OK
+                    </button>
+                  </Button>
+                </div>
+              </ButtonSet>
+            </div>
+            <span
+              className="bx--visually-hidden"
+              role="link"
+              tabIndex="0"
+            >
+              Focus sentinel
+            </span>
+          </div>
+        </Modal>
+      </WidgetRemoveModal>
     </div>
   </WidgetWrapper>
 </Provider>


### PR DESCRIPTION
Converted dashboard widget remove modal to React.

Before:
<img width="1206" alt="Screenshot 2024-01-03 at 10 44 10 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/d7e9acfa-c671-4ceb-9473-415d53d3cdb0">

After:
<img width="1209" alt="Screenshot 2024-01-03 at 10 40 18 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/d5a5d753-2916-43e9-8ac1-12c0cfc44cc8">
