### PR TITLE
Fix debug toast wrapper style

### DIFF
--- a/app/javascript/oldjs/miq_debug.css
+++ b/app/javascript/oldjs/miq_debug.css
@@ -2,9 +2,10 @@
   position: fixed;
   top: 20px;
   right: 20px;
-  left: 66%;
   z-index: 10000;
   width: calc(34% - 20px);
   max-height: calc(100% - 40px);
   overflow-y: auto;
+  max-width: 50%;
+  min-width: 30%;
 }


### PR DESCRIPTION
**Before**
A portion of the debug toast notification is hidden on the right end
<img width="1660" alt="Screenshot 2024-02-13 at 10 47 25 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/620b20c4-0651-42d0-8a5f-adee02e95dbb">

**After**
<img width="1787" alt="Screenshot 2024-02-13 at 10 48 22 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/51796403-a159-4a74-b57c-03246ad32d77">


Note: Maybe we can move this component to a react carbon component (Toast notification)
