### PR TITLE
Fix dashboard missing chart

### DIFF
--- a/app/javascript/components/carbon-charts/groupChart.js
+++ b/app/javascript/components/carbon-charts/groupChart.js
@@ -2,9 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { GroupedBarChart } from '@carbon/charts-react';
 
-const GroupBarChart = ({ data, title }) => {
+const GroupBarChart = ({ data, title, showLegend }) => {
   const options = {
     title,
+    legend: { enabled: showLegend },
     axes: {
       left: {
         mapsTo: 'value',
@@ -30,11 +31,13 @@ const GroupBarChart = ({ data, title }) => {
 GroupBarChart.propTypes = {
   data: PropTypes.arrayOf(PropTypes.any),
   title: PropTypes.string,
+  showLegend: PropTypes.bool,
 };
 
 GroupBarChart.defaultProps = {
   data: null,
   title: '',
+  showLegend: true,
 };
 
 export default GroupBarChart;

--- a/app/javascript/components/carbon-charts/helpers.js
+++ b/app/javascript/components/carbon-charts/helpers.js
@@ -87,7 +87,7 @@ export const pieData = [{
 
 // convert report data to carbon chart data format.
 export const getConvertedData = (data) => {
-  if (data && data.data.columns && data.data && data.miq && data.miq.category_table && data.miq.name_table) {
+  if (data && data.data.columns && data.data && data.miq && data.miq.category_table) {
     const columnsData = data.data.columns;
     const dataGroups = data.miq.category_table;
     const rowsData = data.miq.name_table;
@@ -98,7 +98,11 @@ export const getConvertedData = (data) => {
           const obj = {};
           if (i !== 0 && rowsData[items[0]]) {
             obj.group = rowsData[items[0]];
-            obj.key = dataGroups[i - 1];
+            if (dataGroups && typeof dataGroups[i - 1] === 'number') {
+              obj.key = dataGroups[i - 1].toString();
+            } else if (dataGroups) {
+              obj.key = dataGroups[i - 1];
+            }
             obj.value = item;
             arr.push(obj);
           }

--- a/app/javascript/components/dashboard-widgets/dashboard-charts/index.jsx
+++ b/app/javascript/components/dashboard-widgets/dashboard-charts/index.jsx
@@ -10,6 +10,19 @@ import EmptyChart from './emptyChart';
 // eslint-disable-next-line no-unused-vars
 const DashboardWidget = ({ data, id, title }) => {
   const convertedData = getConvertedData(data);
+  let showLegend = true;
+  const nameTable = data.miq.name_table;
+  if (convertedData.length > 0 && data.miq) {
+    if (!nameTable) {
+      showLegend = false;
+    } else {
+      const keys = Object.keys(nameTable);
+      if (keys.length === 1 && nameTable[keys[0]] === 'Unknown') {
+        showLegend = false;
+      }
+    }
+  }
+
   if (convertedData.length > 0) {
     if (data.miqChart === 'Area') {
       return (<AreaChartGraph data={convertedData} title={title} />);
@@ -33,7 +46,7 @@ const DashboardWidget = ({ data, id, title }) => {
       return (<StackBarChartGraph data={convertedData} title={title} />);
     }
     if ((data.miqChart === 'StackedColumn' || data.miqChart === 'Column') && !data.data.groups) {
-      return (<GroupBarChart data={convertedData} title={title} />);
+      return (<GroupBarChart data={convertedData} title={title} showLegend={showLegend} />);
     }
     return (<StackBarChartGraph data={convertedData} title={title} />);
   }


### PR DESCRIPTION
Depends on: https://github.com/ManageIQ/manageiq/pull/22872

Fixes a bug where the number of nodes per CPU cores chart won't render despite data being contained in the report.

Before:
<img width="707" alt="Screenshot 2024-02-01 at 12 41 06 PM" src="https://github.com/ManageIQ/manageiq/assets/32444791/1317a873-e031-4e85-93a2-fec1d26adf5b">

After:
<img width="714" alt="Screenshot 2024-02-01 at 12 35 26 PM" src="https://github.com/ManageIQ/manageiq/assets/32444791/3f41d59d-ae38-4fcc-aeb3-fb47fc608349">
