### PR TITLE
Fixed events search bar

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2165,6 +2165,9 @@ Rails.application.routes.draw do
         show
         show_list
       ],
+      :post => %w[
+        show_list
+      ]
     },
 
     :condition => {


### PR DESCRIPTION
Fixed events search bar bug.

Before:
<img width="1021" alt="Screenshot 2024-03-05 at 10 36 09 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/2626f64a-e6c5-4a29-9bc6-0167da69258c">

After:
<img width="1411" alt="Screenshot 2024-03-05 at 10 31 18 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/1e27274d-6c29-481a-9c4a-6004b1aec80d">
