### PR TITLE
Reduce the button size from default to small in data table rows

### DIFF
--- a/app/javascript/components/miq-data-table/miq-table-cell.jsx
+++ b/app/javascript/components/miq-data-table/miq-table-cell.jsx
@@ -143,7 +143,7 @@ const MiqTableCell = ({
           disabled={item.disabled}
           onKeyPress={(e) => cellButtonEvent(item, e)}
           tabIndex={0}
-          size={item.size ? item.size : 'default'}
+          size={item.size ? item.size : 'sm'}
           title={item.title ? item.title : truncateText}
           kind={item.kind ? item.kind : 'primary'}
           className={classNames('miq-data-table-button', item.buttonClassName)}

--- a/app/javascript/spec/reconfigure-vm-form/__snapshots__/reconfigure-vm-form.spec.js.snap
+++ b/app/javascript/spec/reconfigure-vm-form/__snapshots__/reconfigure-vm-form.spec.js.snap
@@ -8886,14 +8886,14 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                                     kind="ghost"
                                                                     onClick={[Function]}
                                                                     onKeyPress={[Function]}
-                                                                    size="default"
+                                                                    size="sm"
                                                                     tabIndex={0}
                                                                     title="Resize"
                                                                   >
                                                                     <button
                                                                       aria-describedby={null}
                                                                       aria-pressed={null}
-                                                                      className="miq-data-table-button bx--btn bx--btn--ghost"
+                                                                      className="miq-data-table-button bx--btn bx--btn--sm bx--btn--ghost"
                                                                       disabled={false}
                                                                       onBlur={[Function]}
                                                                       onClick={[Function]}
@@ -9127,14 +9127,14 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                                     kind="ghost"
                                                                     onClick={[Function]}
                                                                     onKeyPress={[Function]}
-                                                                    size="default"
+                                                                    size="sm"
                                                                     tabIndex={0}
                                                                     title="Delete"
                                                                   >
                                                                     <button
                                                                       aria-describedby={null}
                                                                       aria-pressed={null}
-                                                                      className="miq-data-table-button bx--btn bx--btn--ghost"
+                                                                      className="miq-data-table-button bx--btn bx--btn--sm bx--btn--ghost"
                                                                       disabled={false}
                                                                       onBlur={[Function]}
                                                                       onClick={[Function]}
@@ -11065,14 +11065,14 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                                     kind="ghost"
                                                                     onClick={[Function]}
                                                                     onKeyPress={[Function]}
-                                                                    size="default"
+                                                                    size="sm"
                                                                     tabIndex={0}
                                                                     title="Cancel Disconnect"
                                                                   >
                                                                     <button
                                                                       aria-describedby={null}
                                                                       aria-pressed={null}
-                                                                      className="miq-data-table-button bx--btn bx--btn--ghost"
+                                                                      className="miq-data-table-button bx--btn bx--btn--sm bx--btn--ghost"
                                                                       disabled={false}
                                                                       onBlur={[Function]}
                                                                       onClick={[Function]}
@@ -11214,14 +11214,14 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
                                                                     kind="ghost"
                                                                     onClick={[Function]}
                                                                     onKeyPress={[Function]}
-                                                                    size="default"
+                                                                    size="sm"
                                                                     tabIndex={0}
                                                                     title="Connect"
                                                                   >
                                                                     <button
                                                                       aria-describedby={null}
                                                                       aria-pressed={null}
-                                                                      className="miq-data-table-button bx--btn bx--btn--ghost"
+                                                                      className="miq-data-table-button bx--btn bx--btn--sm bx--btn--ghost"
                                                                       disabled={false}
                                                                       onBlur={[Function]}
                                                                       onClick={[Function]}
@@ -36529,14 +36529,14 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                                     kind="ghost"
                                                                     onClick={[Function]}
                                                                     onKeyPress={[Function]}
-                                                                    size="default"
+                                                                    size="sm"
                                                                     tabIndex={0}
                                                                     title="Resize"
                                                                   >
                                                                     <button
                                                                       aria-describedby={null}
                                                                       aria-pressed={null}
-                                                                      className="miq-data-table-button bx--btn bx--btn--ghost"
+                                                                      className="miq-data-table-button bx--btn bx--btn--sm bx--btn--ghost"
                                                                       disabled={false}
                                                                       onBlur={[Function]}
                                                                       onClick={[Function]}
@@ -36770,14 +36770,14 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                                     kind="ghost"
                                                                     onClick={[Function]}
                                                                     onKeyPress={[Function]}
-                                                                    size="default"
+                                                                    size="sm"
                                                                     tabIndex={0}
                                                                     title="Delete"
                                                                   >
                                                                     <button
                                                                       aria-describedby={null}
                                                                       aria-pressed={null}
-                                                                      className="miq-data-table-button bx--btn bx--btn--ghost"
+                                                                      className="miq-data-table-button bx--btn bx--btn--sm bx--btn--ghost"
                                                                       disabled={false}
                                                                       onBlur={[Function]}
                                                                       onClick={[Function]}
@@ -38248,14 +38248,14 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                                     kind="ghost"
                                                                     onClick={[Function]}
                                                                     onKeyPress={[Function]}
-                                                                    size="default"
+                                                                    size="sm"
                                                                     tabIndex={0}
                                                                     title="Edit"
                                                                   >
                                                                     <button
                                                                       aria-describedby={null}
                                                                       aria-pressed={null}
-                                                                      className="miq-data-table-button bx--btn bx--btn--ghost"
+                                                                      className="miq-data-table-button bx--btn bx--btn--sm bx--btn--ghost"
                                                                       disabled={false}
                                                                       onBlur={[Function]}
                                                                       onClick={[Function]}
@@ -38409,14 +38409,14 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                                                                     kind="ghost"
                                                                     onClick={[Function]}
                                                                     onKeyPress={[Function]}
-                                                                    size="default"
+                                                                    size="sm"
                                                                     tabIndex={0}
                                                                     title="Delete"
                                                                   >
                                                                     <button
                                                                       aria-describedby={null}
                                                                       aria-pressed={null}
-                                                                      className="miq-data-table-button bx--btn bx--btn--ghost"
+                                                                      className="miq-data-table-button bx--btn bx--btn--sm bx--btn--ghost"
                                                                       disabled={false}
                                                                       onBlur={[Function]}
                                                                       onClick={[Function]}
@@ -53106,14 +53106,14 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                                     kind="ghost"
                                                                     onClick={[Function]}
                                                                     onKeyPress={[Function]}
-                                                                    size="default"
+                                                                    size="sm"
                                                                     tabIndex={0}
                                                                     title="Resize"
                                                                   >
                                                                     <button
                                                                       aria-describedby={null}
                                                                       aria-pressed={null}
-                                                                      className="miq-data-table-button bx--btn bx--btn--ghost bx--btn--disabled"
+                                                                      className="miq-data-table-button bx--btn bx--btn--sm bx--btn--ghost bx--btn--disabled"
                                                                       disabled={true}
                                                                       onBlur={[Function]}
                                                                       onClick={[Function]}
@@ -53344,14 +53344,14 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                                     kind="ghost"
                                                                     onClick={[Function]}
                                                                     onKeyPress={[Function]}
-                                                                    size="default"
+                                                                    size="sm"
                                                                     tabIndex={0}
                                                                     title="Cancel Delete"
                                                                   >
                                                                     <button
                                                                       aria-describedby={null}
                                                                       aria-pressed={null}
-                                                                      className="miq-data-table-button bx--btn bx--btn--ghost"
+                                                                      className="miq-data-table-button bx--btn bx--btn--sm bx--btn--ghost"
                                                                       disabled={false}
                                                                       onBlur={[Function]}
                                                                       onClick={[Function]}
@@ -55284,14 +55284,14 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                                     kind="ghost"
                                                                     onClick={[Function]}
                                                                     onKeyPress={[Function]}
-                                                                    size="default"
+                                                                    size="sm"
                                                                     tabIndex={0}
                                                                     title="Disconnect"
                                                                   >
                                                                     <button
                                                                       aria-describedby={null}
                                                                       aria-pressed={null}
-                                                                      className="miq-data-table-button bx--btn bx--btn--ghost"
+                                                                      className="miq-data-table-button bx--btn bx--btn--sm bx--btn--ghost"
                                                                       disabled={false}
                                                                       onBlur={[Function]}
                                                                       onClick={[Function]}
@@ -55433,14 +55433,14 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
                                                                     kind="ghost"
                                                                     onClick={[Function]}
                                                                     onKeyPress={[Function]}
-                                                                    size="default"
+                                                                    size="sm"
                                                                     tabIndex={0}
                                                                     title="Connect"
                                                                   >
                                                                     <button
                                                                       aria-describedby={null}
                                                                       aria-pressed={null}
-                                                                      className="miq-data-table-button bx--btn bx--btn--ghost bx--btn--disabled"
+                                                                      className="miq-data-table-button bx--btn bx--btn--sm bx--btn--ghost bx--btn--disabled"
                                                                       disabled={true}
                                                                       onBlur={[Function]}
                                                                       onClick={[Function]}

--- a/app/javascript/spec/settings-compan-categories/__snapshots__/settings-company-categories.spec.js.snap
+++ b/app/javascript/spec/settings-compan-categories/__snapshots__/settings-company-categories.spec.js.snap
@@ -2431,14 +2431,14 @@ exports[`SettingsCompanyCategories component should render a SettingsCompanyCate
                                 kind="danger"
                                 onClick={[Function]}
                                 onKeyPress={[Function]}
-                                size="default"
+                                size="sm"
                                 tabIndex={0}
                                 title="Category cannot be deleted"
                               >
                                 <button
                                   aria-describedby="danger-description-9"
                                   aria-pressed={null}
-                                  className="miq-data-table-button bx--btn bx--btn--danger"
+                                  className="miq-data-table-button bx--btn bx--btn--sm bx--btn--danger"
                                   disabled={false}
                                   onBlur={[Function]}
                                   onClick={[Function]}
@@ -3590,14 +3590,14 @@ exports[`SettingsCompanyCategories component should render a SettingsCompanyCate
                                 kind="danger"
                                 onClick={[Function]}
                                 onKeyPress={[Function]}
-                                size="default"
+                                size="sm"
                                 tabIndex={0}
                                 title="Click to delete this category"
                               >
                                 <button
                                   aria-describedby="danger-description-10"
                                   aria-pressed={null}
-                                  className="miq-data-table-button bx--btn bx--btn--danger bx--btn--disabled"
+                                  className="miq-data-table-button bx--btn bx--btn--sm bx--btn--danger bx--btn--disabled"
                                   disabled={true}
                                   onBlur={[Function]}
                                   onClick={[Function]}
@@ -4749,14 +4749,14 @@ exports[`SettingsCompanyCategories component should render a SettingsCompanyCate
                                 kind="danger"
                                 onClick={[Function]}
                                 onKeyPress={[Function]}
-                                size="default"
+                                size="sm"
                                 tabIndex={0}
                                 title="Click to delete this category"
                               >
                                 <button
                                   aria-describedby="danger-description-11"
                                   aria-pressed={null}
-                                  className="miq-data-table-button bx--btn bx--btn--danger bx--btn--disabled"
+                                  className="miq-data-table-button bx--btn bx--btn--sm bx--btn--danger bx--btn--disabled"
                                   disabled={true}
                                   onBlur={[Function]}
                                   onClick={[Function]}
@@ -5908,14 +5908,14 @@ exports[`SettingsCompanyCategories component should render a SettingsCompanyCate
                                 kind="danger"
                                 onClick={[Function]}
                                 onKeyPress={[Function]}
-                                size="default"
+                                size="sm"
                                 tabIndex={0}
                                 title="Click to delete this category"
                               >
                                 <button
                                   aria-describedby="danger-description-12"
                                   aria-pressed={null}
-                                  className="miq-data-table-button bx--btn bx--btn--danger bx--btn--disabled"
+                                  className="miq-data-table-button bx--btn bx--btn--sm bx--btn--danger bx--btn--disabled"
                                   disabled={true}
                                   onBlur={[Function]}
                                   onClick={[Function]}

--- a/app/javascript/spec/settings-label-tag-mapping/__snapshots__/settings-label-tag-mapping.spec.js.snap
+++ b/app/javascript/spec/settings-label-tag-mapping/__snapshots__/settings-label-tag-mapping.spec.js.snap
@@ -1346,14 +1346,14 @@ exports[`SettingsLabelTagMapping component should render a SettingsLabelTagMappi
                                 kind="danger"
                                 onClick={[Function]}
                                 onKeyPress={[Function]}
-                                size="default"
+                                size="sm"
                                 tabIndex={0}
                                 title="Click to delete this mapping"
                               >
                                 <button
                                   aria-describedby="danger-description-15"
                                   aria-pressed={null}
-                                  className="miq-data-table-button bx--btn bx--btn--danger"
+                                  className="miq-data-table-button bx--btn bx--btn--sm bx--btn--danger"
                                   disabled={false}
                                   onBlur={[Function]}
                                   onClick={[Function]}
@@ -1860,14 +1860,14 @@ exports[`SettingsLabelTagMapping component should render a SettingsLabelTagMappi
                                 kind="danger"
                                 onClick={[Function]}
                                 onKeyPress={[Function]}
-                                size="default"
+                                size="sm"
                                 tabIndex={0}
                                 title="Click to delete this mapping"
                               >
                                 <button
                                   aria-describedby="danger-description-16"
                                   aria-pressed={null}
-                                  className="miq-data-table-button bx--btn bx--btn--danger"
+                                  className="miq-data-table-button bx--btn bx--btn--sm bx--btn--danger"
                                   disabled={false}
                                   onBlur={[Function]}
                                   onClick={[Function]}
@@ -2374,14 +2374,14 @@ exports[`SettingsLabelTagMapping component should render a SettingsLabelTagMappi
                                 kind="danger"
                                 onClick={[Function]}
                                 onKeyPress={[Function]}
-                                size="default"
+                                size="sm"
                                 tabIndex={0}
                                 title="Click to delete this mapping"
                               >
                                 <button
                                   aria-describedby="danger-description-17"
                                   aria-pressed={null}
-                                  className="miq-data-table-button bx--btn bx--btn--danger"
+                                  className="miq-data-table-button bx--btn bx--btn--sm bx--btn--danger"
                                   disabled={false}
                                   onBlur={[Function]}
                                   onClick={[Function]}
@@ -2888,14 +2888,14 @@ exports[`SettingsLabelTagMapping component should render a SettingsLabelTagMappi
                                 kind="danger"
                                 onClick={[Function]}
                                 onKeyPress={[Function]}
-                                size="default"
+                                size="sm"
                                 tabIndex={0}
                                 title="Click to delete this mapping"
                               >
                                 <button
                                   aria-describedby="danger-description-18"
                                   aria-pressed={null}
-                                  className="miq-data-table-button bx--btn bx--btn--danger"
+                                  className="miq-data-table-button bx--btn bx--btn--sm bx--btn--danger"
                                   disabled={false}
                                   onBlur={[Function]}
                                   onClick={[Function]}
@@ -4265,14 +4265,14 @@ exports[`SettingsLabelTagMapping component should render a SettingsLabelTagMappi
                                 kind="danger"
                                 onClick={[Function]}
                                 onKeyPress={[Function]}
-                                size="default"
+                                size="sm"
                                 tabIndex={0}
                                 title="Click to delete this mapping"
                               >
                                 <button
                                   aria-describedby="danger-description-6"
                                   aria-pressed={null}
-                                  className="miq-data-table-button bx--btn bx--btn--danger"
+                                  className="miq-data-table-button bx--btn bx--btn--sm bx--btn--danger"
                                   disabled={false}
                                   onBlur={[Function]}
                                   onClick={[Function]}
@@ -4779,14 +4779,14 @@ exports[`SettingsLabelTagMapping component should render a SettingsLabelTagMappi
                                 kind="danger"
                                 onClick={[Function]}
                                 onKeyPress={[Function]}
-                                size="default"
+                                size="sm"
                                 tabIndex={0}
                                 title="Click to delete this mapping"
                               >
                                 <button
                                   aria-describedby="danger-description-7"
                                   aria-pressed={null}
-                                  className="miq-data-table-button bx--btn bx--btn--danger"
+                                  className="miq-data-table-button bx--btn bx--btn--sm bx--btn--danger"
                                   disabled={false}
                                   onBlur={[Function]}
                                   onClick={[Function]}
@@ -5293,14 +5293,14 @@ exports[`SettingsLabelTagMapping component should render a SettingsLabelTagMappi
                                 kind="danger"
                                 onClick={[Function]}
                                 onKeyPress={[Function]}
-                                size="default"
+                                size="sm"
                                 tabIndex={0}
                                 title="Click to delete this mapping"
                               >
                                 <button
                                   aria-describedby="danger-description-8"
                                   aria-pressed={null}
-                                  className="miq-data-table-button bx--btn bx--btn--danger"
+                                  className="miq-data-table-button bx--btn bx--btn--sm bx--btn--danger"
                                   disabled={false}
                                   onBlur={[Function]}
                                   onClick={[Function]}
@@ -5807,14 +5807,14 @@ exports[`SettingsLabelTagMapping component should render a SettingsLabelTagMappi
                                 kind="danger"
                                 onClick={[Function]}
                                 onKeyPress={[Function]}
-                                size="default"
+                                size="sm"
                                 tabIndex={0}
                                 title="Click to delete this mapping"
                               >
                                 <button
                                   aria-describedby="danger-description-9"
                                   aria-pressed={null}
-                                  className="miq-data-table-button bx--btn bx--btn--danger"
+                                  className="miq-data-table-button bx--btn bx--btn--sm bx--btn--danger"
                                   disabled={false}
                                   onBlur={[Function]}
                                   onClick={[Function]}

--- a/app/stylesheet/miq-data-table.scss
+++ b/app/stylesheet/miq-data-table.scss
@@ -123,7 +123,7 @@
 
       button {
         padding: 0;
-        margin: 5px 0;
+        margin: -5px 0 0 0;
 
         span {
           display: flex;


### PR DESCRIPTION
The size of the buttons in data tables was a bit bigger by default consuming a lot of vertical space before.
Therefore, changing the button size to `small` if no size is specified.

Before
<img width="1524" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/040340e8-dc57-4c68-9948-817e5c7b08c8">

After
<img width="1521" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/f61215e7-9e1e-413a-a2a5-6cc4baf38b5f">
