### PR TITLE
Disable ip address fields when dhcp is selected

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -38,6 +38,12 @@ module ApplicationController::MiqRequestMethods
 
       all_dialogs = @edit[:wf].get_all_dialogs rescue []
 
+      if @edit[:new] && @edit[:new][:addr_mode] && @edit[:new][:addr_mode][0] == "dhcp"
+        all_dialogs[:customize][:fields][:hostname][:read_only] = true
+        all_dialogs[:customize][:fields][:subnet_mask][:read_only] = true
+        all_dialogs[:customize][:fields][:gateway][:read_only] = true
+      end
+
       render :update do |page|
         page << javascript_prologue
         # Going thru all dialogs to see if model has set any of the dialog display to hide/ignore


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/9064

When DHCP is selected on the provision form for the IP Address Mode the IP Address Information fields should be disabled.

Before:
<img width="1408" alt="Screenshot 2024-02-05 at 10 16 05 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/24d6e025-2098-45f3-a70e-536e9921c9c7">

After:
<img width="1414" alt="Screenshot 2024-02-05 at 10 17 02 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/24fe895c-e907-4d7d-b624-f3b94a64a6d9">
