### PR TITLE
Fix action form tag bug

### DIFF
--- a/app/javascript/components/action-form/action-form.schema.js
+++ b/app/javascript/components/action-form/action-form.schema.js
@@ -491,6 +491,8 @@ function createSchema(recordId, promise, inheritTags, evaluateAlert, tags, ansib
           id: 'options.tags',
           name: 'options.tags',
           label: __('Tag to Apply'),
+          isRequired: true,
+          validate: [{ type: validatorTypes.REQUIRED }],
           options: buildTags(tags, inheritTags),
         },
       ],

--- a/app/javascript/components/action-form/helper.js
+++ b/app/javascript/components/action-form/helper.js
@@ -187,7 +187,7 @@ const findLabel = (inheritTags, catLabel) => {
 
 const buildTags = (tags, inheritTags) => {
   const entry = Object.entries(tags);
-  const tagArray = [];
+  const tagArray = [{ label: __('<Choose>'), value: '' }];
   entry.forEach((pt) => {
     const catOptions = [];
     const tempObj = { label: pt[0], value: pt[1] };

--- a/app/javascript/spec/action-form/__snapshots__/action-form.spec.js.snap
+++ b/app/javascript/spec/action-form/__snapshots__/action-form.spec.js.snap
@@ -751,9 +751,14 @@ exports[`Action Form Component should render adding a new action 1`] = `
                     Object {
                       "component": "select",
                       "id": "options.tags",
+                      "isRequired": true,
                       "label": "Tag to Apply",
                       "name": "options.tags",
                       "options": Array [
+                        Object {
+                          "label": "<Choose>",
+                          "value": "",
+                        },
                         Object {
                           "label": "AUTO APPROVE - MAX CPU",
                           "options": Array [
@@ -778,6 +783,11 @@ exports[`Action Form Component should render adding a new action 1`] = `
                               "value": "prov_max_cpu/5",
                             },
                           ],
+                        },
+                      ],
+                      "validate": Array [
+                        Object {
+                          "type": "required",
                         },
                       ],
                     },
@@ -1456,9 +1466,14 @@ exports[`Action Form Component should render adding a new action 1`] = `
                       Object {
                         "component": "select",
                         "id": "options.tags",
+                        "isRequired": true,
                         "label": "Tag to Apply",
                         "name": "options.tags",
                         "options": Array [
+                          Object {
+                            "label": "<Choose>",
+                            "value": "",
+                          },
                           Object {
                             "label": "AUTO APPROVE - MAX CPU",
                             "options": Array [
@@ -1483,6 +1498,11 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                 "value": "prov_max_cpu/5",
                               },
                             ],
+                          },
+                        ],
+                        "validate": Array [
+                          Object {
+                            "type": "required",
                           },
                         ],
                       },
@@ -2154,9 +2174,14 @@ exports[`Action Form Component should render adding a new action 1`] = `
                         Object {
                           "component": "select",
                           "id": "options.tags",
+                          "isRequired": true,
                           "label": "Tag to Apply",
                           "name": "options.tags",
                           "options": Array [
+                            Object {
+                              "label": "<Choose>",
+                              "value": "",
+                            },
                             Object {
                               "label": "AUTO APPROVE - MAX CPU",
                               "options": Array [
@@ -2181,6 +2206,11 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                   "value": "prov_max_cpu/5",
                                 },
                               ],
+                            },
+                          ],
+                          "validate": Array [
+                            Object {
+                              "type": "required",
                             },
                           ],
                         },
@@ -2852,9 +2882,14 @@ exports[`Action Form Component should render adding a new action 1`] = `
                             Object {
                               "component": "select",
                               "id": "options.tags",
+                              "isRequired": true,
                               "label": "Tag to Apply",
                               "name": "options.tags",
                               "options": Array [
+                                Object {
+                                  "label": "<Choose>",
+                                  "value": "",
+                                },
                                 Object {
                                   "label": "AUTO APPROVE - MAX CPU",
                                   "options": Array [
@@ -2879,6 +2914,11 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                       "value": "prov_max_cpu/5",
                                     },
                                   ],
+                                },
+                              ],
+                              "validate": Array [
+                                Object {
+                                  "type": "required",
                                 },
                               ],
                             },
@@ -3514,9 +3554,14 @@ exports[`Action Form Component should render adding a new action 1`] = `
                             Object {
                               "component": "select",
                               "id": "options.tags",
+                              "isRequired": true,
                               "label": "Tag to Apply",
                               "name": "options.tags",
                               "options": Array [
+                                Object {
+                                  "label": "<Choose>",
+                                  "value": "",
+                                },
                                 Object {
                                   "label": "AUTO APPROVE - MAX CPU",
                                   "options": Array [
@@ -3541,6 +3586,11 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                       "value": "prov_max_cpu/5",
                                     },
                                   ],
+                                },
+                              ],
+                              "validate": Array [
+                                Object {
+                                  "type": "required",
                                 },
                               ],
                             },
