### PR TITLE
Remove report tab technical debt

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -108,18 +108,6 @@ class ReportController < ApplicationController
     case params[:tab].split("_")[0]
     when "edit"
       redirect_to(:action => "miq_report_edit", :tab => params[:tab])
-    when "schedules"
-      assert_privileges("miq_report_schedules")
-
-      redirect_to(:action => params[:tab])
-    when "saved_reports"
-      assert_privileges("miq_report_saved_reports")
-
-      redirect_to(:action => params[:tab])
-    when "menueditor"
-      assert_privileges("miq_report_menu_editor")
-
-      redirect_to(:action => "menu_edit")
     else
       assert_privileges("miq_report")
 


### PR DESCRIPTION
Remove code from the report controller to handle various tabs that do not exist in the UI.

schedules: The schedules pages do not contain any tabs
<img width="1381" alt="Screenshot 2024-01-17 at 2 50 55 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/0224f817-bbef-4a3e-9acb-e2ea92845e52">
<img width="1376" alt="Screenshot 2024-01-17 at 2 51 07 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/b361fe69-1cd8-47aa-9f2a-7f2e636a772e">
<img width="1372" alt="Screenshot 2024-01-17 at 2 53 18 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/fb907208-f7fd-41c4-a352-b2260428b4d5">

saved_reports: The saved reports tab is handled in the file: https://github.com/ManageIQ/manageiq-ui-classic/tree/master/app/views/report/_report_list.html.haml

menuEditor: There is no action that exists called menu_edit, meaning this block of tabs code is not actually doing anything.