### PR TITLE
Fix dashboard initial tab

### DIFF
--- a/app/javascript/components/custom-url-tabs/index.jsx
+++ b/app/javascript/components/custom-url-tabs/index.jsx
@@ -33,7 +33,7 @@ const CustomURLTabs = ({
 
   useEffect(() => {
     const currentTabIndex = tabs.findIndex((tab) => tab[0] === currentTab);
-    if (currentTabIndex) {
+    if (currentTabIndex >= 0) {
       setState((state) => ({
         ...state,
         selectedTab: currentTabIndex,


### PR DESCRIPTION
Follow up to PR: #9004
When first logging in there is no initial tab highlighted for the dashboard page. This pr fixes that.

Before:
<img width="814" alt="Screenshot 2024-01-05 at 8 41 07 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/f80cb262-8fdb-4421-b996-49efb22acad4">

After:
<img width="879" alt="Screenshot 2024-01-05 at 10 44 21 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/f8e70942-228f-416f-b6b0-69c87b662b6c">

