### PR TITLE
Fixed bug with deleting group tags

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1078,7 +1078,8 @@ module OpsController::OpsRbac
     if params[:check]                               # User checked/unchecked a tree node
       if params[:tree_typ] == "tags"                # MyCompany tag checked
         cat_name = Classification.find_by(:id => params[:cat]).name
-        tag_name = Classification.find_by(:id => params[:val]).name
+        classification = Classification.find_by(:id => params[:val])
+        tag_name = classification ? classification.name : ''
         if params[:check] == "0" #   unchecked
           @edit[:new][:filters].except!("#{cat_name}-#{tag_name}") # Remove the tag from the filters array
         else

--- a/app/javascript/components/taggingWrapper.jsx
+++ b/app/javascript/components/taggingWrapper.jsx
@@ -9,7 +9,7 @@ const selectedTags = (state, tag) => {
   return [state.tagging.appState.assignedTags.map((t) => t.values.map((val) => val.id)).flat(), selectedVal].flat();
 };
 
-const params = (type = 'default', state, tag = {}) => ({
+const params = (type = 'default', state, tag = { tagCategory: undefined, tagValue: { id: undefined } }) => ({
   provision: {
     id: 'new',
     ids_checked: selectedTags(state, tag),
@@ -18,7 +18,7 @@ const params = (type = 'default', state, tag = {}) => ({
   default: {
     id: state.tagging.appState.affectedItems[0] || 'new',
     cat: tag.tagCategory.id,
-    val: tag.tagValue.id || tag.tagValue[0].id,
+    val: tag.tagValue.id || tag.tagValue[0],
     check: 1,
     tree_typ: 'tags',
   },


### PR DESCRIPTION
Fixed a bug where selecting then deselecting all tags from the Group tag form will break the form.

Steps to reproduce:
1) Navigate to the Edit Group form
2) Add Tags using the multi select
3) Remove the tags using the multi select
4) This will then break the form

Before:
<img width="1051" alt="Screenshot 2024-03-12 at 4 28 17 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/276e9253-a8dd-4a9f-8b37-5d219ec730de">

After:
<img width="1054" alt="Screenshot 2024-03-12 at 4 29 33 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/c98a9bb7-8d48-48b8-8ac3-97921a2a7d88">
