### PR TITLE
Fix for the error messages in Request-info tabs in the Service catalog item summary pages

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -350,8 +350,6 @@ class CatalogController < ApplicationController
       return
     end
 
-    build_accordions_and_trees
-
     if params[:id] && !params[:button] # If a tree node id came in, show in one of the trees
       @nodetype, id = parse_nodetype_and_id(params[:id])
       self.x_active_tree   = 'sandt_tree'
@@ -363,6 +361,8 @@ class CatalogController < ApplicationController
     else
       @in_a_form = false
     end
+
+    build_accordions_and_trees
 
     if params[:commit] == "Upload" && session.fetch_path(:edit, :new, :sysprep_enabled, 1) == "Sysprep Answer File"
       upload_sysprep_file

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -18,6 +18,7 @@ class ServiceController < ApplicationController
 
   def show
     super
+    @options = {}
     @view, @pages = get_view(Vm, :parent => @record, :parent_method => :all_vms, :all_pages => true)
   end
 


### PR DESCRIPTION
This fix also solves the 'stack level too deep' error notification we see on the services summary page sometimes.

Please see the steps to replicate the issue(s)

https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/d9704165-188f-4ead-a217-ed4e3505a931


Before
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/afc8c1d7-e7dc-4ba7-a4c9-597abf82c490)

After

https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/bfece834-0d0c-44d7-9196-67ab2c48e291

