### PR TITLE
fix hostname error

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -38,8 +38,9 @@ module ApplicationController::MiqRequestMethods
 
       all_dialogs = @edit[:wf].get_all_dialogs rescue []
 
-      if @edit[:new] && @edit[:new][:addr_mode] && @edit[:new][:addr_mode][0] == "dhcp"
-        all_dialogs[:customize][:fields][:hostname][:read_only] = true
+      if @edit[:new] && @edit[:new][:addr_mode] && @edit[:new][:addr_mode][0] == "dhcp" && all_dialogs[:customize]
+        all_dialogs[:customize][:fields][:hostname]&.[]=(:read_only, true)
+        all_dialogs[:customize][:fields][:linux_host_name]&.[]=(:read_only, true)
         all_dialogs[:customize][:fields][:subnet_mask][:read_only] = true
         all_dialogs[:customize][:fields][:gateway][:read_only] = true
       end


### PR DESCRIPTION
this fixes an issue with:
- https://github.com/ManageIQ/manageiq-ui-classic/pull/9063

Reproducer:

- http://localhost:3000/vm_infra/explorer#/
- choose a vm
- Lifecycle > clone a vm

Not sure if this needs to handle `hostname` and/or `linux_host_name` or the name was wrong.


It calls URL http://localhost:3000/vm_infra/prov_field_changed/new

```
Data undefined method `[]=' for nil:NilClass [vm_infra/prov_field_changed]

manageiq-ui-classic/app/controllers/application_controller/miq_request_methods.rb:42:in `prov_field_changed'
```

It also causes another issue on other pages:

```
all_dialogs[:customize][:fields][:hostname][:read_only] = true
                                           ^^^^^^^^^^^^^^

manageiq-ui-classic/app/controllers/application_controller/miq_request_methods.rb:42:in `prov_field_changed'
```

