### PR TITLE
Remove dashboard haml file change tab js code

### DIFF
--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -11,6 +11,3 @@
         - widget = MiqWidget.find_by_id(w)
         - if widget && widget.enabled && @available_widgets.include?(widget.id)
           = WidgetPresenter.new(self, controller, widget).render_partial
-- if WidgetPresenter.chart_data.present?
-  :javascript
-    ManageIQ.charts.chartData = #{{"widgetchart" => WidgetPresenter.chart_data}.to_json.html_safe};


### PR DESCRIPTION
Dashboard tabs were converted to React in this PR: #9004 

But the haml file js code used to handle the old tabs functionality was never removed in that PR.