### PR TITLE
Fix duplicate DOM ID warning in automate modal form

### DIFF
--- a/app/views/miq_ae_class/_all_tabs.html.haml
+++ b/app/views/miq_ae_class/_all_tabs.html.haml
@@ -17,7 +17,8 @@
       = miq_tab_content("instances", @sb[:active_tab]) do
         = render :partial => "class_instances"
       = miq_tab_content("methods", @sb[:active_tab]) do
-        = render :partial => "class_methods"
+        #class_methods_div
+          = render :partial => "class_methods"
       = miq_tab_content("props", @sb[:active_tab]) do
         = render :partial => "class_props"
       = miq_tab_content("schema", @sb[:active_tab]) do

--- a/app/views/miq_ae_class/_class_methods.html.haml
+++ b/app/views/miq_ae_class/_class_methods.html.haml
@@ -1,12 +1,11 @@
-#class_methods_div
-  - if !@in_a_form && !@angular_form
-    %h3= _('Methods')
-    - if @record.ae_methods.present?
-      = render :partial => 'datastore_list', :locals => {:type => MiqAeClassHelper::DATASTORE_TYPES[:methods], :data => @record.ae_methods.order(:name)}
-    - else
-      = render :partial => "layouts/info_msg",
-               :locals  => {:message => _("No methods found")}
-  - elsif @angular_form || @edit[:new][:fields]
-    .form_div
-      - partial_name = @angular_form ? 'angular_method_form' : 'method_form'
-      = render :partial => partial_name, :locals  => {:prefix => "cls_", :location => @edit[:new][:location]}
+
+- if !@in_a_form && !@angular_form
+  %h3= _('Methods')
+  - if @record.ae_methods.present?
+    = render :partial => 'datastore_list', :locals => {:type => MiqAeClassHelper::DATASTORE_TYPES[:methods], :data => @record.ae_methods.order(:name)}
+  - else
+    = render :partial => "layouts/info_msg", :locals => {:message => _("No methods found")}
+- elsif @angular_form || @edit[:new][:fields]
+  .form_div
+    - partial_name = @angular_form ? 'angular_method_form' : 'method_form'
+    = render :partial => partial_name, :locals => {:prefix => "cls_", :location => @edit[:new][:location]}


### PR DESCRIPTION
Automate / Explorer / Datastore / .... / `Methods` Tab > `Configuration` > Add a new method > Select `Inline`


Before
<img width="1786" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/f6f4c065-2917-4a94-85a2-f75241638ba8">

After
<img width="903" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/10bade8a-5665-4072-aea0-6b62e316068e">
