### PR TITLE
Updated RecordId in Edit Management Engine Form

### DIFF
--- a/app/views/vm_common/_evm_relationship.html.haml
+++ b/app/views/vm_common/_evm_relationship.html.haml
@@ -3,4 +3,4 @@
   %h3
     = _('Servers')
   .col-md-12
-    = react('VmServerRelationshipForm', :recordId => @edit[:vm_id].to_s, :redirect => url_for(:action => :show, :id => @record.id))
+    = react('VmServerRelationshipForm', :recordId => @record.id.to_s, :redirect => url_for(:action => :show, :id => @record.id))


### PR DESCRIPTION
`@edit[:vm_id]` was removed in https://github.com/ManageIQ/manageiq-ui-classic/pull/7456 but `recordId` was still being set to to it causing a `bad_request` error in the API.

Before:
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/766552b9-04d8-43e7-8d03-e739fcdf3d8f)
