### PR TITLE
Fixed Incorrect Values Being Displayed When Editing Action

### DIFF
--- a/app/javascript/components/action-form/helper.js
+++ b/app/javascript/components/action-form/helper.js
@@ -102,7 +102,7 @@ const constructAeHash = (aeHashPairs) => {
   const options = [];
   const aeHashAttribute = Object.keys(aeHashPairs);
   aeHashAttribute.forEach((pt) => {
-    const tempObj = { attribute: pt, value: Object.values(aeHashPairs)[0] };
+    const tempObj = { attribute: pt, value: aeHashPairs[pt] };
     options.push(tempObj);
   });
   return options;


### PR DESCRIPTION
Currently there's an issue when editing an Action with it's action type set to `Invoke a Custom Automation` where all attribute/value pairs are displayed as having the same value despite this not being the case. This change corrects that.

Before:
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/031e4b53-901c-48b3-a71f-0d3ff1190c6f)

After:
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/8f38f77d-c8a3-49d9-a7a0-58af4ea7bc48)
