### PR TITLE
Updated Flash Message Text for Consistency

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -38,7 +38,7 @@ class ServiceController < ApplicationController
     when "custom_button"
       @display == 'generic_objects' ? generic_object_custom_buttons : custom_buttons
     else
-      add_flash(_("Invalid button action!"), :error)
+      add_flash(_("Invalid button action"), :error)
       render_flash
     end
   end


### PR DESCRIPTION
This change updates the `"Invalid button action"` string to match with the rest of the ui for consistency (eg. https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/mixins/generic_button_mixin.rb#L99).