### PR TITLE
Prepend ActionView::Helpers::NumberHelper with our NumberHelper

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,7 +20,6 @@ class ApplicationController < ActionController::Base
   helper ChartingHelper
   ManageIQ::Reporting::Charting.load_helpers(self)
 
-  include ActionView::Helpers::NumberHelper # bring in the number helpers for number_to_human_size
   include ActionView::Helpers::TextHelper
   include ActionView::Helpers::DateHelper
   include ApplicationHelper

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,7 +10,7 @@ module ApplicationHelper
   include StiRoutingHelper
   include ToolbarHelper
   include TextualSummaryHelper
-  include NumberHelper
+  ActionView::Helpers::NumberHelper.prepend NumberHelper # override rails number helper with our needs for number_to_human_size
   include Title
   include ReactjsHelper
   include Webpack


### PR DESCRIPTION
This ensures we prepend our NumberHelper into the existing helper.  Previously, there was a loading order problem where the original rails NumberHelper would be used. 

For rails 7, this load order was causing these types of errors where the original number helper was being used:


```
  1) MiqReport::Formatting #format_mhz_to_human_size adds a prefix and suffix to NumberHelper#mhz_to_human_size
     Failure/Error: val = ApplicationController.helpers.mhz_to_human_size(val, options[:precision])

     NoMethodError:
       undefined method `mhz_to_human_size' for #<ActionView::Base:0x000000012e3573c8 @_config=#< {}>, @lookup_context=#<ActionView::LookupContext:0x000000012e357d78 @details_key=nil, @digest_cache=nil, @cache=true, @prefixes=[], @details={:locale=>[:en], :formats=>[:html, :text, :js, :css, :ics, :csv, :vcf, :vtt, :png, :jpeg, :gif, :bmp, :tiff, :svg, :mpeg, :mp3, :ogg, :m4a, :webm, :mp4, :otf, :ttf, :woff, :woff2, :xml, :rss, :atom, :yaml, :multipart_form, :url_encoded_form, :json, :pdf, :zip, :gzip], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :haml, :rjs]}, @view_paths=#<ActionView::PathSet:0x000000012e357508 @paths=[]>>, @view_renderer=#<ActionView::Renderer:0x000000012e354fb0 @lookup_context=#<ActionView::LookupContext:0x000000012e357d78 @details_key=nil, @digest_cache=nil, @cache=true, @prefixes=[], @details={:locale=>[:en], :formats=>[:html, :text, :js, :css, :ics, :csv, :vcf, :vtt, :png, :jpeg, :gif, :bmp, :tiff, :svg, :mpeg, :mp3, :ogg, :m4a, :webm, :mp4, :otf, :ttf, :woff, :woff2, :xml, :rss, :atom, :yaml, :multipart_form, :url_encoded_form, :json, :pdf, :zip, :gzip], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :haml, :rjs]}, @view_paths=#<ActionView::PathSet:0x000000012e357508 @paths=[]>>>, @current_template=nil, @_assigns={}, @_controller=nil, @view_flow=#<ActionView::OutputFlow:0x000000012e34f6c8 @content={}>, @output_buffer=nil, @virtual_path=nil>

           val = ApplicationController.helpers.mhz_to_human_size(val, options[:precision])
                                              ^^^^^^^^^^^^^^^^^^
       Did you mean?  number_to_human_size
     # ./app/models/miq_report/formatting.rb:165:in `format_mhz_to_human_size'
     # ./spec/models/miq_report/formatting_spec.rb:36:in `block (3 levels) in <main>'
     # /Users/joerafaniello/.gem/ruby/3.1.5/gems/webmock-3.23.0/lib/webmock/rspec.rb:39:in `block (2 levels) in <main>'

  2) MiqReport::Formatting #format formats megabytes value
     Failure/Error: expect(container_report.format(memory_col, 7822)).to eq('7.6 GB')

       expected: "7.6 GB"
            got: "8 GB"

       (compared using ==)
     # ./spec/models/miq_report/formatting_spec.rb:64:in `block (3 levels) in <main>'
     # /Users/joerafaniello/.gem/ruby/3.1.5/gems/webmock-3.23.0/lib/webmock/rspec.rb:39:in `block (2 levels) in <main>'

...
  1) MiqReportResult::ResultSetOperations.result_set_for_reporting filters with one column
     Failure/Error: expect(subject[:result_set]).to match_array(expected_result_set)

       expected collection contained:  [{"name"=>"TEST_VM2", "size"=>"112.8 KB", "type"=>"small"}, {"name"=>"TEST_VM1", "size"=>"324.4 KB", "type"=>"large"}]
       actual collection contained:    [{"name"=>"TEST_VM1", "size"=>"300 KB", "type"=>"large"}, {"name"=>"TEST_VM2", "size"=>"100 KB", "type"=>"small"}]
       the missing elements were:      [{"name"=>"TEST_VM2", "size"=>"112.8 KB", "type"=>"small"}, {"name"=>"TEST_VM1", "size"=>"324.4 KB", "type"=>"large"}]
       the extra elements were:        [{"name"=>"TEST_VM1", "size"=>"300 KB", "type"=>"large"}, {"name"=>"TEST_VM2", "size"=>"100 KB", "type"=>"small"}]
     # ./spec/models/miq_report_result/result_set_operations_spec.rb:38:in `block (3 levels) in <main>'
     # /Users/joerafaniello/.gem/ruby/3.1.5/gems/webmock-3.23.0/lib/webmock/rspec.rb:39:in `block (2 levels) in <main>'

  2) MiqReportResult::ResultSetOperations.result_set_for_reporting with more columns filters
     Failure/Error: expect(subject[:result_set]).to match_array(expected_result_set)

       expected collection contained:  [{"name"=>"TEST_VM2", "size"=>"112.8 KB", "type"=>"small"}]
       actual collection contained:    [{"name"=>"TEST_VM2", "size"=>"100 KB", "type"=>"small"}]
       the missing elements were:      [{"name"=>"TEST_VM2", "size"=>"112.8 KB", "type"=>"small"}]
       the extra elements were:        [{"name"=>"TEST_VM2", "size"=>"100 KB", "type"=>"small"}]
     # ./spec/models/miq_report_result/result_set_operations_spec.rb:51:in `block (4 levels) in <main>'
     # /Users/joerafaniello/.gem/ruby/3.1.5/gems/webmock-3.23.0/lib/webmock/rspec.rb:39:in `block (2 levels) in <main>'

  3) MiqReportResult::ResultSetOperations.result_set_for_reporting with more columns with various order of parameters filters
     Failure/Error: expect(subject[:result_set]).to match_array(expected_result_set)

       expected collection contained:  [{"name"=>"TEST_VM2", "size"=>"112.8 KB", "type"=>"small"}]
       actual collection contained:    [{"name"=>"TEST_VM2", "size"=>"100 KB", "type"=>"small"}]
       the missing elements were:      [{"name"=>"TEST_VM2", "size"=>"112.8 KB", "type"=>"small"}]
       the extra elements were:        [{"name"=>"TEST_VM2", "size"=>"100 KB", "type"=>"small"}]
     # ./spec/models/miq_report_result/result_set_operations_spec.rb:60:in `block (5 levels) in <main>'
     # /Users/joerafaniello/.gem/ruby/3.1.5/gems/webmock-3.23.0/lib/webmock/rspec.rb:39:in `block (2 levels) in <main>'
```