### PR TITLE
Added Redirects to Pods Table in Container Projects

### DIFF
--- a/app/javascript/components/container-projects/helper.jsx
+++ b/app/javascript/components/container-projects/helper.jsx
@@ -402,10 +402,15 @@ export const getQuotasChart = (isLoading, dashboardData) => {
 export const getPodsTable = (isLoading, dashboardData) => {
   if (isLoading !== true) {
     if (dashboardData.data.pods.length > 0) {
-      const rows = [];
-      dashboardData.data.pods.forEach((row) => {
-        rows.push({ ...row, id: `${Math.random()}` });
-      });
+      const rows = dashboardData.data.pods.map((row) => ({
+        ...row,
+        id: `${row.id}`,
+        name: {
+          is_link: true,
+          href: `/container_group/show/${row.id}/`,
+          text: row.name,
+        },
+      }));
       const headers = [
         { key: 'name', header: __('Name') },
         { key: 'phase', header: __('Status') },

--- a/app/javascript/components/miq-data-table/miq-table-cell.jsx
+++ b/app/javascript/components/miq-data-table/miq-table-cell.jsx
@@ -171,7 +171,7 @@ const MiqTableCell = ({
   const cellLink = (item, _id) => (
     <div className={cellClass}>
       <Link href={item.href}>
-        {item.label}
+        {truncateText}
       </Link>
     </div>
   );

--- a/app/services/container_project_dashboard_service.rb
+++ b/app/services/container_project_dashboard_service.rb
@@ -67,6 +67,7 @@ class ContainerProjectDashboardService < DashboardService
   def pods
     @project.container_groups.collect do |pod|
       {
+        :id                         => pod.id,
         :name                       => pod.name,
         :phase                      => pod.phase,
         :running_containers_summary => pod.running_containers_summary,

--- a/app/stylesheet/cloud-container-projects-dashboard.scss
+++ b/app/stylesheet/cloud-container-projects-dashboard.scss
@@ -72,6 +72,7 @@
     margin-bottom: 25px;
     margin-left: 10px;
     margin-right: 10px;
+    overflow: auto;
 
     thead,
     tbody {


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/9066

Adds a redirect to the Pods table in Container Projects that takes the user to a pod's summary page when that pod is clicked in the table. Also added in a small css change that makes it so the table won't go off of the page and instead becomes scrollable inside of it's card/box.

Before:
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/11a72c49-e90d-4c47-bd3d-b45c99f46277)

After:

https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/12b351ee-a900-443d-bfc2-db632f7fc01f


