### PR TITLE
Fix task details page

### DIFF
--- a/app/views/miq_task/show.html.haml
+++ b/app/views/miq_task/show.html.haml
@@ -1,7 +1,7 @@
 #task_div
   = task_details_summary(@miq_task, @miq_server)
   - record_ids = request_task_configuration_script_ids(@miq_task)
-  - if record_ids.any?
+  - if record_ids.present?
     %h3
       = _("Workflow States")
     = react('RequestWorkflowStatus', {:ids => record_ids})


### PR DESCRIPTION
Introduced by: https://github.com/ManageIQ/manageiq-ui-classic/pull/9000

Fixed a bug where the task details page fails to load for non-workflow tasks.

Before:
<img width="1282" alt="Screenshot 2024-01-12 at 10 54 42 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/3da848a6-b154-4b39-8e1c-fd4f1d94d6ef">

After:
<img width="1389" alt="Screenshot 2024-01-12 at 10 55 06 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/b3c67e0d-a5c0-42e7-b370-b7a560473631">
