### PR TITLE
Display OS 'name' as 'Description'

### DIFF
--- a/app/helpers/textual_mixins/textual_os_info.rb
+++ b/app/helpers/textual_mixins/textual_os_info.rb
@@ -28,7 +28,7 @@ module TextualMixins::TextualOsInfo
     if @record.operating_system.present?
       os_info = {:product_name => _("Operating System"), :service_pack => _("Service Pack"),
                  :productid => _("Product ID"), :version => _("Version"), :build_number => _("Build Number"),
-                 :bitness => _("System Type")}.map do |method, title|
+                 :bitness => _("System Type"), :name => _("Description")}.map do |method, title|
                    value = @record.operating_system.send(method)
                    value ? OsInfo.new(title, value) : next
                  end


### PR DESCRIPTION
If an OS 'name' attribute is not nil then display it in the UI as 'Description'.

Related to: https://github.com/ManageIQ/manageiq-providers-ibm_power_vc/pull/106

Screenshot:
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/1637291/5ab89cb3-6ced-4019-b1df-7ab7b9cb918e)

