### PR TITLE
Fixed cypress readme and comments

### DIFF
--- a/cypress/README.md
+++ b/cypress/README.md
@@ -27,54 +27,40 @@ Actual tests can be found in `cypress/integration/ui/`.
 
 ManageIQ implements the following cypress extensions:
 
+#### Commands
+
 ##### explorer
 
-* `cy.accordion(title)` - open an accordion panel. title: String for the accordion title for the accordion panel to open.
-* `cy.accordionItem(name)` - click on a record in the accordion panel. name: String for the record to click in the accordion panel.
+* `cy.accordion(title)` - open an accordion panel. `title`: String for the accordion title for the accordion panel to open.
+* `cy.accordionItem(name)` - click on a record in the accordion panel. `name`: String for the record to click in the accordion panel.
+
+##### gtl
+
+* `cy.gtl_error()` - check that error message is present.
+* `cy.gtl_no_record()` - check that `No Record` message is present.
+* `cy.gtlGetTable()` - returns GTL table.
+* `cy.gtlGetRows(columns)` - return GTL table row data in an array. `columns`: Array of 0-based indexes of the columns to read (e.g. [1, 2, 3] will return all row data from columns 1, 2, and 3).
+* `cy.gtlClickRow(columns)` - click on a row in a GTL table. `columns`: Array of `{ title: String, number: Integer }`. `title` is the string you want to find in the table to click on, `number` is the column that string is found in. (e.g. `[{title: 'Default', number: 1}, {title: 'Compute', number: 2}]` will click on a row in the GTL table with `Default` in column 1 and `Compute` in column 2. Using just `[{title: 'Default', number: 1}]` will click on the first row found in the GTL table with `Default` in column 1).
 
 ##### login
 
-`cy.login()` - logs in as admin
+* `cy.login(user = admin, password = smartvm)` - log in to ManageIQ with the provided username and password. `user`: String for the user account to log in to, default is `admin`. `password`: String for the user account password to log in with, default is `smartvm`.
 
-##### navigation
+##### menu
 
-* `cy.menu('Compute', 'Infrastructure', 'VMs')` - navigates the main menu
-* `cy.accordion('Service Dialogs')` - expand accordion
-* TODO `cy.treeSelect('All VMs & Templates', 'HyperV', 'SCVMM')` - switch tree items
-* `cy.toolbar('Configuration', 'Edit this VM')` - trigger toolbar buttons
-* TODO `cy.tab('Report Info')` - switch miq tabs
+* `cy.menu('primaryMenu', 'secondaryMenu', 'tertiaryMenu')` - navigates the side bar menu items. `primaryMenu`: String for the outer menu item on the side bar. `secondaryMenu`: String for the secondary menu when a side bar menu item is clicked. `tertiaryMenu`: String (optional) for the tertiary menu when a side bar secondary item is clicked. (e.g. `cy.menu('Overview', 'Dashboard')` will navigate to the Overview > Dashboard page while `cy.menu('Overview', 'Chargeback', 'Rates')` will navigate to the Overview > Chargeback > Rates page).
+* `cy.menuItems()` - returns an Array of `{ title: String, items: Array of { title: String, href: String, items: Array of { title: String, href: String } }}` for the menu items on the side bar. `title`: String for the menu item title. `href`: String for the url to navigate to, included when the menu item has no children. `items`: Array of the same object with `title` and `href`/`items`, this is included when the menu item has children menu items.
 
