### PR TITLE
Fix cypress search box assertions

### DIFF
--- a/cypress/README.md
+++ b/cypress/README.md
@@ -50,6 +50,8 @@ TODO allow using {id:...} instead of string label for menu items, gtl items, tre
 
 * `cy.expect_explorer_title('Active Services')` - check the title on an explorer screen
 * `cy.expect_show_list_title('Cloud Providers')` - check the title on a show\_list screen
+* `cy.expect_search_box()` - check if searchbox is present on screen
+* `cy.expect_no_search_box()` - check if no searchbox is present on the screen
 * TODO `cy.expect_layout('miq-layout-center_div_with_listnav')` - check current layout
 
 #### GTL

--- a/cypress/e2e/ui/searchbox.cy.js
+++ b/cypress/e2e/ui/searchbox.cy.js
@@ -13,23 +13,21 @@ describe('Search box', () => {
 
   it('Is present on list view page', () => {
     cy.menu('Compute', 'Clouds', 'Providers');
-    cy.get('#search_text').first().click();
-    cy.search_box();
+    cy.expect_search_box();
   });
 
   it('Is present on explorer page', () => {
     cy.menu('Services', 'Workloads');
-    cy.get('div[class=panel-heading]').first().click();
-    cy.search_box();
+    cy.expect_search_box();
   });
 
   it('Is not present on non-list page', () => {
     cy.menu('Overview', 'Dashboard');
-    cy.no_search_box();
+    cy.expect_no_search_box();
   });
 
   it('Is not present on list view page', () => {
     cy.menu('Control', 'Alerts');
-    cy.no_search_box();
+    cy.expect_no_search_box();
   });
 });

--- a/cypress/support/assertions/expect_search_box.js
+++ b/cypress/support/assertions/expect_search_box.js
@@ -1,10 +1,9 @@
 /* eslint-disable no-undef */
 
-// Searchbox related helpers
-Cypress.Commands.add('search_box', () => {
+Cypress.Commands.add('expect_search_box', () => {
   return cy.get('#search_text').should('be.visible');
 });
 
-Cypress.Commands.add('no_search_box', () => {
+Cypress.Commands.add('expect_no_search_box', () => {
   return cy.get('#search_text').should('not.exist');
 });

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -43,10 +43,10 @@
 import './commands/gtl.js'
 import './commands/login.js'
 import './commands/menu.js'
-import './commands/search.js'
 import './commands/toolbar.js'
 
 // Assertions
+import './assertions/expect_search_box.js'
 import './assertions/expect_title.js'
 import './assertions/expect_text.js'
 


### PR DESCRIPTION
Moved the code for the Cypress search box assertions from the Commands folder to the Assertions folder since these functions are checking if something is true rather than returning a Cypress element / performing an action on the UI. Also, updated the Cypress search tests and documentation to reflect these changes.