### PR TITLE
Fix styles for control action summary and form pages

### DIFF
--- a/app/controllers/miq_action_controller.rb
+++ b/app/controllers/miq_action_controller.rb
@@ -384,7 +384,7 @@ class MiqActionController < ApplicationController
   end
 
   def get_session_data
-    @action = MiqAction.find_by(:id => params[:miq_grid_checks])
+    @action = MiqAction.find_by(:id => params[:id] || params[:miq_grid_checks])
     @title = if @action.present?
                _("Editing Action \"%{name}\"") % {:name => @action.description}
              else

--- a/app/helpers/miq_action_helper.rb
+++ b/app/helpers/miq_action_helper.rb
@@ -1,4 +1,15 @@
 module MiqActionHelper
+  def control_action_summary(record, alert_guids, cats, action_policies)
+    safe_join([
+                miq_summary_action_info(record),
+                miq_summary_action_type(record, alert_guids, cats),
+                miq_summary_attribute_value_pair(record),
+                miq_summary_action_policies(action_policies)
+              ])
+  end
+
+  private
+
   def miq_summary_action_info(record)
     data = {:title => _("Basic Information"), :mode => "miq_action_info"}
     rows = []
@@ -24,17 +35,6 @@ module MiqActionHelper
       rows.push({:cells => {:label => _('Object Details')}})
       rows.push({:cells => {:label => _('Starting Message'), :value => record_options[:ae_message]}})
       rows.push({:cells => {:label => _('Request'), :value => record_options[:ae_request]}})
-
-      value_pair = []
-      if record_options[:ae_hash].present?
-        record_options[:ae_hash].each do |k, v|
-          value_pair.push({:label => k})
-          value_pair.push({:label => v})
-        end
-      else
-        value_pair.push({:label => _('No Attribute/Value Pairs found')})
-      end
-      rows.push({:cells => {:label => _('Attribute/Value Pairs'), :value => value_pair}})
 
     when "email"
       data[:title] = _('E-mail Settings')
@@ -127,6 +127,21 @@ module MiqActionHelper
       data[:rows] = rows
       miq_structured_list(data)
     end
+  end
+
+  def miq_summary_attribute_value_pair(record)
+    record_options = record.options
+    rows = []
+    if record_options[:ae_hash].present?
+      record_options[:ae_hash].each do |k, v|
+        rows.push({:cells => [{:value => k}, {:value => v}]})
+      end
+    end
+    miq_structured_list(
+      :title => _('Attribute/Value Pairs'),
+      :mode  => "control_action_attribute_value_pairs",
+      :rows  => rows
+    )
   end
 
   def miq_summary_action_policies(action_policies)

