### PR TITLE
convert ServiceTemplate.orderable? to supports?(:order)

### DIFF
--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -174,7 +174,7 @@ class OrchestrationStackController < ApplicationController
   def make_ot_orderable
     stack = find_record_with_rbac(OrchestrationStack, params[:id])
     template = stack.orchestration_template
-    if template.orderable?
+    if template.supports?(:order)
       add_flash(_("Orchestration template \"%{name}\" is already orderable") % {:name => template.name}, :error)
       render_flash
     else
@@ -198,7 +198,7 @@ class OrchestrationStackController < ApplicationController
 
   def orchestration_template_copy
     @record = find_record_with_rbac(OrchestrationStack, params[:id])
-    if @record.orchestration_template.orderable?
+    if @record.orchestration_template.supports?(:order)
       add_flash(_("Orchestration template \"%{name}\" is already orderable") %
         {:name => @record.orchestration_template.name}, :error)
       render_flash

--- a/app/helpers/application_helper/button/orchestration_template_orderable.rb
+++ b/app/helpers/application_helper/button/orchestration_template_orderable.rb
@@ -1,6 +1,6 @@
 class ApplicationHelper::Button::OrchestrationTemplateOrderable < ApplicationHelper::Button::Basic
   def disabled?
-    @error_message = _('This Template is already orderable') if @record.orchestration_template.orderable?
+    @error_message = _('This Template is already orderable') if @record.orchestration_template.supports?(:order)
     @error_message.present?
   end
 end

--- a/app/helpers/application_helper/button/orchestration_template_view_in_catalog.rb
+++ b/app/helpers/application_helper/button/orchestration_template_view_in_catalog.rb
@@ -1,6 +1,6 @@
 class ApplicationHelper::Button::OrchestrationTemplateViewInCatalog < ApplicationHelper::Button::Basic
   def disabled?
-    @error_message = _('This Template is not orderable') unless @record.orchestration_template.orderable?
+    @error_message = _('This Template is not orderable') unless @record.orchestration_template.supports?(:order)
     @error_message.present?
   end
 end

--- a/app/views/orchestration_stack/_stack_orchestration_template.html.haml
+++ b/app/views/orchestration_stack/_stack_orchestration_template.html.haml
@@ -18,8 +18,10 @@
             = label
           %td
             - case sym
-            - when :draft, :orderable?
-              = @record.orchestration_template.send(sym) ? _("True") : _("False")
+            - when :draft
+              = @record.orchestration_template.draft ? _("True") : _("False")
+            - when :orderable?
+              = @record.orchestration_template.supports?(:order) ? _("True") : _("False")
             - when :read_only
               = @record.orchestration_template.in_use? ? _("True") : _("False")
             - else

--- a/spec/controllers/orchestration_stack_controller_spec.rb
+++ b/spec/controllers/orchestration_stack_controller_spec.rb
@@ -119,7 +119,7 @@ describe OrchestrationStackController do
       it "won't allow making stack's orchestration template orderable when already orderable" do
         record = FactoryBot.create(:orchestration_stack_cloud_with_template)
         post :button, :params => {:id => record.id, :pressed => "make_ot_orderable"}
-        expect(record.orchestration_template.orderable?).to be_truthy
+        expect(record.orchestration_template.supports?(:order)).to be_truthy
         expect(response.status).to eq(200)
         expect(response).to render_template(:partial => "layouts/_flash_msg")
         expect(assigns(:flash_array).first[:message]).to include('is already orderable')
@@ -128,7 +128,7 @@ describe OrchestrationStackController do
       it "makes stack's orchestration template orderable" do
         record = FactoryBot.create(:orchestration_stack_cloud, :orchestration_template => non_orderable_template)
         post :button, :params => {:id => record.id, :pressed => "make_ot_orderable"}
-        expect(record.orchestration_template.orderable?).to be_falsey
+        expect(record.orchestration_template.supports?(:order)).to be_falsey
         expect(response.status).to eq(200)
         expect(response).to render_template(:partial => "layouts/_flash_msg")
         expect(assigns(:flash_array).first[:message]).to include('is now orderable')
@@ -139,7 +139,7 @@ describe OrchestrationStackController do
       it "won't allow copying stack's orchestration template orderable when already orderable" do
         record = FactoryBot.create(:orchestration_stack_cloud_with_template)
         post :button, :params => {:id => record.id, :pressed => "orchestration_template_copy"}
-        expect(record.orchestration_template.orderable?).to be_truthy
+        expect(record.orchestration_template.supports?(:order)).to be_truthy
         expect(response.status).to eq(200)
         expect(response).to render_template(:partial => "layouts/_flash_msg")
         expect(assigns(:flash_array).first[:message]).to include('is already orderable')
@@ -148,7 +148,7 @@ describe OrchestrationStackController do
       it "renders orchestration template copying form" do
         record = FactoryBot.create(:orchestration_stack_cloud, :orchestration_template => non_orderable_template)
         post :button, :params => {:id => record.id, :pressed => "orchestration_template_copy"}
-        expect(record.orchestration_template.orderable?).to be_falsey
+        expect(record.orchestration_template.supports?(:order)).to be_falsey
         expect(response.status).to eq(200)
         expect(response).to render_template(:partial => "orchestration_stack/_copy_orchestration_template")
       end


### PR DESCRIPTION
Part of bigger:
- https://github.com/ManageIQ/manageiq/issues/21989

depends upon:
- [x] https://github.com/ManageIQ/manageiq/pull/22902
 
# Overview

This is the second attempt at #9071 

Now that ServiceTemplates and ServiceOrders both offer `supports :order`, dropping `orderable?` and using the standard `supports`.

