### PR TITLE
Searchbar UI

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2167,7 +2167,15 @@ Rails.application.routes.draw do
       ],
       :post => %w[
         show_list
+<<<<<<< HEAD
       ]
+=======
+<<<<<<< HEAD
+      ]      
+=======
+      ]
+>>>>>>> 6e857535109a78c40892d6cf2bb228b1e1c6428c
+>>>>>>> f5a686828 (Committing changes before pulling latest updates)
     },
 
     :condition => {


### PR DESCRIPTION
**Add Search Bar to Provision Instances Page**

### Purpose
This pull request introduces a search bar to the provision instances page in the ManageIQ UI Classic. The addition of this feature aims to enhance the user experience by allowing users to easily search for and select images when provisioning instances.

![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/146204923/f8f4e93e-6e0a-4347-8839-0ed4ea775703)

Path: Compute/Cloud/Instances/Instances by Provider/Provision Instances-Select an Image

URL_Path: https://localhost:3000/vm_cloud/explorer#/