### PR TITLE
Fixed Empty Applied Tag Section in Control Actions Summary Page

### DIFF
--- a/app/helpers/miq_action_helper.rb
+++ b/app/helpers/miq_action_helper.rb
@@ -123,7 +123,10 @@ module MiqActionHelper
       rows.push({:cells => {:label => _("Categories"), :value => cats}})
     end
 
-    miq_structured_list(data) if !data[:title].empty?
+    if !data[:title].empty?
+      data[:rows] = rows
+      miq_structured_list(data)
+    end
   end
 
   def miq_summary_action_policies(action_policies)


### PR DESCRIPTION
The tag data for the Control Actions summary page is formatted by `miq_summary_action_type` in `app/helpers/miq_action_helper.rb`, but never actually sent to the `MiqStructuredList` component. This change fixes that by adding the missing `data[:rows] = rows` line found in the other helper functions.

Before:
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/d19a9bc4-8ead-4e94-a777-ef8af8fd9f04)

After:
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/429a19d6-5b49-4ff7-b603-e34dd8860e29)
