### PR TITLE
Drop include_concern

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -53,28 +53,28 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  include_concern 'AdvancedSearch'
-  include_concern 'Automate'
-  include_concern 'Buttons'
-  include_concern 'CiProcessing'
-  include_concern 'Compare'
-  include_concern 'CurrentUser'
-  include_concern 'DialogRunner'
-  include_concern 'Explorer'
-  include_concern 'Filter'
-  include_concern 'MiqRequestMethods'
-  include_concern 'Performance'
-  include_concern 'PolicySupport'
-  include_concern 'ReportDownloads'
-  include_concern 'SessionSize'
-  include_concern 'SysprepAnswerFile'
-  include_concern 'UserScriptFile'
-  include_concern 'Tags'
-  include_concern 'Tenancy'
-  include_concern 'Timelines'
-  include_concern 'Timezone'
-  include_concern 'TreeSupport'
-  include_concern 'WaitForTask'
+  include AdvancedSearch
+  include Automate
+  include Buttons
+  include CiProcessing
+  include Compare
+  include CurrentUser
+  include DialogRunner
+  include Explorer
+  include Filter
+  include MiqRequestMethods
+  include Performance
+  include PolicySupport
+  include ReportDownloads
+  include SessionSize
+  include SysprepAnswerFile
+  include UserScriptFile
+  include Tags
+  include Tenancy
+  include Timelines
+  include Timezone
+  include TreeSupport
+  include WaitForTask
 
   before_action :reset_toolbar
   before_action :set_session_tenant

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -1,8 +1,8 @@
 class MiqAeCustomizationController < ApplicationController
   require "English"
-  include_concern 'CustomButtons'
-  include_concern 'OldDialogs'
-  include_concern 'Dialogs'
+  include CustomButtons
+  include OldDialogs
+  include Dialogs
 
   helper ApplicationHelper::ImportExportHelper
   include Mixins::GenericSessionMixin

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -1,6 +1,6 @@
 class MiqPolicyController < ApplicationController
-  include_concern 'Events'
-  include_concern 'Policies'
+  include Events
+  include Policies
 
   before_action :check_privileges
   before_action :get_session_data

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -1,8 +1,8 @@
 class OpsController < ApplicationController
   # Methods for accordions
-  include_concern 'Diagnostics'
-  include_concern 'OpsRbac'
-  include_concern 'Settings'
+  include Diagnostics
+  include OpsRbac
+  include Settings
   include OpsHelper::MyServer
   include Mixins::CustomButtonDialogFormMixin
   include Mixins::BreadcrumbsMixin

--- a/app/controllers/ops_controller/settings.rb
+++ b/app/controllers/ops_controller/settings.rb
@@ -1,17 +1,16 @@
 # Setting Accordion methods included in OpsController.rb
 module OpsController::Settings
   extend ActiveSupport::Concern
-
-  include_concern 'AnalysisProfiles'
-  include_concern 'CapAndU'
-  include_concern 'Common'
-  include_concern 'Schedules'
-  include_concern 'AutomateSchedules'
-  include_concern 'Tags'
-  include_concern 'LabelTagMapping'
-  include_concern 'Upload'
-  include_concern 'Zones'
-  include_concern 'HelpMenu'
+  include AnalysisProfiles
+  include CapAndU
+  include Common
+  include Schedules
+  include AutomateSchedules
+  include Tags
+  include LabelTagMapping
+  include Upload
+  include Zones
+  include HelpMenu
 
   # Apply the good records from an uploaded import file
   def apply_imports

--- a/app/controllers/pxe_controller.rb
+++ b/app/controllers/pxe_controller.rb
@@ -1,9 +1,9 @@
 class PxeController < ApplicationController
   # Methods for accordions
-  include_concern 'PxeServers'
-  include_concern 'PxeImageTypes'
-  include_concern 'PxeCustomizationTemplates'
-  include_concern 'IsoDatastores'
+  include PxeServers
+  include PxeImageTypes
+  include PxeCustomizationTemplates
+  include IsoDatastores
 
   before_action :check_privileges
   before_action :get_session_data

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -4,12 +4,12 @@ class ReportController < ApplicationController
   DEFAULT_SORT_COLUMN_NUMBER = 2
   DEFAULT_SORT_ORDER = "DESC".freeze
 