@@ -4187,9 +4237,14 @@ exports[`Action Form Component should render adding a new action 1`] = `
                               Object {
                                 "component": "select",
                                 "id": "options.tags",
+                                "isRequired": true,
                                 "label": "Tag to Apply",
                                 "name": "options.tags",
                                 "options": Array [
+                                  Object {
+                                    "label": "<Choose>",
+                                    "value": "",
+                                  },
                                   Object {
                                     "label": "AUTO APPROVE - MAX CPU",
                                     "options": Array [
@@ -4214,6 +4269,11 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                         "value": "prov_max_cpu/5",
                                       },
                                     ],
+                                  },
+                                ],
+                                "validate": Array [
+                                  Object {
+                                    "type": "required",
                                   },
                                 ],
                               },
@@ -4855,9 +4915,14 @@ exports[`Action Form Component should render adding a new action 1`] = `
                               Object {
                                 "component": "select",
                                 "id": "options.tags",
+                                "isRequired": true,
                                 "label": "Tag to Apply",
                                 "name": "options.tags",
                                 "options": Array [
+                                  Object {
+                                    "label": "<Choose>",
+                                    "value": "",
+                                  },
                                   Object {
                                     "label": "AUTO APPROVE - MAX CPU",
                                     "options": Array [
@@ -4882,6 +4947,11 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                         "value": "prov_max_cpu/5",
                                       },
                                     ],
+                                  },
+                                ],
+                                "validate": Array [
+                                  Object {
+                                    "type": "required",
                                   },
                                 ],
                               },
@@ -5543,9 +5613,14 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                 Object {
                                   "component": "select",
                                   "id": "options.tags",
+                                  "isRequired": true,
                                   "label": "Tag to Apply",
                                   "name": "options.tags",
                                   "options": Array [
+                                    Object {
+                                      "label": "<Choose>",
+                                      "value": "",
+                                    },
                                     Object {
                                       "label": "AUTO APPROVE - MAX CPU",
                                       "options": Array [
@@ -5570,6 +5645,11 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                           "value": "prov_max_cpu/5",
                                         },
                                       ],
+                                    },
+                                  ],
+                                  "validate": Array [
+                                    Object {
+                                      "type": "required",
                                     },
                                   ],
                                 },
@@ -6211,9 +6291,14 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                 Object {
                                   "component": "select",
                                   "id": "options.tags",
+                                  "isRequired": true,
                                   "label": "Tag to Apply",
                                   "name": "options.tags",
                                   "options": Array [
+                                    Object {
+                                      "label": "<Choose>",
+                                      "value": "",
+                                    },
                                     Object {
                                       "label": "AUTO APPROVE - MAX CPU",
                                       "options": Array [
@@ -6238,6 +6323,11 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                           "value": "prov_max_cpu/5",
                                         },
                                       ],
+                                    },
+                                  ],
+                                  "validate": Array [
+                                    Object {
+                                      "type": "required",
                                     },
                                   ],
                                 },
@@ -6890,9 +6980,14 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                   Object {
                                     "component": "select",
                                     "id": "options.tags",
+                                    "isRequired": true,
                                     "label": "Tag to Apply",
                                     "name": "options.tags",
                                     "options": Array [
+                                      Object {
+                                        "label": "<Choose>",
+                                        "value": "",
+                                      },
                                       Object {
                                         "label": "AUTO APPROVE - MAX CPU",
                                         "options": Array [
@@ -6917,6 +7012,11 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                             "value": "prov_max_cpu/5",
                                           },
                                         ],
+                                      },
+                                    ],
+                                    "validate": Array [
+                                      Object {
+                                        "type": "required",
                                       },
                                     ],
                                   },
