### PR TITLE
Fix cypress explorer helper functions

### DIFF
--- a/cypress/README.md
+++ b/cypress/README.md
@@ -27,6 +27,11 @@ Actual tests can be found in `cypress/integration/ui/`.
 
 ManageIQ implements the following cypress extensions:
 
+##### explorer
+
+* `cy.accordion(title)` - open an accordion panel. title: String for the accordion title for the accordion panel to open.
+* `cy.accordionItem(name)` - click on a record in the accordion panel. name: String for the record to click in the accordion panel.
+
 ##### login
 
 `cy.login()` - logs in as admin

--- a/cypress/support/commands/explorer.js
+++ b/cypress/support/commands/explorer.js
@@ -1,19 +1,25 @@
 /* eslint-disable no-undef */
-// cy.accordion('Catalog Items') - click accordion, unless already expanded
+// title: String of the accordion title for the accordian panel to open.
 Cypress.Commands.add('accordion', (text) => {
-  cy.get('#main-content');  // ensure screen loads first
-
+  cy.get('#main-content'); // ensure screen loads first
   let ret = cy.get('#accordion')
     .find('.panel-title a')
     .contains(new RegExp(`^${text}$`));
 
   ret.then((el) => {
-    // do not collapse if expanded
+    // Do not collapse if already expanded
     if (el.is('.collapsed')) {
-      el.click();
+      el.trigger('click');
     }
     return el;
   });
 
   return ret.parents('.panel');
+});
+
+// name: String of the record in the accordion panel to click
+Cypress.Commands.add('accordionItem', (name) => {
+  cy.get('#main-content'); // ensure screen loads first
+
+  cy.get('.list-group-item').contains(name).click();
 });

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -40,6 +40,7 @@
 // ***********************************************************
 
 // Commands
+import './commands/explorer.js'
 import './commands/gtl.js'
 import './commands/login.js'
 import './commands/menu.js'


### PR DESCRIPTION
Fix the Cypress explorer helper functions to open a panel in the explorer view. Also, fixed the README.md file to reflect this change.