### PR TITLE
Fix EMS network "Region" text

### DIFF
--- a/app/helpers/ems_network_helper/textual_summary.rb
+++ b/app/helpers/ems_network_helper/textual_summary.rb
@@ -32,7 +32,7 @@ module EmsNetworkHelper::TextualSummary
   # Items
   #
   def textual_provider_region
-    @record.provider_region.present? ? {:label => _("Region"), :value => @record.description} : nil
+    @record.provider_region.present? ? {:label => _("Region"), :value => @record.provider_region} : nil
   end
 
   def textual_hostname


### PR DESCRIPTION
Set EMS network "Region" text to the record's '.provider_region' value. The '.description' doesn't have any region information (for example, the VMWare network manager description is always "VMware Cloud Network"). Also, many providers only define a 'description' class method breaking their Network Manager summary page altogether.