-  include_concern 'Dashboards'
-  include_concern 'Menus'
-  include_concern 'Reports'
-  include_concern 'SavedReports'
-  include_concern 'Schedules'
-  include_concern 'Widgets'
+  include Dashboards
+  include Menus
+  include Reports
+  include SavedReports
+  include Schedules
+  include Widgets
 
   helper ApplicationHelper::ImportExportHelper
   include ReportHelper

--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -1,8 +1,7 @@
 module ReportController::Reports
   include DataTableHelper
   extend ActiveSupport::Concern
-
-  include_concern 'Editor'
+  include Editor
 
   def miq_report_run
     assert_privileges("miq_report_run")

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -1,6 +1,6 @@
 class StorageController < ApplicationController
-  include_concern 'StorageD'
-  include_concern 'StoragePod'
+  include StorageD
+  include StoragePod
   include Mixins::GenericSessionMixin
   include Mixins::GenericShowMixin
   include Mixins::MoreShowActions

--- a/app/helpers/ansible_credential_helper.rb
+++ b/app/helpers/ansible_credential_helper.rb
@@ -1,3 +1,3 @@
 module AnsibleCredentialHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/ansible_playbook_helper.rb
+++ b/app/helpers/ansible_playbook_helper.rb
@@ -1,3 +1,3 @@
 module AnsiblePlaybookHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/ansible_repository_helper.rb
+++ b/app/helpers/ansible_repository_helper.rb
@@ -1,3 +1,3 @@
 module AnsibleRepositoryHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/auth_key_pair_cloud_helper.rb
+++ b/app/helpers/auth_key_pair_cloud_helper.rb
@@ -1,3 +1,3 @@
 module AuthKeyPairCloudHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/availability_zone_helper.rb
+++ b/app/helpers/availability_zone_helper.rb
@@ -1,5 +1,5 @@
 module AvailabilityZoneHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 
   def accessible_select_event_types
     [[_('Management Events'), 'timeline']]

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -1,5 +1,5 @@
 module CatalogHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
   include RequestInfoHelper
   include Mixins::AutomationMixin
   include OrchestrationTemplateHelper

--- a/app/helpers/cloud_database_helper.rb
+++ b/app/helpers/cloud_database_helper.rb
@@ -1,3 +1,3 @@
 module CloudDatabaseHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/cloud_network_helper.rb
+++ b/app/helpers/cloud_network_helper.rb
@@ -1,3 +1,3 @@
 module CloudNetworkHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/cloud_object_store_container_helper.rb
+++ b/app/helpers/cloud_object_store_container_helper.rb
@@ -1,3 +1,3 @@
 module CloudObjectStoreContainerHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/cloud_object_store_object_helper.rb
+++ b/app/helpers/cloud_object_store_object_helper.rb
@@ -1,3 +1,3 @@
 module CloudObjectStoreObjectHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/cloud_subnet_helper.rb
+++ b/app/helpers/cloud_subnet_helper.rb
@@ -1,3 +1,3 @@
 module CloudSubnetHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/cloud_tenant_helper.rb
+++ b/app/helpers/cloud_tenant_helper.rb
@@ -1,3 +1,3 @@
 module CloudTenantHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/cloud_volume_backup_helper.rb
+++ b/app/helpers/cloud_volume_backup_helper.rb
@@ -1,3 +1,3 @@
 module CloudVolumeBackupHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/cloud_volume_helper.rb
+++ b/app/helpers/cloud_volume_helper.rb
@@ -1,3 +1,3 @@
 module CloudVolumeHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/cloud_volume_snapshot_helper.rb
+++ b/app/helpers/cloud_volume_snapshot_helper.rb
@@ -1,3 +1,3 @@
 module CloudVolumeSnapshotHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/cloud_volume_type_helper.rb
+++ b/app/helpers/cloud_volume_type_helper.rb
@@ -1,3 +1,3 @@
 module CloudVolumeTypeHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/configuration_job_helper.rb