--- a/app/javascript/components/action-form/action-form.schema.js
+++ b/app/javascript/components/action-form/action-form.schema.js
@@ -171,6 +171,7 @@ function createSchema(recordId, promise, inheritTags, evaluateAlert, tags, ansib
       id: 'subform-7',
       name: 'subform-7',
       title: __('Attribute/Value Pairs'),
+      className: 'attribute_value_pair_wrapper',
       condition: {
         when: 'action_type',
         is: 'custom_automation',
@@ -190,6 +191,7 @@ function createSchema(recordId, promise, inheritTags, evaluateAlert, tags, ansib
           fields: [
             {
               component: componentTypes.TEXT_FIELD,
+              className: 'attribute_value_field_wrapper',
               name: 'attribute',
               id: 'attribute',
               label: 'attribute',
@@ -198,6 +200,7 @@ function createSchema(recordId, promise, inheritTags, evaluateAlert, tags, ansib
             },
             {
               component: componentTypes.TEXT_FIELD,
+              className: 'attribute_value_field_wrapper',
               name: 'value',
               id: 'value',
               label: 'value',

--- a/app/javascript/components/miq-structured-list/miq-structured-list-body/value-types/miq-structured-list-object.jsx
+++ b/app/javascript/components/miq-structured-list/miq-structured-list-body/value-types/miq-structured-list-object.jsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { StructuredListCell } from 'carbon-components-react';
 import MiqStructuredListConditionalTag from '../value-tags/miq-structured-list-conditional-tag';
 
-/** Usage eg: Automation / Embeded Automate / Generic Objects / item
+/** Usage eg: Automation / Embedded Automate / Generic Objects / item
   * Properties has no links & Relationships have links */
 const MiqStructuredListObject = ({ row, clickEvents, onClick }) => {
   const isContent = row.label || (row.value && row.value.input);

--- a/app/javascript/spec/action-form/__snapshots__/action-form.spec.js.snap
+++ b/app/javascript/spec/action-form/__snapshots__/action-form.spec.js.snap
@@ -387,6 +387,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                   "title": "Custom Automation",
                 },
                 Object {
+                  "className": "attribute_value_pair_wrapper",
                   "component": "sub-form",
                   "condition": Object {
                     "is": "custom_automation",
@@ -404,6 +405,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                       "fieldKey": "field_array",
                       "fields": Array [
                         Object {
+                          "className": "attribute_value_field_wrapper",
                           "component": "text-field",
                           "id": "attribute",
                           "isRequired": true,
@@ -416,6 +418,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                           ],
                         },
                         Object {
+                          "className": "attribute_value_field_wrapper",
                           "component": "text-field",
                           "id": "value",
                           "isRequired": true,
@@ -1089,6 +1092,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                     "title": "Custom Automation",
                   },
                   Object {
+                    "className": "attribute_value_pair_wrapper",
                     "component": "sub-form",
                     "condition": Object {
                       "is": "custom_automation",
@@ -1106,6 +1110,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                         "fieldKey": "field_array",
                         "fields": Array [
                           Object {
+                            "className": "attribute_value_field_wrapper",
                             "component": "text-field",
                             "id": "attribute",
                             "isRequired": true,
@@ -1118,6 +1123,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                             ],
                           },
                           Object {
+                            "className": "attribute_value_field_wrapper",
                             "component": "text-field",
                             "id": "value",
                             "isRequired": true,
@@ -1784,6 +1790,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                       "title": "Custom Automation",
                     },
                     Object {
+                      "className": "attribute_value_pair_wrapper",
                       "component": "sub-form",
                       "condition": Object {
                         "is": "custom_automation",
@@ -1801,6 +1808,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                           "fieldKey": "field_array",
                           "fields": Array [
                             Object {
+                              "className": "attribute_value_field_wrapper",
                               "component": "text-field",
                               "id": "attribute",
                               "isRequired": true,
@@ -1813,6 +1821,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                               ],
                             },
                             Object {
+                              "className": "attribute_value_field_wrapper",
                               "component": "text-field",
                               "id": "value",
                               "isRequired": true,
@@ -2479,6 +2488,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                           "title": "Custom Automation",
                         },
                         Object {
+                          "className": "attribute_value_pair_wrapper",
                           "component": "sub-form",
                           "condition": Object {
                             "is": "custom_automation",
@@ -2496,6 +2506,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                               "fieldKey": "field_array",
                               "fields": Array [
                                 Object {
+                                  "className": "attribute_value_field_wrapper",
                                   "component": "text-field",
                                   "id": "attribute",
                                   "isRequired": true,
@@ -2508,6 +2519,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                   ],
                                 },
                                 Object {
+                                  "className": "attribute_value_field_wrapper",
                                   "component": "text-field",
                                   "id": "value",
                                   "isRequired": true,
@@ -3138,6 +3150,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                           "title": "Custom Automation",
                         },
                         Object {
+                          "className": "attribute_value_pair_wrapper",
                           "component": "sub-form",
                           "condition": Object {
                             "is": "custom_automation",
@@ -3155,6 +3168,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                               "fieldKey": "field_array",
                               "fields": Array [
                                 Object {
+                                  "className": "attribute_value_field_wrapper",
                                   "component": "text-field",
                                   "id": "attribute",
                                   "isRequired": true,
@@ -3167,6 +3181,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                   ],
                                 },
                                 Object {
+                                  "className": "attribute_value_field_wrapper",
                                   "component": "text-field",
                                   "id": "value",
                                   "isRequired": true,
@@ -3808,6 +3823,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                             "title": "Custom Automation",
                           },
                           Object {
+                            "className": "attribute_value_pair_wrapper",
                             "component": "sub-form",
                             "condition": Object {
                               "is": "custom_automation",
@@ -3825,6 +3841,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                 "fieldKey": "field_array",
                                 "fields": Array [
                                   Object {
+                                    "className": "attribute_value_field_wrapper",
                                     "component": "text-field",
                                     "id": "attribute",
                                     "isRequired": true,
@@ -3837,6 +3854,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                     ],
                                   },
                                   Object {
+                                    "className": "attribute_value_field_wrapper",
                                     "component": "text-field",
                                     "id": "value",
                                     "isRequired": true,
@@ -4473,6 +4491,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                             "title": "Custom Automation",
                           },
                           Object {
+                            "className": "attribute_value_pair_wrapper",
                             "component": "sub-form",
                             "condition": Object {
                               "is": "custom_automation",
@@ -4490,6 +4509,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                 "fieldKey": "field_array",
                                 "fields": Array [
                                   Object {
+                                    "className": "attribute_value_field_wrapper",
                                     "component": "text-field",
                                     "id": "attribute",
                                     "isRequired": true,
@@ -4502,6 +4522,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                     ],
                                   },
                                   Object {
+                                    "className": "attribute_value_field_wrapper",
                                     "component": "text-field",
                                     "id": "value",
                                     "isRequired": true,
@@ -5158,6 +5179,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                               "title": "Custom Automation",
                             },
                             Object {
+                              "className": "attribute_value_pair_wrapper",
                               "component": "sub-form",
                               "condition": Object {
                                 "is": "custom_automation",
@@ -5175,6 +5197,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                   "fieldKey": "field_array",
                                   "fields": Array [
                                     Object {
+                                      "className": "attribute_value_field_wrapper",
                                       "component": "text-field",
                                       "id": "attribute",
                                       "isRequired": true,
@@ -5187,6 +5210,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                       ],
                                     },
                                     Object {
+                                      "className": "attribute_value_field_wrapper",
                                       "component": "text-field",
                                       "id": "value",
                                       "isRequired": true,
@@ -5823,6 +5847,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                               "title": "Custom Automation",
                             },
                             Object {
+                              "className": "attribute_value_pair_wrapper",
                               "component": "sub-form",
                               "condition": Object {
                                 "is": "custom_automation",
@@ -5840,6 +5865,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                   "fieldKey": "field_array",
                                   "fields": Array [
                                     Object {
+                                      "className": "attribute_value_field_wrapper",
                                       "component": "text-field",
                                       "id": "attribute",
                                       "isRequired": true,
@@ -5852,6 +5878,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                       ],
                                     },
                                     Object {
+                                      "className": "attribute_value_field_wrapper",
                                       "component": "text-field",
                                       "id": "value",
                                       "isRequired": true,
@@ -6499,6 +6526,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                 "title": "Custom Automation",
                               },
                               Object {
+                                "className": "attribute_value_pair_wrapper",
                                 "component": "sub-form",
                                 "condition": Object {
                                   "is": "custom_automation",
@@ -6516,6 +6544,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                     "fieldKey": "field_array",
                                     "fields": Array [
                                       Object {
+                                        "className": "attribute_value_field_wrapper",
                                         "component": "text-field",
                                         "id": "attribute",
                                         "isRequired": true,
@@ -6528,6 +6557,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                         ],
                                       },
                                       Object {
+                                        "className": "attribute_value_field_wrapper",
                                         "component": "text-field",
                                         "id": "value",
                                         "isRequired": true,
@@ -7152,6 +7182,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                     "title": "Custom Automation",
                                   },
                                   Object {
+                                    "className": "attribute_value_pair_wrapper",
                                     "component": "sub-form",
                                     "condition": Object {
                                       "is": "custom_automation",
@@ -7169,6 +7200,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                         "fieldKey": "field_array",
                                         "fields": Array [
                                           Object {
+                                            "className": "attribute_value_field_wrapper",
                                             "component": "text-field",
                                             "id": "attribute",
                                             "isRequired": true,
@@ -7181,6 +7213,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                             ],
                                           },
                                           Object {
+                                            "className": "attribute_value_field_wrapper",
                                             "component": "text-field",
                                             "id": "value",
                                             "isRequired": true,
@@ -7809,6 +7842,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                       "title": "Custom Automation",
                                     },
                                     Object {
+                                      "className": "attribute_value_pair_wrapper",
                                       "component": "sub-form",
                                       "condition": Object {
                                         "is": "custom_automation",
@@ -7826,6 +7860,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                           "fieldKey": "field_array",
                                           "fields": Array [
                                             Object {
+                                              "className": "attribute_value_field_wrapper",
                                               "component": "text-field",
                                               "id": "attribute",
                                               "isRequired": true,
@@ -7838,6 +7873,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                               ],
                                             },
                                             Object {
+                                              "className": "attribute_value_field_wrapper",
                                               "component": "text-field",
                                               "id": "value",
                                               "isRequired": true,
@@ -10283,6 +10319,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                     </FormConditionWrapper>
                                   </SingleField>
                                   <SingleField
+                                    className="attribute_value_pair_wrapper"
                                     component="sub-form"
                                     condition={
                                       Object {
@@ -10303,6 +10340,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                           "fieldKey": "field_array",
                                           "fields": Array [
                                             Object {
+                                              "className": "attribute_value_field_wrapper",
                                               "component": "text-field",
                                               "id": "attribute",
                                               "isRequired": true,
@@ -10315,6 +10353,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                               ],
                                             },
                                             Object {
+                                              "className": "attribute_value_field_wrapper",
                                               "component": "text-field",
                                               "id": "value",
                                               "isRequired": true,
@@ -10346,6 +10385,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                       }
                                       field={
                                         Object {
+                                          "className": "attribute_value_pair_wrapper",
                                           "component": "sub-form",
                                           "fields": Array [
                                             Object {
@@ -10359,6 +10399,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                               "fieldKey": "field_array",
                                               "fields": Array [
                                                 Object {
+                                                  "className": "attribute_value_field_wrapper",
                                                   "component": "text-field",
                                                   "id": "attribute",
                                                   "isRequired": true,
@@ -10371,6 +10412,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                                   ],
                                                 },
                                                 Object {
+                                                  "className": "attribute_value_field_wrapper",
                                                   "component": "text-field",
                                                   "id": "value",
                                                   "isRequired": true,
@@ -10402,6 +10444,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                         }
                                         field={
                                           Object {
+                                            "className": "attribute_value_pair_wrapper",
                                             "component": "sub-form",
                                             "fields": Array [
                                               Object {
@@ -10415,6 +10458,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                                 "fieldKey": "field_array",
                                                 "fields": Array [
                                                   Object {
+                                                    "className": "attribute_value_field_wrapper",
                                                     "component": "text-field",
                                                     "id": "attribute",
                                                     "isRequired": true,
@@ -10427,6 +10471,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                                     ],
                                                   },
                                                   Object {
+                                                    "className": "attribute_value_field_wrapper",
                                                     "component": "text-field",
                                                     "id": "value",
                                                     "isRequired": true,
@@ -10471,6 +10516,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                             }
                                             field={
                                               Object {
+                                                "className": "attribute_value_pair_wrapper",
                                                 "component": "sub-form",
                                                 "fields": Array [
                                                   Object {
@@ -10484,6 +10530,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                                     "fieldKey": "field_array",
                                                     "fields": Array [
                                                       Object {
+                                                        "className": "attribute_value_field_wrapper",
                                                         "component": "text-field",
                                                         "id": "attribute",
                                                         "isRequired": true,
@@ -10496,6 +10543,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                                         ],
                                                       },
                                                       Object {
+                                                        "className": "attribute_value_field_wrapper",
                                                         "component": "text-field",
                                                         "id": "value",
                                                         "isRequired": true,
@@ -10533,6 +10581,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                               }
                                               field={
                                                 Object {
+                                                  "className": "attribute_value_pair_wrapper",
                                                   "component": "sub-form",
                                                   "fields": Array [
                                                     Object {
@@ -10546,6 +10595,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                                       "fieldKey": "field_array",
                                                       "fields": Array [
                                                         Object {
+                                                          "className": "attribute_value_field_wrapper",
                                                           "component": "text-field",
                                                           "id": "attribute",
                                                           "isRequired": true,
@@ -10558,6 +10608,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                                           ],
                                                         },
                                                         Object {
+                                                          "className": "attribute_value_field_wrapper",
                                                           "component": "text-field",
                                                           "id": "value",
                                                           "isRequired": true,
@@ -10594,6 +10645,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                                 }
                                                 field={
                                                   Object {
+                                                    "className": "attribute_value_pair_wrapper",
                                                     "component": "sub-form",
                                                     "fields": Array [
                                                       Object {
@@ -10607,6 +10659,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                                         "fieldKey": "field_array",
                                                         "fields": Array [
                                                           Object {
+                                                            "className": "attribute_value_field_wrapper",
                                                             "component": "text-field",
                                                             "id": "attribute",
                                                             "isRequired": true,
@@ -10619,6 +10672,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                                             ],
                                                           },
                                                           Object {
+                                                            "className": "attribute_value_field_wrapper",
                                                             "component": "text-field",
                                                             "id": "value",
                                                             "isRequired": true,
@@ -13805,6 +13859,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                         "title": "Custom Automation",
                                       },
                                       Object {
+                                        "className": "attribute_value_pair_wrapper",
                                         "component": "sub-form",
                                         "condition": Object {
                                           "is": "custom_automation",
@@ -13822,6 +13877,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                             "fieldKey": "field_array",
                                             "fields": Array [
                                               Object {
+                                                "className": "attribute_value_field_wrapper",
                                                 "component": "text-field",
                                                 "id": "attribute",
                                                 "isRequired": true,
@@ -13834,6 +13890,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                                 ],
                                               },
                                               Object {
+                                                "className": "attribute_value_field_wrapper",
                                                 "component": "text-field",
                                                 "id": "value",
                                                 "isRequired": true,
@@ -14544,6 +14601,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                         "title": "Custom Automation",
                                       },
                                       Object {
+                                        "className": "attribute_value_pair_wrapper",
                                         "component": "sub-form",
                                         "condition": Object {
                                           "is": "custom_automation",
@@ -14561,6 +14619,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                             "fieldKey": "field_array",
                                             "fields": Array [
                                               Object {
+                                                "className": "attribute_value_field_wrapper",
                                                 "component": "text-field",
                                                 "id": "attribute",
                                                 "isRequired": true,
@@ -14573,6 +14632,7 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                                 ],
                                               },
                                               Object {
+                                                "className": "attribute_value_field_wrapper",
                                                 "component": "text-field",
                                                 "id": "value",
                                                 "isRequired": true,
@@ -15304,6 +15364,7 @@ exports[`Action Form Component should render correctly 1`] = `
               "title": "Custom Automation",
             },
             Object {
+              "className": "attribute_value_pair_wrapper",
               "component": "sub-form",
               "condition": Object {
                 "is": "custom_automation",
@@ -15321,6 +15382,7 @@ exports[`Action Form Component should render correctly 1`] = `
                   "fieldKey": "field_array",
                   "fields": Array [
                     Object {
+                      "className": "attribute_value_field_wrapper",
                       "component": "text-field",
                       "id": "attribute",
                       "isRequired": true,
@@ -15333,6 +15395,7 @@ exports[`Action Form Component should render correctly 1`] = `
                       ],
                     },
                     Object {
+                      "className": "attribute_value_field_wrapper",
                       "component": "text-field",
                       "id": "value",
                       "isRequired": true,

--- a/app/stylesheet/ddf_override.scss
+++ b/app/stylesheet/ddf_override.scss
@@ -466,3 +466,28 @@
   margin-top: 3rem;
   margin-left: 15rem;
 }
+
+
+.attribute_value_pair_wrapper fieldset {
+  .bx--form-item {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 5px;
+
+    label {
+      margin-bottom: 0;
+    }
+  }
+
+  div > div {
+    display: flex;
+    flex-direction: row;
+    gap: 20px;
+    align-items: center;
+
+    .attribute_value_field_wrapper {
+      flex-grow: 1;
+    }
+  }
+}

--- a/app/stylesheet/miq-structured-list.scss
+++ b/app/stylesheet/miq-structured-list.scss
@@ -65,6 +65,9 @@
   }
 
   .content_value {
+    &.array_item:first-child {
+      width: 250px;
+    }
     .content {
       display: flex;
       flex-direction: row;

--- a/app/views/miq_action/show.html.haml
+++ b/app/views/miq_action/show.html.haml
@@ -1,9 +1,5 @@
 #action-details-div
 
   = render :partial => "layouts/flash_msg"
-  
-  = miq_summary_action_info(@record)
 
-  = miq_summary_action_type(@record, @alert_guids, @cats)
-
-  = miq_summary_action_policies(@action_policies)
+  = control_action_summary(@record, @alert_guids, @cats, @action_policies)


### PR DESCRIPTION
**Control / Actions**

**Edit action breadcrumb**
Before
<img width="360" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/03920f40-152e-42d0-baf3-d16f34b9c8fe">
After
<img width="454" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/f632c652-b9c0-48df-b087-5180095eaf56">

**Attribute/Value pair in forms**
Before
<img width="1507" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/65b059bc-b5b3-45bc-b512-c2270cd7a045">
After
<img width="1510" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/ab057990-f38b-4e47-938c-f5d88adc324a">

**Attribute/Value pair summary**
Before
<img width="667" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/043436a9-e94e-4538-88a5-9c7b50670e1f">

After
<img width="822" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/2e731298-466c-4388-959b-300003d7a745">

