### PR TITLE
Add searchbar for actions page

### DIFF
--- a/app/controllers/miq_action_controller.rb
+++ b/app/controllers/miq_action_controller.rb
@@ -19,6 +19,10 @@ class MiqActionController < ApplicationController
     miq_action_reset_or_set
   end
 
+  def show_searchbar?
+    true
+  end
+
   def edit
     @_params[:pressed] ||= 'miq_action_edit'
     case params[:button]


### PR DESCRIPTION
Add a search bar for the actions page.

Before:
<img width="1403" alt="Screenshot 2024-02-20 at 9 39 10 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/c3415182-2b09-45fb-953d-81c99cc8b3c1">

After:
<img width="1415" alt="Screenshot 2024-02-20 at 9 39 35 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/9a630740-46f8-460e-86ff-08332a5c0dba">
<img width="1422" alt="Screenshot 2024-02-20 at 9 39 28 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/6f8ee3e8-48ee-4263-acbb-be2113590fa5">