+++ b/app/helpers/configuration_job_helper.rb
@@ -1,3 +1,3 @@
 module ConfigurationJobHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/configuration_profile_helper.rb
+++ b/app/helpers/configuration_profile_helper.rb
@@ -1,3 +1,3 @@
 module ConfigurationProfileHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/configured_system_helper.rb
+++ b/app/helpers/configured_system_helper.rb
@@ -1,3 +1,3 @@
 module ConfiguredSystemHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/container_build_helper.rb
+++ b/app/helpers/container_build_helper.rb
@@ -1,4 +1,4 @@
 module ContainerBuildHelper
-  include_concern 'ContainerSummaryHelper'
-  include_concern 'TextualSummary'
+  include ContainerSummaryHelper
+  include TextualSummary
 end

--- a/app/helpers/container_group_helper.rb
+++ b/app/helpers/container_group_helper.rb
@@ -1,5 +1,5 @@
 module ContainerGroupHelper
-  include_concern 'ComplianceSummaryHelper'
-  include_concern 'ContainerSummaryHelper'
-  include_concern 'TextualSummary'
+  include ComplianceSummaryHelper
+  include ContainerSummaryHelper
+  include TextualSummary
 end

--- a/app/helpers/container_helper.rb
+++ b/app/helpers/container_helper.rb
@@ -1,4 +1,4 @@
 module ContainerHelper
-  include_concern 'ContainerSummaryHelper'
-  include_concern 'TextualSummary'
+  include ContainerSummaryHelper
+  include TextualSummary
 end

--- a/app/helpers/container_image_helper.rb
+++ b/app/helpers/container_image_helper.rb
@@ -1,5 +1,5 @@
 module ContainerImageHelper
-  include_concern 'ComplianceSummaryHelper'
-  include_concern 'ContainerSummaryHelper'
-  include_concern 'TextualSummary'
+  include ComplianceSummaryHelper
+  include ContainerSummaryHelper
+  include TextualSummary
 end

--- a/app/helpers/container_image_registry_helper.rb
+++ b/app/helpers/container_image_registry_helper.rb
@@ -1,4 +1,4 @@
 module ContainerImageRegistryHelper
-  include_concern 'ContainerSummaryHelper'
-  include_concern 'TextualSummary'
+  include ContainerSummaryHelper
+  include TextualSummary
 end

--- a/app/helpers/container_node_helper.rb
+++ b/app/helpers/container_node_helper.rb
@@ -1,5 +1,5 @@
 module ContainerNodeHelper
-  include_concern 'ComplianceSummaryHelper'
-  include_concern 'ContainerSummaryHelper'
-  include_concern 'TextualSummary'
+  include ComplianceSummaryHelper
+  include ContainerSummaryHelper
+  include TextualSummary
 end

--- a/app/helpers/container_project_helper.rb
+++ b/app/helpers/container_project_helper.rb
@@ -1,4 +1,4 @@
 module ContainerProjectHelper
-  include_concern 'ContainerSummaryHelper'
-  include_concern 'TextualSummary'
+  include ContainerSummaryHelper
+  include TextualSummary
 end

--- a/app/helpers/container_replicator_helper.rb
+++ b/app/helpers/container_replicator_helper.rb
@@ -1,5 +1,5 @@
 module ContainerReplicatorHelper
-  include_concern 'ComplianceSummaryHelper'
-  include_concern 'ContainerSummaryHelper'
-  include_concern 'TextualSummary'
+  include ComplianceSummaryHelper
+  include ContainerSummaryHelper
+  include TextualSummary
 end

--- a/app/helpers/container_route_helper.rb
+++ b/app/helpers/container_route_helper.rb
@@ -1,4 +1,4 @@
 module ContainerRouteHelper
-  include_concern 'ContainerSummaryHelper'
-  include_concern 'TextualSummary'
+  include ContainerSummaryHelper
+  include TextualSummary
 end

--- a/app/helpers/container_service_helper.rb
+++ b/app/helpers/container_service_helper.rb
@@ -1,4 +1,4 @@
 module ContainerServiceHelper
