### PR TITLE
Fix typo in comments for ansible-playbook catalog form

### DIFF
--- a/app/javascript/components/ansible-playbook-edit-catalog-form/helper.js
+++ b/app/javascript/components/ansible-playbook-edit-catalog-form/helper.js
@@ -5,13 +5,13 @@ import { TrashCan32 } from '@carbon/icons-react';
 import PropTypes from 'prop-types';
 import { TreeViewRedux } from '../tree-view';
 
-/** Helper function to convert object into array used for extra vars restrcutring */
+/** Helper function to convert object into array used for extra vars restructuring */
 const convertObject = (inputObj) => {
   const outputArray = Object.entries(inputObj).map(([key, value]) => ({ key, value: value.default }));
   return outputArray;
 };
 
-/** Helper function used for restructing extra vars */
+/** Helper function used for restructuring extra vars */
 const refactorExtraVars = (catalogData) => {
   if (Object.prototype.hasOwnProperty.call(catalogData.config_info.provision, 'extra_vars')) {
     catalogData.config_info.provision.extra_vars = convertObject(catalogData.config_info.provision.extra_vars);
@@ -22,7 +22,7 @@ const refactorExtraVars = (catalogData) => {
   return catalogData;
 };
 
-/** Helper function to convert array into object used for extra vars restrcutring */
+/** Helper function to convert array into object used for extra vars restructuring */
 const convertArrayToObject = (arr) => arr.reduce((acc, curr) => {
   acc[curr.key] = { default: curr.value };
   return acc;
@@ -78,7 +78,7 @@ export const formCloudTypes = (data) => {
   return getSortedHash(cloudTypes);
 };
 
-/** Helper function to append tenat infront of catalog name */
+/** Helper function to append tenant in front of catalog name */
 const formOptsCatalogTenants = (catalogs) => catalogs.map((catalog) => ({
   name: catalog[0],
   id: catalog[1].toString(),
@@ -110,7 +110,7 @@ export const CopyFromProvisonButton = (props) => {
   );
 };
 
-/** conditional checkbox mapper component to render esclation privelage field */
+/** conditional checkbox mapper component to render escalation privilege field */
 export const conditionalCheckbox = (props) => {
   const {
     input, label, id, display,
@@ -214,7 +214,7 @@ export const KeyValueListComponent = (props) => {
 export const prepareRequestObject = (values, formId) => {
   const requestObject = { ...values };
 
-  // if price property is not there add price property if its present convert the valye into string
+  // if price property is not there add price property if its present convert the value into string
   if (!Object.prototype.hasOwnProperty.call(requestObject, 'price')) {
     requestObject.price = '';
   } else {
@@ -244,7 +244,7 @@ export const prepareRequestObject = (values, formId) => {
   delete requestObject.config_info.provision.specify_host_type;
   delete requestObject.config_info.retirement.specify_host_type;
 
-  // restructing the extra_vars to convert it from array to object with key value pairs
+  // restructuring the extra_vars to convert it from array to object with key value pairs
   if (requestObject.config_info.provision.extra_vars) {
     requestObject.config_info.provision.extra_vars = convertArrayToObject(requestObject.config_info.provision.extra_vars);
   }
@@ -273,7 +273,7 @@ export const prepareRequestObject = (values, formId) => {
   return requestObject;
 };
 
-/** Helper function to prepare the restruture data to show fields in DDF form */
+/** Helper function to prepare the restructure data to show fields in DDF form */
 export const restructureCatalogData = function(catalogData, provisionCloudType, retirementCloudType) {
   let restructuredCatalogData = { ...catalogData };
 
@@ -307,7 +307,7 @@ export const restructureCatalogData = function(catalogData, provisionCloudType, 
   restructuredCatalogData.config_info.provision.cloud_type = provisionCloudType;
   restructuredCatalogData.config_info.retirement.cloud_type = retirementCloudType;
 
-  // refactor the extra vars field for provision and retirment
+  // refactor the extra vars field for provision and retirement
   restructuredCatalogData = refactorExtraVars(restructuredCatalogData);
 
   // add config_info.retirement.remove_resources_with_no_repistory_id if repiostry_id is empty


### PR DESCRIPTION
Fix typo in comments for the functions in ansible-playbook catalog form

<img width="1341" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/ce3f9d32-43d2-473b-987d-d2cd8abe203e">
<img width="1335" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/85b60b50-32bb-48f7-95e7-d23ea63475d0">
<img width="1337" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/dd836d57-573d-4b28-a0d8-acea2ca4f292">
<img width="1338" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/603a3cf9-159f-45f8-8549-a22f78310ab2">
<img width="1337" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/a161aa85-4b1d-4b9c-8f65-aacbc314727c">
<img width="1338" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/aeeeaadb-eace-4b48-bb25-1912ef55484a">
<img width="1337" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/e350c6cd-60b6-4bd7-85a3-15eaacc92c3d">
<img width="1335" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/e7687efa-b52e-49be-a0d5-7349e9460302">
<img width="1336" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/cbd60967-b0dc-4447-b65c-16f48c270c82">