-TODO allow using {id:...} instead of string label for menu items, gtl items, tree nodes, accordions, toolbar items
-
-##### inspection
-
-* `cy.menuItems()` - parse the main menu and yield an object tree
-* `cy.toolbarItem(...)` - yields an object describing a toolbar button state, or null
-
-#### assertions
-
-* `cy.expect_explorer_title('Active Services')` - check the title on an explorer screen
-* `cy.expect_show_list_title('Cloud Providers')` - check the title on a show\_list screen
-* `cy.expect_search_box()` - check if searchbox is present on screen
-* `cy.expect_no_search_box()` - check if no searchbox is present on the screen
-* `cy.expect_rates_table(headers, rows)` - check the values in a chargeback rate table. `headers`: Array of strings representing the headers of the table. `rows`: Array of type `[String, [...String], [...String], [...String], [...String], String]` where each index of the array represents a column in the table. The arrays within the `rows` array can be any length and represent the values in each given column, e.g. an array of `[0.0, 100.0]` in the index for the `Range Start` column would verify that the column contains two range starts with values `0.0` and `100.0`.
-* TODO `cy.expect_layout('miq-layout-center_div_with_listnav')` - check current layout
-
-#### GTL
-
-* `cy.gtl_error` - check that error message is present
-* `cy.gtl_no_record` - check that `No data` message is present
-* `cy.gtlGetTable` - return GTL table
-* `cy.gtlGetRows(columns)` - return GTL table row data in an array. columns: Array of 0-based indexes of the columns to read (e.g. [1, 2, 3] will return all row data from columns 1, 2, and 3)
-* `cy.gtlClickRow(columns)` - click on a row in a GTL table. columns: Array of `{ title: String, number: Integer }`. `title` is the string you want to find in the table to click on, `number` is the column that string is found in. (e.g. `[{title: 'Default', number: 1}, {title: 'Compute', number: 2}]` will click on a row in the GTL table with 'Default' in column 1 and 'Compute' in column 2. Using just `[{title: 'Default', number: 1}]` will click on the first row found in the GTL table with 'Default' in column 1).
-
-#### searchbox
-
-* `cy.search_box()` - check that searchbox is present 
-* `cy.no_search_box()` - check that searchbox is not present
-
-##### Toolbar
+##### toolbar
 
 * `cy.toolbarItems(toolbarButton)` - returns an array of objects {text: String, disabled: Boolean} for the toolbar dropdown buttons for when a toolbar button is clicked. `toolbarButton` is the string for the text of the toolbar button that you want to click on.
-* `cy.toolbar(toolbarButton, dropdownButton)` - click on the toolbar button specified by the user. Can also then click on a specified dropdown button as well. `toolbarButton` is the string for the text of the toolbar button that you want to click on. `dropdownButton` is the string for the text of the toolbar dropdown button that you want to click on. 
-  
+* `cy.toolbar(toolbarButton, dropdownButton)` - click on the toolbar button specified by the user. Can also then click on a specified dropdown button as well. `toolbarButton` is the string for the text of the toolbar button that you want to click on. `dropdownButton` is the string for the text of the toolbar dropdown button that you want to click on. s
+
+#### Assertions
+
+* `cy.expect_explorer_title(title)` - check that the title on an explorer screen matches the provided title. `title`: String for the title.
+* `cy.expect_no_search_box()` - check if no searchbox is present on the screen.
+* `cy.expect_rates_table(headers, rows)` - check the values in a chargeback rate table. `headers`: Array of strings representing the headers of the table. `rows`: Array of type `[String, [...String], [...String], [...String], [...String], String]` where each index of the array represents a column in the table. The arrays within the `rows` array can be any length and represent the values in each given column, e.g. an array of `[0.0, 100.0]` in the index for the `Range Start` column would verify that the column contains two range starts with values `0.0` and `100.0`.
+* `cy.expect_show_list_title(title)` - check the title on a show\_list screen matches the provided title. `title`: String for the title.
+* `cy.expect_search_box()` - check if searchbox is present on the screen.
+* `cy.expect_text(element, text)` - check if the text in the element found by doing cy.get on the element String matches the provided text. `element`: String for the Cypress selector to get a specific element on the screen. `text`: String for the text that should be found within the selected element.

--- a/cypress/support/assertions/expect_rates_table.js
+++ b/cypress/support/assertions/expect_rates_table.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-undef */
 