-  include_concern 'ContainerSummaryHelper'
-  include_concern 'TextualSummary'
+  include ContainerSummaryHelper
+  include TextualSummary
 end

--- a/app/helpers/container_template_helper.rb
+++ b/app/helpers/container_template_helper.rb
@@ -1,4 +1,4 @@
 module ContainerTemplateHelper
-  include_concern 'ContainerSummaryHelper'
-  include_concern 'TextualSummary'
+  include ContainerSummaryHelper
+  include TextualSummary
 end

--- a/app/helpers/ems_cloud_helper.rb
+++ b/app/helpers/ems_cloud_helper.rb
@@ -1,6 +1,6 @@
 module EmsCloudHelper
-  include_concern 'TextualSummary'
-  include_concern 'ComplianceSummaryHelper'
+  include TextualSummary
+  include ComplianceSummaryHelper
 
   def edit_redirect_path(lastaction, ems)
     lastaction == 'show_list' ? ems_clouds_path : ems_cloud_path(ems)

--- a/app/helpers/ems_cluster_helper.rb
+++ b/app/helpers/ems_cluster_helper.rb
@@ -1,3 +1,3 @@
 module EmsClusterHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/ems_configuration_helper.rb
+++ b/app/helpers/ems_configuration_helper.rb
@@ -1,5 +1,5 @@
 module EmsConfigurationHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 
   def edit_redirect_path(lastaction, ems)
     lastaction == 'show_list' ? ems_configuration_path : ems_configuration_path(ems)

--- a/app/helpers/ems_container_helper.rb
+++ b/app/helpers/ems_container_helper.rb
@@ -1,7 +1,7 @@
 module EmsContainerHelper
   include ContainerSummaryHelper
-  include_concern 'TextualSummary'
-  include_concern 'ComplianceSummaryHelper'
+  include TextualSummary
+  include ComplianceSummaryHelper
 
   def edit_redirect_path(lastaction, ems)
     lastaction == 'show_list' ? ems_containers_path : ems_container_path(ems)

--- a/app/helpers/ems_infra_helper.rb
+++ b/app/helpers/ems_infra_helper.rb
@@ -1,6 +1,6 @@
 module EmsInfraHelper
-  include_concern 'TextualSummary'
-  include_concern 'ComplianceSummaryHelper'
+  include TextualSummary
+  include ComplianceSummaryHelper
 
   def scaling_field_label(param_name)
     field_name = param_name.dup

--- a/app/helpers/ems_network_helper.rb
+++ b/app/helpers/ems_network_helper.rb
@@ -1,5 +1,5 @@
 module EmsNetworkHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 
   def edit_redirect_path(lastaction, ems)
     lastaction == 'show_list' ? ems_networks_path : ems_network_path(ems)

--- a/app/helpers/ems_physical_infra_helper.rb
+++ b/app/helpers/ems_physical_infra_helper.rb
@@ -1,6 +1,6 @@
 module EmsPhysicalInfraHelper
-  include_concern 'TextualSummary'
-  include_concern 'ComplianceSummaryHelper'
+  include TextualSummary
+  include ComplianceSummaryHelper
 
   def edit_redirect_path(lastaction, ems)
     lastaction == 'show_list' ? ems_physical_infras_path : ems_physical_infra_path(ems)

--- a/app/helpers/ems_storage_helper.rb
+++ b/app/helpers/ems_storage_helper.rb
@@ -1,5 +1,5 @@
 module EmsStorageHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 
   def edit_redirect_path(lastaction, ems)
     lastaction == 'show_list' ? ems_storages_path : ems_storages_path(ems)

--- a/app/helpers/firmware_binary_helper.rb
+++ b/app/helpers/firmware_binary_helper.rb
@@ -1,3 +1,3 @@
 module FirmwareBinaryHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/firmware_registry_helper.rb
+++ b/app/helpers/firmware_registry_helper.rb
@@ -1,3 +1,3 @@
 module FirmwareRegistryHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/firmware_target_helper.rb
+++ b/app/helpers/firmware_target_helper.rb
@@ -1,3 +1,3 @@
 module FirmwareTargetHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/flavor_helper.rb
