### PR TITLE
Fix assigned filter tag style

### DIFF
--- a/app/javascript/tagging/components/InnerComponents/Tag.js
+++ b/app/javascript/tagging/components/InnerComponents/Tag.js
@@ -41,7 +41,9 @@ const Tag = ({
         className="tagColor"
         title={tagValue.description}
       >
-        {truncate(tagValue.description)}
+        <div className="value-label">
+          {truncate(tagValue.description)}
+        </div>
       </FormLabel>
     </li>
   );
@@ -52,12 +54,13 @@ Tag.propTypes = {
   tagCategory: TaggingPropTypes.category,
   tagValue: TaggingPropTypes.value,
   truncate: PropTypes.func.isRequired,
-  showCloseButton: PropTypes.bool.isRequired,
+  showCloseButton: PropTypes.bool,
 };
 
 Tag.defaultProps = {
   tagCategory: undefined,
   tagValue: undefined,
+  showCloseButton: false,
 };
 
 export default Tag;

--- a/app/javascript/tagging/sass/_tag.scss
+++ b/app/javascript/tagging/sass/_tag.scss
@@ -36,6 +36,11 @@
 
 .value-label {
   background-color: #78a9ff;
+  height: 26px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0 5px;
 
   .value-span {
     padding-left: 0.5rem;

--- a/app/javascript/tagging/tests/__snapshots__/tag.test.js.snap
+++ b/app/javascript/tagging/tests/__snapshots__/tag.test.js.snap
@@ -10,6 +10,10 @@ exports[`Tag Component match snapshot 1`] = `
     id="tag_value_1"
     key="1"
     title="duck"
-  />
+  >
+    <div
+      className="value-label"
+    />
+  </FormLabel>
 </li>
 `;

--- a/app/views/ops/rbac_group/_customer_tags.html.haml
+++ b/app/views/ops/rbac_group/_customer_tags.html.haml
@@ -20,7 +20,8 @@
     - if @edit[:new][:use_filter_expression]
       = render(:partial => "layouts/group_filter_expression")
     - else
-      = react 'TaggingWrapperConnected', { :tags => @tags, :urls => @button_urls, :options => { :hideHeaders => true, :hideButtons => true,  :url => url_for_only_path(:action => 'rbac_group_field_changed')} }
+      .tagging-container
+        = react 'TaggingWrapperConnected', {:tags => @tags, :urls => @button_urls, :options => {:hideHeaders => false, :hideButtons => true, :url => url_for_only_path(:action => 'rbac_group_field_changed')}}
   - elsif @use_filter_expression
     = render(:partial => "layouts/group_filter_expression")
   - else
@@ -30,4 +31,4 @@
     - if @tags[:assignedTags].blank?
       = _('There are not tags assigned to this group.')
     - else
-      = react 'TagView', { :assignedTags => @tags[:assignedTags], :hideHeader => true }
+      = react 'TagView', {:assignedTags => @tags[:assignedTags], :hideHeader => true, :showCloseButton => false}


### PR DESCRIPTION
**Before**
<img width="1532" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/ce6bf829-c32a-4be0-b110-843fd79502bf">

**After** - Reused the tags designs (like we have for service catalogs)
<img width="1528" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/2eac04ab-6df3-480f-9cf0-0dc89123f588">

**Before** - The assigned filters tags had a close button which dose nothing
<img width="1531" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/62678bf2-0c39-468a-8b56-1585778b7cf7">

**After** - Removed the close button for the tags
<img width="1523" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/19774ff1-f4cf-4641-a8c6-de7114796e53">