+// headers: Array of strings of length 7 for the chargeback rates table headers to check.
+// rows: Array of form: [String, [...String], [...String], [...String], [...String], [...String], String]. This is the row data you want to check.
 Cypress.Commands.add('expect_rates_table', (headers, rows) => {
   // Verify header titles
   cy.get('thead > tr > :nth-child(1)').contains(headers[0]);

--- a/cypress/support/assertions/expect_text.js
+++ b/cypress/support/assertions/expect_text.js
@@ -1,4 +1,7 @@
 /* eslint-disable no-undef */
+
+// element: String for the Cypress selector to get a specific element on the screen.
+// text: String for the text that should be found within the selected element.
 Cypress.Commands.add('expect_text', (element, text) => {
   cy.get(element).then((value) => {
     expect(value[0].innerText).to.eq(text);

--- a/cypress/support/assertions/expect_title.js
+++ b/cypress/support/assertions/expect_title.js
@@ -1,8 +1,11 @@
 /* eslint-disable no-undef */
+
+// text: String for the text that should be found within an explorer page title.
 Cypress.Commands.add('expect_explorer_title', (text) => {
   return cy.get('#explorer_title_text').contains(text);
 });
 
+// text: String for the text that should be found within the show_list page title
 Cypress.Commands.add('expect_show_list_title', (text) => {
   return cy.get('#main-content h1').contains(text);
 });

--- a/cypress/support/commands/explorer.js
+++ b/cypress/support/commands/explorer.js
@@ -1,10 +1,11 @@
 /* eslint-disable no-undef */
+
 // title: String of the accordion title for the accordian panel to open.
-Cypress.Commands.add('accordion', (text) => {
+Cypress.Commands.add('accordion', (title) => {
   cy.get('#main-content'); // ensure screen loads first
   let ret = cy.get('#accordion')
     .find('.panel-title a')
-    .contains(new RegExp(`^${text}$`));
+    .contains(new RegExp(`^${title}$`));
 
   ret.then((el) => {
     // Do not collapse if already expanded
@@ -17,7 +18,7 @@ Cypress.Commands.add('accordion', (text) => {
   return ret.parents('.panel');
 });
 
-// name: String of the record in the accordion panel to click
+// name: String of the record in the accordion panel to click.
 Cypress.Commands.add('accordionItem', (name) => {
   cy.get('#main-content'); // ensure screen loads first
 

--- a/cypress/support/commands/gtl.js
+++ b/cypress/support/commands/gtl.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-// GTL related helpers
+
 Cypress.Commands.add('gtl_error', () => {
   return cy.get('#miq-gtl-view > #flash_msg_div').should('be.visible');
 });
@@ -12,7 +12,7 @@ Cypress.Commands.add('gtlGetTable', () => {
   return cy.get('#miq-gtl-view > .miq-data-table > .miq-data-table > .bx--data-table-content > table');
 });
 
-// columns: Array of 0-based indexes of the columns to read (e.g. [1, 2, 3] will return all row data from columns 1, 2, and 3)
+// columns: Array of 0-based indexes of the columns to read (e.g. [1, 2, 3] will return all row data from columns 1, 2, and 3).
 Cypress.Commands.add('gtlGetRows', (columns) => {
   const rowsData = [];
   cy.gtlGetTable().get('tr.clickable-row').then((rows) => {

--- a/cypress/support/commands/login.js
+++ b/cypress/support/commands/login.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
-// cy.login() - log in
-// FIXME: use cy.request and inject cookie and localStorage.miqToken
+
+// user: String of username to log in with, default is admin.
+// password: String of password to log in with, default is smartvm.
 Cypress.Commands.add('login', (user = 'admin', password = 'smartvm') => {
   cy.visit('/');
 

--- a/cypress/support/commands/menu.js
+++ b/cypress/support/commands/menu.js
@@ -3,7 +3,7 @@
 const primary = '#main-menu nav.primary';
 const secondary = 'div[role="presentation"] > .bx--side-nav__items';
 
-// cy.menu('Compute', 'Infrastructure', 'VMs') - navigate the main menu
+// items: Strings with at least 2 to a maximum of 3. These are the strings for the side bar menu names to click.
 Cypress.Commands.add('menu', (...items) => {
   expect(items.length).to.be.within(1, 3);
   let ret = cy.get(`${primary} > ul > li`)
@@ -39,7 +39,6 @@ Cypress.Commands.add('menu', (...items) => {
   return ret;
 });
 
-// cy.menuItems() - returns an array of top level menu items with {title, href, items (array of children)}
 Cypress.Commands.add('menuItems', () => {
   const menuItems = [];
   cy.get(`${primary} > ul > li`).each(($li) => {


### PR DESCRIPTION
Cleaned up the Cypress Readme file documentation for the commands and assertions. Also cleaned up the comments for the command and assertion files to specify the required parameters for each function.