@@ -7546,9 +7646,14 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                       Object {
                                         "component": "select",
                                         "id": "options.tags",
+                                        "isRequired": true,
                                         "label": "Tag to Apply",
                                         "name": "options.tags",
                                         "options": Array [
+                                          Object {
+                                            "label": "<Choose>",
+                                            "value": "",
+                                          },
                                           Object {
                                             "label": "AUTO APPROVE - MAX CPU",
                                             "options": Array [
@@ -7573,6 +7678,11 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                                 "value": "prov_max_cpu/5",
                                               },
                                             ],
+                                          },
+                                        ],
+                                        "validate": Array [
+                                          Object {
+                                            "type": "required",
                                           },
                                         ],
                                       },
@@ -8206,9 +8316,14 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                         Object {
                                           "component": "select",
                                           "id": "options.tags",
+                                          "isRequired": true,
                                           "label": "Tag to Apply",
                                           "name": "options.tags",
                                           "options": Array [
+                                            Object {
+                                              "label": "<Choose>",
+                                              "value": "",
+                                            },
                                             Object {
                                               "label": "AUTO APPROVE - MAX CPU",
                                               "options": Array [
@@ -8233,6 +8348,11 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                                   "value": "prov_max_cpu/5",
                                                 },
                                               ],
+                                            },
+                                          ],
+                                          "validate": Array [
+                                            Object {
+                                              "type": "required",
                                             },
                                           ],
                                         },
@@ -13225,9 +13345,14 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                         Object {
                                           "component": "select",
                                           "id": "options.tags",
+                                          "isRequired": true,
                                           "label": "Tag to Apply",
                                           "name": "options.tags",
                                           "options": Array [
+                                            Object {
+                                              "label": "<Choose>",
+                                              "value": "",
+                                            },
                                             Object {
                                               "label": "AUTO APPROVE - MAX CPU",
                                               "options": Array [
@@ -13254,6 +13379,11 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                               ],
                                             },
                                           ],
+                                          "validate": Array [
+                                            Object {
+                                              "type": "required",
+                                            },
+                                          ],
                                         },
                                       ]
                                     }
@@ -13276,9 +13406,14 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                             Object {
                                               "component": "select",
                                               "id": "options.tags",
+                                              "isRequired": true,
                                               "label": "Tag to Apply",
                                               "name": "options.tags",
                                               "options": Array [
+                                                Object {
+                                                  "label": "<Choose>",
+                                                  "value": "",
+                                                },
                                                 Object {
                                                   "label": "AUTO APPROVE - MAX CPU",
                                                   "options": Array [
@@ -13305,6 +13440,11 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                                   ],
                                                 },
                                               ],
+                                              "validate": Array [
+                                                Object {
+                                                  "type": "required",
+                                                },
+                                              ],
                                             },
                                           ],
                                           "id": "subform-17",
@@ -13327,9 +13467,14 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                               Object {
                                                 "component": "select",
                                                 "id": "options.tags",
+                                                "isRequired": true,
                                                 "label": "Tag to Apply",
                                                 "name": "options.tags",
                                                 "options": Array [
+                                                  Object {
+                                                    "label": "<Choose>",
+                                                    "value": "",
+                                                  },
                                                   Object {
                                                     "label": "AUTO APPROVE - MAX CPU",
                                                     "options": Array [
@@ -13354,6 +13499,11 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                                         "value": "prov_max_cpu/5",
                                                       },
                                                     ],
+                                                  },
+                                                ],
+                                                "validate": Array [
+                                                  Object {
+                                                    "type": "required",
                                                   },
                                                 ],
                                               },
@@ -13391,9 +13541,14 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                                   Object {
                                                     "component": "select",
                                                     "id": "options.tags",
+                                                    "isRequired": true,
                                                     "label": "Tag to Apply",
                                                     "name": "options.tags",
                                                     "options": Array [
+                                                      Object {
+                                                        "label": "<Choose>",
+                                                        "value": "",
+                                                      },
                                                       Object {
                                                         "label": "AUTO APPROVE - MAX CPU",
                                                         "options": Array [
@@ -13418,6 +13573,11 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                                             "value": "prov_max_cpu/5",
                                                           },
                                                         ],
+                                                      },
+                                                    ],
+                                                    "validate": Array [
+                                                      Object {
+                                                        "type": "required",
                                                       },
                                                     ],
                                                   },
