### PR TITLE
Fix tasks menu cypress test

### DIFF
--- a/cypress/e2e/ui/menu.cy.js
+++ b/cypress/e2e/ui/menu.cy.js
@@ -459,7 +459,7 @@ describe('Menu', () => {
       });
 
       it('Tasks', () => {
-        cy.menu('Settings', 'Tasks').get('#main-content a').contains('My Tasks');
+        cy.menu('Settings', 'Tasks').get('.bx--tabs--scrollable__nav > li').contains('My Tasks');
       });
 
       it('Documentation', () => {


### PR DESCRIPTION
Fixes the task menu cypress test. Due to changes made in this pr: #9045 the menu test for the task page was broken. This PR fixes this test.