+++ b/app/helpers/flavor_helper.rb
@@ -1,3 +1,3 @@
 module FlavorHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/floating_ip_helper.rb
+++ b/app/helpers/floating_ip_helper.rb
@@ -1,3 +1,3 @@
 module FloatingIpHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/generic_object_definition_helper.rb
+++ b/app/helpers/generic_object_definition_helper.rb
@@ -1,5 +1,5 @@
 module GenericObjectDefinitionHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 
   def generic_object_definition_button_summary(button)
     style = button.options.key?(:button_color) ? button.options[:button_color].to_s : nil

--- a/app/helpers/generic_object_helper.rb
+++ b/app/helpers/generic_object_helper.rb
@@ -1,3 +1,3 @@
 module GenericObjectHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/guest_device_helper.rb
+++ b/app/helpers/guest_device_helper.rb
@@ -1,3 +1,3 @@
 module GuestDeviceHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/host_aggregate_helper.rb
+++ b/app/helpers/host_aggregate_helper.rb
@@ -1,3 +1,3 @@
 module HostAggregateHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/host_helper.rb
+++ b/app/helpers/host_helper.rb
@@ -1,6 +1,6 @@
 module HostHelper
-  include_concern 'TextualSummary'
-  include_concern 'ComplianceSummaryHelper'
+  include TextualSummary
+  include ComplianceSummaryHelper
 
   def host_info
     devices = devices_details

--- a/app/helpers/host_initiator_group_helper.rb
+++ b/app/helpers/host_initiator_group_helper.rb
@@ -1,4 +1,4 @@
 module HostInitiatorGroupHelper
-  include_concern 'TextualSummary'
-  include_concern 'ComplianceSummaryHelper'
+  include TextualSummary
+  include ComplianceSummaryHelper
 end

--- a/app/helpers/host_initiator_helper.rb
+++ b/app/helpers/host_initiator_helper.rb
@@ -1,4 +1,4 @@
 module HostInitiatorHelper
-  include_concern 'TextualSummary'
-  include_concern 'ComplianceSummaryHelper'
+  include TextualSummary
+  include ComplianceSummaryHelper
 end

--- a/app/helpers/infra_networking_helper.rb
+++ b/app/helpers/infra_networking_helper.rb
@@ -1,3 +1,3 @@
 module InfraNetworkingHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/network_port_helper.rb
+++ b/app/helpers/network_port_helper.rb
@@ -1,3 +1,3 @@
 module NetworkPortHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/network_router_helper.rb
+++ b/app/helpers/network_router_helper.rb
@@ -1,3 +1,3 @@
 module NetworkRouterHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/network_service_helper.rb
+++ b/app/helpers/network_service_helper.rb
@@ -1,3 +1,3 @@
 module NetworkServiceHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/ops_helper.rb
+++ b/app/helpers/ops_helper.rb
@@ -1,6 +1,6 @@
 module OpsHelper
-  include_concern 'TextualSummary'
-  include_concern 'MyServer'
+  include TextualSummary
+  include MyServer
   include VmwareConsoleHelper
   include SettingsAnalysisProfileHelper
   include SettingsTagsTabsHelper

--- a/app/helpers/orchestration_stack_helper.rb
+++ b/app/helpers/orchestration_stack_helper.rb
@@ -1,3 +1,3 @@
 module OrchestrationStackHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/persistent_volume_helper.rb
+++ b/app/helpers/persistent_volume_helper.rb
@@ -1,4 +1,4 @@
 module PersistentVolumeHelper
-  include_concern 'ContainerSummaryHelper'
-  include_concern 'TextualSummary'
+  include ContainerSummaryHelper
+  include TextualSummary
 end

--- a/app/helpers/physical_chassis_helper.rb
+++ b/app/helpers/physical_chassis_helper.rb
@@ -1,3 +1,3 @@
 module PhysicalChassisHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/physical_network_port_helper.rb
+++ b/app/helpers/physical_network_port_helper.rb
@@ -1,3 +1,3 @@
 module PhysicalNetworkPortHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/physical_rack_helper.rb
+++ b/app/helpers/physical_rack_helper.rb
@@ -1,3 +1,3 @@
 module PhysicalRackHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/physical_server_helper.rb