@@ -13448,9 +13608,14 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                                     Object {
                                                       "component": "select",
                                                       "id": "options.tags",
+                                                      "isRequired": true,
                                                       "label": "Tag to Apply",
                                                       "name": "options.tags",
                                                       "options": Array [
+                                                        Object {
+                                                          "label": "<Choose>",
+                                                          "value": "",
+                                                        },
                                                         Object {
                                                           "label": "AUTO APPROVE - MAX CPU",
                                                           "options": Array [
@@ -13475,6 +13640,11 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                                               "value": "prov_max_cpu/5",
                                                             },
                                                           ],
+                                                        },
+                                                      ],
+                                                      "validate": Array [
+                                                        Object {
+                                                          "type": "required",
                                                         },
                                                       ],
                                                     },
@@ -13504,9 +13674,14 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                                       Object {
                                                         "component": "select",
                                                         "id": "options.tags",
+                                                        "isRequired": true,
                                                         "label": "Tag to Apply",
                                                         "name": "options.tags",
                                                         "options": Array [
+                                                          Object {
+                                                            "label": "<Choose>",
+                                                            "value": "",
+                                                          },
                                                           Object {
                                                             "label": "AUTO APPROVE - MAX CPU",
                                                             "options": Array [
@@ -13531,6 +13706,11 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                                                 "value": "prov_max_cpu/5",
                                                               },
                                                             ],
+                                                          },
+                                                        ],
+                                                        "validate": Array [
+                                                          Object {
+                                                            "type": "required",
                                                           },
                                                         ],
                                                       },
@@ -14223,9 +14403,14 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                           Object {
                                             "component": "select",
                                             "id": "options.tags",
+                                            "isRequired": true,
                                             "label": "Tag to Apply",
                                             "name": "options.tags",
                                             "options": Array [
+                                              Object {
+                                                "label": "<Choose>",
+                                                "value": "",
+                                              },
                                               Object {
                                                 "label": "AUTO APPROVE - MAX CPU",
                                                 "options": Array [
@@ -14250,6 +14435,11 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                                     "value": "prov_max_cpu/5",
                                                   },
                                                 ],
+                                              },
+                                            ],
+                                            "validate": Array [
+                                              Object {
+                                                "type": "required",
                                               },
                                             ],
                                           },
@@ -14965,9 +15155,14 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                           Object {
                                             "component": "select",
                                             "id": "options.tags",
+                                            "isRequired": true,
                                             "label": "Tag to Apply",
                                             "name": "options.tags",
                                             "options": Array [
+                                              Object {
+                                                "label": "<Choose>",
+                                                "value": "",
+                                              },
                                               Object {
                                                 "label": "AUTO APPROVE - MAX CPU",
                                                 "options": Array [
@@ -14992,6 +15187,11 @@ exports[`Action Form Component should render adding a new action 1`] = `
                                                     "value": "prov_max_cpu/5",
                                                   },
                                                 ],
+                                              },
+                                            ],
+                                            "validate": Array [
+                                              Object {
+                                                "type": "required",
                                               },
                                             ],
                                           },
@@ -15728,9 +15928,14 @@ exports[`Action Form Component should render correctly 1`] = `
                 Object {
                   "component": "select",
                   "id": "options.tags",
+                  "isRequired": true,
                   "label": "Tag to Apply",
                   "name": "options.tags",
                   "options": Array [
+                    Object {
+                      "label": "<Choose>",
+                      "value": "",
+                    },
                     Object {
                       "label": "AUTO APPROVE - MAX CPU",
                       "options": Array [
@@ -15755,6 +15960,11 @@ exports[`Action Form Component should render correctly 1`] = `
                           "value": "prov_max_cpu/5",
                         },
                       ],
+                    },
+                  ],
+                  "validate": Array [
+                    Object {
+                      "type": "required",
                     },
                   ],
                 },


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/9113

Fix bug where the Control > Action form with Action Type Tag receives an undefined value when users don't select a tag value. This pr adds a placeholder value and makes the field required forcing the user to select a value.

Before:
<img width="1402" alt="Screenshot 2024-03-12 at 1 08 04 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/a9f993ae-b61b-420f-823f-ddbf987c1d50">

After:
<img width="1405" alt="Screenshot 2024-03-12 at 1 27 50 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/d089fda7-236f-48ed-83df-6210a0ea9fa8">
<img width="1401" alt="Screenshot 2024-03-12 at 1 29 20 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/abddd4e6-4ba4-4840-be68-3fbde4b12004">
