### PR TITLE
Remove invisible ae tabs

### DIFF
--- a/app/views/miq_ae_class/_all_tabs.html.haml
+++ b/app/views/miq_ae_class/_all_tabs.html.haml
@@ -23,46 +23,19 @@
       = miq_tab_content("schema", @sb[:active_tab]) do
         = render :partial => "class_fields"
   - when "aei"
-    %ul.nav.nav-tabs{'role' => 'tablist'}
-      = miq_tab_header("instances", @sb[:active_tab]) do
-        = _('Instances')
-    .tab-content
-      = miq_tab_content("instances", @sb[:active_tab]) do
-        = render :partial => "instance_fields"
+    = render :partial => "instance_fields"
   - when "aem"
-    %ul.nav.nav-tabs{'role' => 'tablist'}
-      = miq_tab_header("methods", @sb[:active_tab]) do
-        = _("Method Inputs")
-    .tab-content
-      = miq_tab_content("methods", @sb[:active_tab]) do
-        = render :partial => "method_inputs"
+    = render :partial => "method_inputs"
   - when "aen"
     - if @in_a_form && @edit.key?(:ae_class_id)
-      -# class add
-      %ul.nav.nav-tabs{'role' => 'tablist'}
-        = miq_tab_header("details", @sb[:active_tab]) do
-          = _('Properties')
-      .tab-content
-        = miq_tab_content("details", @sb[:active_tab]) do
-          = render :partial => "class_add"
+      = render :partial => "class_add"
     - else
-      %ul.nav.nav-tabs{'role' => 'tablist'}
-        = miq_tab_header("details", @sb[:active_tab]) do
-          = _('Namespace Details')
-      .tab-content
-        = miq_tab_content("details", @sb[:active_tab]) do
-          - if !@in_a_form
-            = render :partial => "ns_details"
-          - else
-            = render :partial => "ns_list"
-  - when "root"
-    -# ns_list_div
-    %ul.nav.nav-tabs
-      = miq_tab_header("namespaces", @sb[:active_tab]) do
-        = _('Namespaces')
-    .tab-content
-      = miq_tab_content("namespaces", @sb[:active_tab]) do
+      - if !@in_a_form
+        = render :partial => "ns_details"
+      - else
         = render :partial => "ns_list"
+  - when "root"
+    = render :partial => "ns_list"
 
 :javascript
   // method takes hash that can have 4 keys: tabs div id, active_tab label,


### PR DESCRIPTION
When only 1 tab exists the UI will not actually render the tab headers and only display the tab content. This PR removes all these invisible tabs from the Automation / Embedded Automate / Explorer page and only renders the tab content.

These are how the UI pages would look if the tabs were rendered. I duplicated each tab so that it can be seen in the UI:

root-tabs
<img width="1378" alt="root-tabs" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/026ed983-f25b-4cf3-82dc-160620258fc4">

aen-tabs
<img width="1366" alt="aen-tabs1" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/89bb78ef-7f80-4ec1-b063-00389a1984e8">
<img width="1390" alt="aen-tabs2" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/4d2306ac-ff6f-4390-ac70-baac61d75ceb">

aem-tabs
<img width="1380" alt="aem-tabs" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/7fe038c4-946b-4c02-a684-d8cd0af28560">

aei-tabs
<img width="1383" alt="aei-tabs" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/0b48fda7-e60d-4e03-9b49-9591515dfbb1">

After deleting the tabs:

root-tabs
<img width="1383" alt="root-after" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/3581614a-6c2d-4dfd-ba02-800a5e41dba4">

aen-tabs
<img width="1331" alt="Screenshot 2024-01-16 at 11 56 22 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/0dbebcba-c3b5-41f9-ac24-70dc4109743a">
<img width="1385" alt="aen1-after" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/c1176e33-fdab-48ce-8159-9cd5883b7c8b">

aem-tabs
<img width="1384" alt="aem-after" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/41168dd7-8f41-4713-92d2-9b858edc13ec">

aei-tabs
<img width="1383" alt="aei-after" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/f9c24e5b-3dac-4e45-93e3-26d9b515cc80">



