### PR TITLE
Fix TaggingModifier test case

### DIFF
--- a/app/javascript/tagging/components/InnerComponents/ValueModifier.js
+++ b/app/javascript/tagging/components/InnerComponents/ValueModifier.js
@@ -35,7 +35,7 @@ ValueModifier.propTypes = {
 };
 
 ValueModifier.defaultProps = {
-  selectedTagValues: {},
+  selectedTagValues: [],
   valueLabel: __('Value'),
   multiValue: true,
   isDisabled: false,

--- a/app/javascript/tagging/tests/__snapshots__/tag.modifier.test.js.snap
+++ b/app/javascript/tagging/tests/__snapshots__/tag.modifier.test.js.snap
@@ -58,7 +58,7 @@ exports[`Tagging modifier match snapshot 1`] = `
           "id": 1,
         }
       }
-      selectedTagValues={Object {}}
+      selectedTagValues={Array []}
       valueLabel="Value"
       values={
         Array [

--- a/app/javascript/tagging/tests/value.modifier.test.js
+++ b/app/javascript/tagging/tests/value.modifier.test.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ValueModifier from '../components/InnerComponents/ValueModifier';
 import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
+import ValueModifier from '../components/InnerComponents/ValueModifier';
 
 const selectedTagValue = [{ description: 'Duck', id: 1 }];
 const onTagValueChange = jest.fn();
 const tagValues = [
   { description: 'Duck', id: 1 },
   { description: 'Cat', id: 2 },
-  { description: 'Dog', id: 3 }
+  { description: 'Dog', id: 3 },
 ];
 
 describe('TagCategory Component', () => {


### PR DESCRIPTION
`yarn run jest -t 'Tagging modifier' --testPathPattern app/javascript/tagging/tests/tag.selector.test.js`

**Before**
`Warning: Failed prop type: Invalid prop selectedTagValues of type object supplied to ValueModifier, expected an array in ValueModifier`

**After**
```
 PASS  app/javascript/tagging/tests/tag.selector.test.js
  Tagging modifier
    ✓ match snapshot (17ms)
    ✓ should call methods (2ms)
```