### PR TITLE
Fix for Error When Trying to Select a Namespace

### DIFF
--- a/app/controllers/mixins/automation_mixin.rb
+++ b/app/controllers/mixins/automation_mixin.rb
@@ -4,7 +4,8 @@ module Mixins
     ENTRY_POINT_TYPES = {
       :fqname             => {:type => :provision,   :name => 'Provision'},
       :reconfigure_fqname => {:type => :reconfigure, :name => 'Reconfigure'},
-      :retire_fqname      => {:type => :retire,      :name => 'Retirement'}
+      :retire_fqname      => {:type => :retire,      :name => 'Retirement'},
+      :namespace          => {:type => :namespace,   :name => 'Namespace'}
     }.freeze
 
     # Returns an object to be resued for passing down to rails form and angular form.

--- a/app/helpers/automate_tree_helper.rb
+++ b/app/helpers/automate_tree_helper.rb
@@ -1,4 +1,6 @@
 module AutomateTreeHelper
+  include Mixins::AutomationMixin
+
   def submit_embedded_method(fqname)
     if @edit[:new][:embedded_methods].include?(fqname)
       add_flash(_("This embedded method is already selected"), :warning)
@@ -64,7 +66,12 @@ module AutomateTreeHelper
 
   def at_tree_select_toggle(type, edit_key)
     automation_type = params[:automation_type] || default_entry_point_type
-    current_entry_point = @edit[:new][edit_key] # before updating @edit varibale.
+
+    if edit_key
+      current_entry_point = @edit[:new][edit_key] # before updating @edit varibale.
+      current_entry_point_fields = entry_point_fields(edit_key)
+    end
+
     build_automate_tree(type) if automation_type == embedded_automate_key
     render :update do |page|
       page << javascript_prologue
@@ -98,8 +105,8 @@ module AutomateTreeHelper
           @edit[:include_domain_prefix] = nil
           @edit[:domain_prefix_check] = nil
 
-          if edit_key
-            field = entry_point_fields(edit_key)
+          if edit_key && current_entry_point && current_entry_point_fields
+            field = current_entry_point_fields
             previous = @edit[:new][field[:previous]]
             entry_point_type = @edit[:new][field[:type]]
             @edit[:new][previous[entry_point_type]] = current_entry_point


### PR DESCRIPTION
This change fixes a bug that was unintentionally added in https://github.com/ManageIQ/manageiq-ui-classic/pull/8815 when trying to manually select a namespace while copying an item in `Automation/Automate/Explorer`.

Before:

https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/584ace36-5378-4e71-aa7e-6f2c6dea41fe

After:

https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/76cd5abe-3103-4cdf-9f1c-f95397b8e5ab
