### PR TITLE
Fix AnsiblePlaybookWorkflow test case

### DIFF
--- a/app/javascript/components/ansible-playbook-workflow/index.jsx
+++ b/app/javascript/components/ansible-playbook-workflow/index.jsx
@@ -48,8 +48,12 @@ const AnsiblePlaybookWorkflow = ({ payload, payloadType }) => {
 };
 
 AnsiblePlaybookWorkflow.propTypes = {
-  payload: PropTypes.string.isRequired,
+  payload: PropTypes.string,
   payloadType: PropTypes.string.isRequired,
+};
+
+AnsiblePlaybookWorkflow.defaultProps = {
+  payload: undefined,
 };
 
 export default AnsiblePlaybookWorkflow;


### PR DESCRIPTION
`yarn run jest -t 'AnsiblePlaybookWorkflow component' --testPathPattern app/javascript/spec/ansible-playbook-workflow/ansible-playbook-workflow.spec.js`

Before
`Warning: Failed prop type: The prop payload is marked as required in AnsiblePlaybookWorkflow, but its value is undefined in AnsiblePlaybookWorkflow`

After
 ```
PASS  app/javascript/spec/ansible-playbook-workflow/ansible-playbook-workflow.spec.js
  AnsiblePlaybookWorkflow component
    ✓ should render the AnsiblePlaybookWorkflow with payload (29ms)
    ✓ should render the AnsiblePlaybookWorkflow without payload and display a notification (164ms)
```