+++ b/app/helpers/physical_server_helper.rb
@@ -1,3 +1,3 @@
 module PhysicalServerHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/physical_storage_helper.rb
+++ b/app/helpers/physical_storage_helper.rb
@@ -1,3 +1,3 @@
 module PhysicalStorageHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/physical_switch_helper.rb
+++ b/app/helpers/physical_switch_helper.rb
@@ -1,3 +1,3 @@
 module PhysicalSwitchHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/placement_group_helper.rb
+++ b/app/helpers/placement_group_helper.rb
@@ -1,3 +1,3 @@
 module PlacementGroupHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/pxe_helper.rb
+++ b/app/helpers/pxe_helper.rb
@@ -1,3 +1,3 @@
 module PxeHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -1,5 +1,5 @@
 module ReportHelper
-  include_concern 'Editor'
+  include Editor
   include ReportInformationHelper
   include ReportDashboardWidgetHelper
   include ReportScheduleHelper

--- a/app/helpers/resource_pool_helper.rb
+++ b/app/helpers/resource_pool_helper.rb
@@ -1,5 +1,5 @@
 module ResourcePoolHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 
   def calculate_rp_config(db_record)
     rp_config = []

--- a/app/helpers/security_group_helper.rb
+++ b/app/helpers/security_group_helper.rb
@@ -1,3 +1,3 @@
 module SecurityGroupHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/security_policy_helper.rb
+++ b/app/helpers/security_policy_helper.rb
@@ -1,3 +1,3 @@
 module SecurityPolicyHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/security_policy_rule_helper.rb
+++ b/app/helpers/security_policy_rule_helper.rb
@@ -1,3 +1,3 @@
 module SecurityPolicyRuleHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -1,3 +1,3 @@
 module ServiceHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/storage_helper.rb
+++ b/app/helpers/storage_helper.rb
@@ -1,3 +1,3 @@
 module StorageHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/storage_resource_helper.rb
+++ b/app/helpers/storage_resource_helper.rb
@@ -1,4 +1,4 @@
 module StorageResourceHelper
-  include_concern 'TextualSummary'
-  include_concern 'ComplianceSummaryHelper'
+  include TextualSummary
+  include ComplianceSummaryHelper
 end

--- a/app/helpers/storage_service_helper.rb
+++ b/app/helpers/storage_service_helper.rb
@@ -1,4 +1,4 @@
 module StorageServiceHelper
-  include_concern 'TextualSummary'
-  include_concern 'ComplianceSummaryHelper'
+  include TextualSummary
+  include ComplianceSummaryHelper
 end

--- a/app/helpers/vm_cloud_helper.rb
+++ b/app/helpers/vm_cloud_helper.rb
@@ -1,4 +1,4 @@
 module VmCloudHelper
   include VmHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/vm_helper.rb
+++ b/app/helpers/vm_helper.rb
@@ -1,8 +1,7 @@
 module VmHelper
   include RequestInfoHelper
-
-  include_concern 'TextualSummary'
-  include_concern 'ComplianceSummaryHelper'
+  include TextualSummary
+  include ComplianceSummaryHelper
 
   # TODO: These methods can be removed once the Summary and ListNav data layer is consolidated.
   def last_date(request_type)

--- a/app/helpers/volume_mapping_helper.rb
+++ b/app/helpers/volume_mapping_helper.rb
@@ -1,3 +1,3 @@
 module VolumeMappingHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/workflow_credential_helper.rb
+++ b/app/helpers/workflow_credential_helper.rb
@@ -1,3 +1,3 @@
 module WorkflowCredentialHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/workflow_helper.rb
+++ b/app/helpers/workflow_helper.rb
@@ -1,3 +1,3 @@
 module WorkflowHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end

--- a/app/helpers/workflow_repository_helper.rb
+++ b/app/helpers/workflow_repository_helper.rb
@@ -1,3 +1,3 @@
 module WorkflowRepositoryHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
 end


### PR DESCRIPTION
Zeitwerk completely removes the need for these methods. See also: https://github.com/ManageIQ/manageiq/pull/22854