### PR TITLE
Fix warning for image with no title in structured list

### DIFF
--- a/app/javascript/components/miq-structured-list/miq-structured-list-body/value-tags/miq-structured-list-image.jsx
+++ b/app/javascript/components/miq-structured-list/miq-structured-list-body/value-tags/miq-structured-list-image.jsx
@@ -12,7 +12,7 @@ export default MiqStructuredListImage;
 
 MiqStructuredListImage.propTypes = {
   row: PropTypes.shape({
-    title: PropTypes.string.isRequired,
+    title: PropTypes.string,
     image: PropTypes.string.isRequired,
   }).isRequired,
 };


### PR DESCRIPTION
Before - warning message in browser console
<img width="1792" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/4465d437-61cd-49e9-bc7b-c0a172d52aa6">

After - No warning messages in browser console
<img width="1767" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/ce21d32d-0868-4250-a798-49bceb79a9e0">

