### PR TITLE
Fixed `no implicit conversion of String into Integer` Error when Adding/Editing Container Provider

### DIFF
--- a/app/javascript/components/provider-form/helper.js
+++ b/app/javascript/components/provider-form/helper.js
@@ -1,11 +1,24 @@
 /** Field names that needs to be trimmed. */
 const trimFields = ['hostname'];
 
+const isObject = (data) => (typeof data === 'object' && data !== null);
+
 /** Function to trim a field's value.
  * If the nested data object contains the key which includes in variable 'trimFields',
  * then, trim the spaces from the value before sending to API.
  */
 export const trimFieldValue = (resource) => {
+  if (!isObject(resource)) {
+    return resource;
+  }
+
+  if (Array.isArray(resource)) {
+    resource.forEach((value, index) => {
+      resource[index] = trimFieldValue(value);
+    });
+    return resource;
+  }
+
   const keys = Object.keys(resource);
 
   keys.find((key) => {

--- a/app/javascript/components/provider-form/index.jsx
+++ b/app/javascript/components/provider-form/index.jsx
@@ -174,13 +174,13 @@ const ProviderForm = ({
       }
 
       // Construct the full form data with all the necessary items
-      const data = {
+      const data = trimFieldValue({
         ...rest,
-        endpoints: trimFieldValue(endpoints),
+        endpoints,
         authentications,
         ...(edit ? undefined : { type }),
         ddf: true,
-      };
+      });
 
       const request = providerId ? API.patch(`/api/providers/${providerId}`, data) : API.post('/api/providers', data);
       request.then(() => miqRedirectBack(message, 'success', redirect)).catch(miqSparkleOff);

--- a/app/javascript/spec/provider-form/helper.spec.js
+++ b/app/javascript/spec/provider-form/helper.spec.js
@@ -1,0 +1,125 @@
+import { trimFieldValue } from '../../components/provider-form/helper';
+
+describe('trimFieldValue function', () => {
+  it('should trim the hostname field', () => {
+    const resource = {
+      hostname: '  example.com  ',
+      otherField: 'value',
+    };
+
+    const trimmedResource = trimFieldValue(resource);
+
+    expect(trimmedResource.hostname).toEqual('example.com');
+    expect(trimmedResource.otherField).toEqual('value');
+  });
+
+  it('should handle nested objects and trim the hostname field', () => {
+    const resource = {
+      nestedObject: {
+        hostname: '  nested-example.com  ',
+      },
+      otherField: 'value',
+    };
+
+    const trimmedResource = trimFieldValue(resource);
+
+    expect(trimmedResource.nestedObject.hostname).toEqual('nested-example.com');
+    expect(trimmedResource.otherField).toEqual('value');
+  });
+
+  it('should handle multiple nested objects and trim the hostname field', () => {
+    const resource = {
+      firstLevel: {
+        nestedObject: {
+          hostname: '  nested-example.com  ',
+        },
+      },
+      otherField: 'value',
+    };
+
+    const trimmedResource = trimFieldValue(resource);
+
+    expect(trimmedResource.firstLevel.nestedObject.hostname).toEqual('nested-example.com');
+    expect(trimmedResource.otherField).toEqual('value');
+  });
+
+  it('should handle undefined values', () => {
+    const resource = {
+      hostname: undefined,
+    };
+
+    const trimmedResource = trimFieldValue(resource);
+
+    expect(trimmedResource.hostname).toEqual('');
+  });
+
+  it('should handle null values', () => {
+    const resource = {
+      hostname: null,
+    };
+
+    const trimmedResource = trimFieldValue(resource);
+
+    expect(trimmedResource.hostname).toEqual('');
+  });
+
+  it('should not modify non-trimmed fields', () => {
+    const resource = {
+      username: 'user123',
+      email: 'user@example.com',
+    };
+
+    const trimmedResource = trimFieldValue(resource);
+
+    expect(trimmedResource.username).toEqual('user123');
+    expect(trimmedResource.email).toEqual('user@example.com');
+  });
+
+  it('should handle non-object values', () => {
+    const resource = 'Hello';
+
+    const trimmedResource = trimFieldValue(resource);
+
+    expect(trimmedResource).toEqual('Hello');
+  });
+
+  it('should handle non-object values inside an array', () => {
+    const resource = ['  example.com  ', '  nested-example.com  ', { hostname: '  test   ' }];
+
+    const trimmedResource = trimFieldValue(resource);
+
+    expect(trimmedResource).toEqual(['  example.com  ', '  nested-example.com  ', { hostname: 'test' }]);
+  });
+
+  it('should handle objects nested inside an array', () => {
+    const resource = {
+      otherField: '  example.com  ',
+      otherField2: [
+        {
+          firstLevel: {
+            nestedObject: {
+              hostname: '  nested-example.com  ',
+            },
+          },
+          nestedField: 'value',
+        },
+      ],
+    };
+
+    const trimmedResource = trimFieldValue(resource);
+
+    expect(trimmedResource).toEqual({
+      otherField: '  example.com  ',
+      otherField2: [
+        {
+          firstLevel: {
+            nestedObject: {
+              hostname: 'nested-example.com',
+            },
+          },
+          nestedField: 'value',
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
Follow up to https://github.com/ManageIQ/manageiq-ui-classic/pull/9003 which introduced the method `trimFieldValue`, that's being called on (validation and) form submit.

Before introducing `trimFieldValue` method
```
endpoints: [
    {
        "role": "default",
        "security_protocol": "ssl-without-validation",
        "hostname": "ocp-master.cfme2.lab.eng.rdu2.redhat.com",
        "port": 8443
    }
]

```
An object returned after introducing `trimFieldValue`
```
endpoints: {
    "0": {
        "role": "default",
        "security_protocol": "ssl-without-validation",
        "hostname": "ocp-master.cfme2.lab.eng.rdu2.redhat.com",
        "port": 8443
    }
}
```

When endpoints were passed through the trimFieldValue method, they converted from an array into an object, which is not in line with what the API expects. 

This PR modification involves calling the trimFieldValue method before formatting the data to prevent this issue.

