### PR TITLE
Style improvements for dual-list component in catalog form

### DIFF
--- a/app/stylesheet/ddf_override.scss
+++ b/app/stylesheet/ddf_override.scss
@@ -26,6 +26,50 @@
 }
 
 #dual-list-sub-form-catalog {
+  fieldset {
+    .bx--grid .bx--row--condensed {
+      .buttonWrapper-0-2-7 {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
+
+      .bx--col-lg-5 {
+        border: 1px solid lightgray;
+        margin-top: 8px;
+    
+        h6 {
+          margin: 0;
+          padding: 10px 20px;
+        }
+    
+        .toolbar-0-2-8 {
+          button {
+            cursor: pointer;
+            width: 50px;
+            display: flex;
+            justify-content: center;
+  
+            svg {
+              margin-top: -20px;
+            }
+          }
+        }
+    
+        .bx--structured-list {
+          .bx--structured-list-row {
+            .bx--col-sm-1 {
+              display: flex;
+              justify-content: flex-end;
+              padding: 0;
+              color: $active-primary;
+            }
+          }
+        }
+      }
+    }
+  }
+  
   #move-right, #move-all-right, #move-all-left, #move-left {
     svg {
       position: unset;


### PR DESCRIPTION
Path: `Service / Catalogs / Catalogs / (Item) / (Add or Edit Catalog)`

Before
<img width="1055" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/076fc043-09b2-43a1-a1e9-c5da8a61d9ad">

After
<img width="1082" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/62df6be2-a049-4ec6-826e-0e78f2d897e1">
