### PR TITLE
Improve taggings-modifier's style in service catalogs

### DIFF
--- a/app/javascript/tagging/components/InnerComponents/CategoryModifier.js
+++ b/app/javascript/tagging/components/InnerComponents/CategoryModifier.js
@@ -12,7 +12,7 @@ const CategoryModifier = ({
   isDisabled,
 }) => (
   <FormGroup legendText={categoryLabel}>
-    <Column xs={12} md={8} lg={8}>
+    <Column className="tag-modifier-form-row category-modifier">
       <TagSelector
         tagCategories={tagCategories}
         onTagCategoryChange={onTagCategoryChange}

--- a/app/javascript/tagging/components/InnerComponents/TagModifier.js
+++ b/app/javascript/tagging/components/InnerComponents/TagModifier.js
@@ -6,13 +6,13 @@ const TagModifier = ({ header, hideHeader, children }) => (
   <>
     { !hideHeader
       && (
-        <Row>
+        <Row className="tag-modifier-header">
           <Column lg={12}>
-            <h2>{header}</h2>
+            <h4>{header}</h4>
           </Column>
         </Row>
       ) }
-    <Form horizontal="true">{children}</Form>
+    <Form horizontal="true" className="tag-modifier-form">{children}</Form>
   </>
 );
 

--- a/app/javascript/tagging/components/InnerComponents/TagView.js
+++ b/app/javascript/tagging/components/InnerComponents/TagView.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { Row, Column } from 'carbon-components-react';
 import TagCategory from './TagCategory';
 import TaggingPropTypes from '../TaggingPropTypes';
+import NotificationMessage from '../../../components/notification-message';
 
 class TagView extends React.Component {
   generateTagCategories = (tag) => (
@@ -23,22 +24,20 @@ class TagView extends React.Component {
     const assignedTags = [...this.props.assignedTags];
     const view = (assignedTags.length > 0
       ? <ul className="list-inline">{ assignedTags.sort((a, b) => (a.description < b.description ? -1 : 1)).map(this.generateTagCategories) }</ul>
-      : <p>{__('No Assigned Tags')}</p>
+      : <NotificationMessage type="info" message={__('No Assigned Tags')} />
     );
     return (
       <div id="assignments_div">
         { !hideHeader
           && (
-            <Row>
+            <Row className="tag-modifier-header">
               <Column lg={12}>
-                <h2>{header}</h2>
+                <h4>{header}</h4>
               </Column>
             </Row>
           )}
-        <Row>
-          <Column lg={12}>
-            { view }
-          </Column>
+        <Row className="tag-modifier-form assigned-tags">
+          { view }
         </Row>
       </div>
     );

--- a/app/javascript/tagging/components/InnerComponents/ValueModifier.js
+++ b/app/javascript/tagging/components/InnerComponents/ValueModifier.js
@@ -13,7 +13,7 @@ const ValueModifier = ({
   isDisabled,
 }) => (
   <FormGroup legendText={valueLabel}>
-    <Column xs={12} md={8} lg={8}>
+    <Column className="tag-modifier-form-row value-modifier">
       <ValueSelector
         values={values}
         onTagValueChange={onTagValueChange}

--- a/app/javascript/tagging/components/Tagging/Tagging.js
+++ b/app/javascript/tagging/components/Tagging/Tagging.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/destructuring-assignment */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Grid, Row, Column } from 'carbon-components-react';
+import { Row, Column } from 'carbon-components-react';
 import TagModifier from '../InnerComponents/TagModifier';
 import TagView from '../InnerComponents/TagView';
 import CategoryModifier from '../InnerComponents/CategoryModifier';
@@ -66,35 +66,33 @@ class Tagging extends React.Component {
     } = this.props;
     const isDisabled = options && options.isDisabled;
     return (
-      <Grid>
-        <Row>
-          <Column xs={12} md={8} lg={6}>
-            <TagModifier hideHeader={options && options.hideHeaders}>
-              <CategoryModifier
-                selectedTagCategory={selectedTagCategory}
-                onTagCategoryChange={onTagCategoryChange}
-                tagCategories={this.tagCategories}
-                isDisabled={isDisabled}
-              />
-              <ValueModifier
-                onTagValueChange={this.onTagValueChange}
-                selectedTagValues={this.getSelectedCategoryValues().values}
-                multiValue={this.isMulti(selectedTagCategory)}
-                values={this.getCategoryValues()}
-                isDisabled={isDisabled}
-              />
-            </TagModifier>
-          </Column>
-          <Column xs={12} md={4} lg={6}>
-            <TagView
-              hideHeader={options && options.hideHeaders}
-              assignedTags={assignedTags}
-              onTagDeleteClick={isDisabled ? () => {} : this.onTagDeleteClick}
-              showCloseButton={!isDisabled}
+      <Row className="tagging-row-wrapper tagging-form">
+        <Column className="tagging-block-outer">
+          <TagModifier hideHeader={options && options.hideHeaders}>
+            <CategoryModifier
+              selectedTagCategory={selectedTagCategory}
+              onTagCategoryChange={onTagCategoryChange}
+              tagCategories={this.tagCategories}
+              isDisabled={isDisabled}
             />
-          </Column>
-        </Row>
-      </Grid>
+            <ValueModifier
+              onTagValueChange={this.onTagValueChange}
+              selectedTagValues={this.getSelectedCategoryValues().values}
+              multiValue={this.isMulti(selectedTagCategory)}
+              values={this.getCategoryValues()}
+              isDisabled={isDisabled}
+            />
+          </TagModifier>
+        </Column>
+        <Column className="tagging-block-outer">
+          <TagView
+            hideHeader={options && options.hideHeaders}
+            assignedTags={assignedTags}
+            onTagDeleteClick={isDisabled ? () => {} : this.onTagDeleteClick}
+            showCloseButton={!isDisabled}
+          />
+        </Column>
+      </Row>
     );
   }
 }

--- a/app/javascript/tagging/components/TaggingWithButtons/TaggingWithButtons.jsx
+++ b/app/javascript/tagging/components/TaggingWithButtons/TaggingWithButtons.jsx
@@ -25,7 +25,7 @@ class TaggingWithButtons extends React.Component {
       options, saveButton, resetButton, cancelButton,
     } = this.props;
     return (
-      <Grid>
+      <Grid className="tagging-container">
         <Tagging
           selectedTagCategory={selectedTagCategory}
           tags={tags}
@@ -36,7 +36,7 @@ class TaggingWithButtons extends React.Component {
           onSingleTagValueChange={onSingleTagValueChange}
           options={options}
         />
-        <Row className="pull-right">
+        <Row className="tagging-row-wrapper tagging-toolbar pull-right">
           <div role="toolbar" className="btn-toolbar">
             <ButtonSet>
               <Button

--- a/app/javascript/tagging/tests/__snapshots__/category.modifier.test.js.snap
+++ b/app/javascript/tagging/tests/__snapshots__/category.modifier.test.js.snap
@@ -9,9 +9,7 @@ exports[`TagCategory Component match snapshot 1`] = `
   messageText=""
 >
   <Column
-    lg={8}
-    md={8}
-    xs={12}
+    className="tag-modifier-form-row category-modifier"
   >
     <TagSelector
       infoText="Only a single value can be assigned from these categories"

--- a/app/javascript/tagging/tests/__snapshots__/tag.modifier.test.js.snap
+++ b/app/javascript/tagging/tests/__snapshots__/tag.modifier.test.js.snap
@@ -2,16 +2,19 @@
 
 exports[`Tagging modifier match snapshot 1`] = `
 <Fragment>
-  <Row>
+  <Row
+    className="tag-modifier-header"
+  >
     <Column
       lg={12}
     >
-      <h2>
+      <h4>
         Add/Modify tag
-      </h2>
+      </h4>
     </Column>
   </Row>
   <Form
+    className="tag-modifier-form"
     horizontal="true"
   >
     <CategoryModifier

--- a/app/javascript/tagging/tests/__snapshots__/tag.view.test.js.snap
+++ b/app/javascript/tagging/tests/__snapshots__/tag.view.test.js.snap
@@ -4,49 +4,49 @@ exports[`Tag view match snapshot 1`] = `
 <div
   id="assignments_div"
 >
-  <Row>
+  <Row
+    className="tag-modifier-header"
+  >
     <Column
       lg={12}
     >
-      <h2>
+      <h4>
         Assigned tags
-      </h2>
+      </h4>
     </Column>
   </Row>
-  <Row>
-    <Column
-      lg={12}
+  <Row
+    className="tag-modifier-form assigned-tags"
+  >
+    <ul
+      className="list-inline"
     >
-      <ul
-        className="list-inline"
+      <li
+        key="1"
       >
-        <li
+        <TagCategory
+          categoryTruncate={[Function]}
           key="1"
-        >
-          <TagCategory
-            categoryTruncate={[Function]}
-            key="1"
-            onTagDeleteClick={[MockFunction]}
-            showCloseButton={true}
-            tagCategory={
+          onTagDeleteClick={[MockFunction]}
+          showCloseButton={true}
+          tagCategory={
+            Object {
+              "description": "Name",
+              "id": 1,
+            }
+          }
+          valueTruncate={[Function]}
+          values={
+            Array [
               Object {
-                "description": "Name",
-                "id": 1,
-              }
-            }
-            valueTruncate={[Function]}
-            values={
-              Array [
-                Object {
-                  "description": "Pepa",
-                  "id": 11,
-                },
-              ]
-            }
-          />
-        </li>
-      </ul>
-    </Column>
+                "description": "Pepa",
+                "id": 11,
+              },
+            ]
+          }
+        />
+      </li>
+    </ul>
   </Row>
 </div>
 `;

--- a/app/javascript/tagging/tests/__snapshots__/tagging.test.js.snap
+++ b/app/javascript/tagging/tests/__snapshots__/tagging.test.js.snap
@@ -1,321 +1,309 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tagging component without redux mapping match snapshot 1`] = `
-<Grid>
-  <Row>
-    <Column
-      lg={6}
-      md={8}
-      xs={12}
+<Row
+  className="tagging-row-wrapper tagging-form"
+>
+  <Column
+    className="tagging-block-outer"
+  >
+    <TagModifier
+      header="Add/Modify tag"
+      hideHeader={false}
     >
-      <TagModifier
-        header="Add/Modify tag"
-        hideHeader={false}
-      >
-        <CategoryModifier
-          categoryLabel="Category"
-          isDisabled={false}
-          onTagCategoryChange={[MockFunction]}
-          selectedTagCategory={
-            Object {
-              "description": "animal",
-              "id": 1,
-            }
+      <CategoryModifier
+        categoryLabel="Category"
+        isDisabled={false}
+        onTagCategoryChange={[MockFunction]}
+        selectedTagCategory={
+          Object {
+            "description": "animal",
+            "id": 1,
           }
-          tagCategories={
-            Array [
-              Object {
-                "description": "Name",
-                "id": 1,
-                "singleValue": undefined,
-              },
-              Object {
-                "description": "Number",
-                "id": 2,
-                "singleValue": undefined,
-              },
-              Object {
-                "description": "Animal",
-                "id": 3,
-                "singleValue": undefined,
-              },
-              Object {
-                "description": "Food",
-                "id": 4,
-                "singleValue": false,
-              },
-              Object {
-                "description": "Something",
-                "id": 5,
-                "singleValue": true,
-              },
-            ]
-          }
-        />
-        <ValueModifier
-          isDisabled={false}
-          multiValue={true}
-          onTagValueChange={[Function]}
-          selectedTagValues={
-            Array [
-              Object {
-                "description": "Pepa",
-                "id": 11,
-              },
-            ]
-          }
-          valueLabel="Value"
-          values={
-            Array [
-              Object {
-                "description": "Pepa",
-                "id": 11,
-              },
-              Object {
-                "description": "Franta",
-                "id": 12,
-              },
-            ]
-          }
-        />
-      </TagModifier>
-    </Column>
-    <Column
-      lg={6}
-      md={4}
-      xs={12}
-    >
-      <TagView
-        assignedTags={
+        }
+        tagCategories={
           Array [
             Object {
               "description": "Name",
               "id": 1,
-              "values": Array [
-                Object {
-                  "description": "Pepa",
-                  "id": 11,
-                },
-              ],
+              "singleValue": undefined,
             },
-          ]
-        }
-        header="Assigned tags"
-        hideHeader={false}
-        onTagDeleteClick={[Function]}
-        showCloseButton={true}
-      />
-    </Column>
-  </Row>
-</Grid>
-`;
-
-exports[`Tagging component without redux mapping should call methods - singleValue is false 1`] = `
-<Grid>
-  <Row>
-    <Column
-      lg={6}
-      md={8}
-      xs={12}
-    >
-      <TagModifier
-        header="Add/Modify tag"
-        hideHeader={false}
-      >
-        <CategoryModifier
-          categoryLabel="Category"
-          isDisabled={false}
-          onTagCategoryChange={[MockFunction]}
-          selectedTagCategory={
+            Object {
+              "description": "Number",
+              "id": 2,
+              "singleValue": undefined,
+            },
+            Object {
+              "description": "Animal",
+              "id": 3,
+              "singleValue": undefined,
+            },
             Object {
               "description": "Food",
               "id": 4,
-            }
-          }
-          tagCategories={
-            Array [
-              Object {
-                "description": "Name",
-                "id": 1,
-                "singleValue": undefined,
-              },
-              Object {
-                "description": "Number",
-                "id": 2,
-                "singleValue": undefined,
-              },
-              Object {
-                "description": "Animal",
-                "id": 3,
-                "singleValue": undefined,
-              },
-              Object {
-                "description": "Food",
-                "id": 4,
-                "singleValue": false,
-              },
-              Object {
-                "description": "Something",
-                "id": 5,
-                "singleValue": true,
-              },
-            ]
-          }
-        />
-        <ValueModifier
-          isDisabled={false}
-          multiValue={true}
-          onTagValueChange={[Function]}
-          selectedTagValues={Array []}
-          valueLabel="Value"
-          values={
-            Array [
-              Object {
-                "description": "Steak",
-                "id": 41,
-              },
-              Object {
-                "description": "Duck",
-                "id": 42,
-              },
-              Object {
-                "description": "Salad",
-                "id": 43,
-              },
-            ]
-          }
-        />
-      </TagModifier>
-    </Column>
-    <Column
-      lg={6}
-      md={4}
-      xs={12}
-    >
-      <TagView
-        assignedTags={
-          Array [
-            Object {
-              "description": "Name",
-              "id": 1,
-              "values": Array [
-                Object {
-                  "description": "Pepa",
-                  "id": 11,
-                },
-              ],
+              "singleValue": false,
             },
-          ]
-        }
-        header="Assigned tags"
-        hideHeader={false}
-        onTagDeleteClick={[Function]}
-        showCloseButton={true}
-      />
-    </Column>
-  </Row>
-</Grid>
-`;
-
-exports[`Tagging component without redux mapping should call methods - singleValue is true 1`] = `
-<Grid>
-  <Row>
-    <Column
-      lg={6}
-      md={8}
-      xs={12}
-    >
-      <TagModifier
-        header="Add/Modify tag"
-        hideHeader={false}
-      >
-        <CategoryModifier
-          categoryLabel="Category"
-          isDisabled={false}
-          onTagCategoryChange={[MockFunction]}
-          selectedTagCategory={
             Object {
               "description": "Something",
               "id": 5,
-            }
-          }
-          tagCategories={
-            Array [
+              "singleValue": true,
+            },
+          ]
+        }
+      />
+      <ValueModifier
+        isDisabled={false}
+        multiValue={true}
+        onTagValueChange={[Function]}
+        selectedTagValues={
+          Array [
+            Object {
+              "description": "Pepa",
+              "id": 11,
+            },
+          ]
+        }
+        valueLabel="Value"
+        values={
+          Array [
+            Object {
+              "description": "Pepa",
+              "id": 11,
+            },
+            Object {
+              "description": "Franta",
+              "id": 12,
+            },
+          ]
+        }
+      />
+    </TagModifier>
+  </Column>
+  <Column
+    className="tagging-block-outer"
+  >
+    <TagView
+      assignedTags={
+        Array [
+          Object {
+            "description": "Name",
+            "id": 1,
+            "values": Array [
               Object {
-                "description": "Name",
-                "id": 1,
-                "singleValue": undefined,
+                "description": "Pepa",
+                "id": 11,
               },
-              Object {
-                "description": "Number",
-                "id": 2,
-                "singleValue": undefined,
-              },
-              Object {
-                "description": "Animal",
-                "id": 3,
-                "singleValue": undefined,
-              },
-              Object {
-                "description": "Food",
-                "id": 4,
-                "singleValue": false,
-              },
-              Object {
-                "description": "Something",
-                "id": 5,
-                "singleValue": true,
-              },
-            ]
-          }
-        />
-        <ValueModifier
-          isDisabled={false}
-          multiValue={false}
-          onTagValueChange={[Function]}
-          selectedTagValues={Array []}
-          valueLabel="Value"
-          values={
-            Array [
-              Object {
-                "description": "Knedlik",
-                "id": 51,
-              },
-              Object {
-                "description": "Daenerys Stormborn of the House Targaryen, First of Her Name,...and Mother of Dragons",
-                "id": 52,
-              },
-            ]
-          }
-        />
-      </TagModifier>
-    </Column>
-    <Column
-      lg={6}
-      md={4}
-      xs={12}
+            ],
+          },
+        ]
+      }
+      header="Assigned tags"
+      hideHeader={false}
+      onTagDeleteClick={[Function]}
+      showCloseButton={true}
+    />
+  </Column>
+</Row>
+`;
+
+exports[`Tagging component without redux mapping should call methods - singleValue is false 1`] = `
+<Row
+  className="tagging-row-wrapper tagging-form"
+>
+  <Column
+    className="tagging-block-outer"
+  >
+    <TagModifier
+      header="Add/Modify tag"
+      hideHeader={false}
     >
-      <TagView
-        assignedTags={
+      <CategoryModifier
+        categoryLabel="Category"
+        isDisabled={false}
+        onTagCategoryChange={[MockFunction]}
+        selectedTagCategory={
+          Object {
+            "description": "Food",
+            "id": 4,
+          }
+        }
+        tagCategories={
           Array [
             Object {
               "description": "Name",
               "id": 1,
-              "values": Array [
-                Object {
-                  "description": "Pepa",
-                  "id": 11,
-                },
-              ],
+              "singleValue": undefined,
+            },
+            Object {
+              "description": "Number",
+              "id": 2,
+              "singleValue": undefined,
+            },
+            Object {
+              "description": "Animal",
+              "id": 3,
+              "singleValue": undefined,
+            },
+            Object {
+              "description": "Food",
+              "id": 4,
+              "singleValue": false,
+            },
+            Object {
+              "description": "Something",
+              "id": 5,
+              "singleValue": true,
             },
           ]
         }
-        header="Assigned tags"
-        hideHeader={false}
-        onTagDeleteClick={[Function]}
-        showCloseButton={true}
       />
-    </Column>
-  </Row>
-</Grid>
+      <ValueModifier
+        isDisabled={false}
+        multiValue={true}
+        onTagValueChange={[Function]}
+        selectedTagValues={Array []}
+        valueLabel="Value"
+        values={
+          Array [
+            Object {
+              "description": "Steak",
+              "id": 41,
+            },
+            Object {
+              "description": "Duck",
+              "id": 42,
+            },
+            Object {
+              "description": "Salad",
+              "id": 43,
+            },
+          ]
+        }
+      />
+    </TagModifier>
+  </Column>
+  <Column
+    className="tagging-block-outer"
+  >
+    <TagView
+      assignedTags={
+        Array [
+          Object {
+            "description": "Name",
+            "id": 1,
+            "values": Array [
+              Object {
+                "description": "Pepa",
+                "id": 11,
+              },
+            ],
+          },
+        ]
+      }
+      header="Assigned tags"
+      hideHeader={false}
+      onTagDeleteClick={[Function]}
+      showCloseButton={true}
+    />
+  </Column>
+</Row>
+`;
+
+exports[`Tagging component without redux mapping should call methods - singleValue is true 1`] = `
+<Row
+  className="tagging-row-wrapper tagging-form"
+>
+  <Column
+    className="tagging-block-outer"
+  >
+    <TagModifier
+      header="Add/Modify tag"
+      hideHeader={false}
+    >
+      <CategoryModifier
+        categoryLabel="Category"
+        isDisabled={false}
+        onTagCategoryChange={[MockFunction]}
+        selectedTagCategory={
+          Object {
+            "description": "Something",
+            "id": 5,
+          }
+        }
+        tagCategories={
+          Array [
+            Object {
+              "description": "Name",
+              "id": 1,
+              "singleValue": undefined,
+            },
+            Object {
+              "description": "Number",
+              "id": 2,
+              "singleValue": undefined,
+            },
+            Object {
+              "description": "Animal",
+              "id": 3,
+              "singleValue": undefined,
+            },
+            Object {
+              "description": "Food",
+              "id": 4,
+              "singleValue": false,
+            },
+            Object {
+              "description": "Something",
+              "id": 5,
+              "singleValue": true,
+            },
+          ]
+        }
+      />
+      <ValueModifier
+        isDisabled={false}
+        multiValue={false}
+        onTagValueChange={[Function]}
+        selectedTagValues={Array []}
+        valueLabel="Value"
+        values={
+          Array [
+            Object {
+              "description": "Knedlik",
+              "id": 51,
+            },
+            Object {
+              "description": "Daenerys Stormborn of the House Targaryen, First of Her Name,...and Mother of Dragons",
+              "id": 52,
+            },
+          ]
+        }
+      />
+    </TagModifier>
+  </Column>
+  <Column
+    className="tagging-block-outer"
+  >
+    <TagView
+      assignedTags={
+        Array [
+          Object {
+            "description": "Name",
+            "id": 1,
+            "values": Array [
+              Object {
+                "description": "Pepa",
+                "id": 11,
+              },
+            ],
+          },
+        ]
+      }
+      header="Assigned tags"
+      hideHeader={false}
+      onTagDeleteClick={[Function]}
+      showCloseButton={true}
+    />
+  </Column>
+</Row>
 `;

--- a/app/javascript/tagging/tests/__snapshots__/value.modifier.test.js.snap
+++ b/app/javascript/tagging/tests/__snapshots__/value.modifier.test.js.snap
@@ -9,9 +9,7 @@ exports[`TagCategory Component match snapshot 1`] = `
   messageText=""
 >
   <Column
-    lg={8}
-    md={8}
-    xs={12}
+    className="tag-modifier-form-row value-modifier"
   >
     <ValueSelector
       isDisabled={false}

--- a/app/stylesheet/application-webpack.scss
+++ b/app/stylesheet/application-webpack.scss
@@ -24,6 +24,7 @@
 @import './search-bar.scss';
 @import './settings.scss';
 @import './responsive_layout.scss';
+@import './tags.scss';
 @import './tree.scss';
 @import './toolbar.scss';
 @import './widget.scss';

--- a/app/stylesheet/tags.scss
+++ b/app/stylesheet/tags.scss
@@ -1,0 +1,83 @@
+.tagging-container {
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+
+  .tagging-row-wrapper {
+    margin: 0;
+    display: flex;
+    gap: 20px;
+
+    .tagging-form {
+      display: flex;
+    }
+
+    .tagging-block-outer {
+      border: 1px solid lightgray;
+      display: flex;
+      flex-direction: column;
+      padding: 0;
+
+      #assignments_div {
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-start;
+        align-items: baseline;
+      }
+
+      .tag-modifier-header {
+        background: lightgray;
+        margin: 0;
+        padding: 5px 0;
+        width: 100%;
+
+        h3 {
+          margin: 10px 0;
+        }
+      }
+
+      .tag-modifier-form {
+        padding: 15px;
+        max-height: 400px;
+        width: 100%;
+        
+        width: 100%;
+
+        &.assigned-tags {
+          overflow-y: auto;
+
+          .alert {
+            width: 100%;
+          }
+        }
+
+        fieldset {
+          margin: 5px 0;
+
+          legend {
+            font-size: 14px;
+          }
+
+          .tag-modifier-form-row {
+            padding: 0;
+          }
+        }
+      }
+    }
+
+    &.tagging-toolbar {
+      .btn-toolbar {
+        width: 100%;
+
+        .bx--btn-set {
+          margin-right: 0;
+          width: 100%;
+          display: flex;
+          flex-direction: row;
+          justify-content: flex-end;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Before
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/10bf0922-5097-413a-a00f-f3dfa1692fc7)
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/173435db-6b2c-4c72-8e2b-348439c2f42c)

After
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/e4679847-5c08-42a9-928d-b185766dfd61)
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/9f45d20d-69ac-4eb9-9327-426bbd953fb2)

When more items are selected, the container displays a scrollbar
<img width="1128" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/08eddd7f-7100-4480-80e6-de40ee7d6b5d">
