### PR TITLE
Fix MiqCustomTab test cases

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -60,18 +60,18 @@ module CatalogHelper
 
   def catalog_tab_configuration(record)
     condition = catalog_tab_conditions(record)
-    tab_labels = [tab_label(:basic)]
-    tab_labels.push(tab_label(:detail)) if condition[:detail]
+    tab_labels = [:basic]
+    tab_labels.push(:detail) if condition[:detail]
 
     if condition[:resource]
-      tab_labels.push(tab_label(:resource))
+      tab_labels.push(:resource)
     elsif condition[:request]
-      tab_labels.push(tab_label(:request))
+      tab_labels.push(:request)
     end
 
     if condition[:provision]
-      tab_labels.push(tab_label(:provision))
-      tab_labels.push(tab_label(:retirement)) if condition[:retirement]
+      tab_labels.push(:provision)
+      tab_labels.push(:retirement) if condition[:retirement]
     end
 
     return tab_labels, condition
@@ -79,19 +79,15 @@ module CatalogHelper
 
   def catalog_tab_edit_configuration(record)
     condition = catalog_tab_edit_conditions(record)
-    tab_labels = [tab_label(:basic)]
-    tab_labels.push(tab_label(:detail)) if condition[:detail]
-    tab_labels.push(tab_label(:resource)) if condition[:resource]
-    tab_labels.push(tab_label(:request)) if condition[:request]
+    tab_labels = [:basic]
+    tab_labels.push(:detail) if condition[:detail]
+    tab_labels.push(:resource) if condition[:resource]
+    tab_labels.push(:request) if condition[:request]
     return tab_labels, condition
   end
 
-  def catalog_tab_edit_generic_configuration
-    [tab_label(:basic), tab_label(:provision), tab_label(:retirement)]
-  end
-
   def catalog_tab_content(key_name, &block)
-    if catalog_tabs_types[key_name]
+    if catalog_tabs_types.include?(key_name)
       class_name = key_name == :basic ? 'tab_content active' : 'tab_content'
       content_tag(:div, :id => key_name, :class => class_name, &block)
     end
@@ -253,14 +249,7 @@ module CatalogHelper
   private
 
   def catalog_tabs_types
-    {
-      :basic      => _('Basic Information'),
-      :detail     => _('Details'),
-      :resource   => _('Selected Resources'),
-      :request    => _('Request Info'),
-      :provision  => _('Provisioning'),
-      :retirement => _('Retirement')
-    }
+    [:basic, :detail, :resource, :request, :provision, :retirement]
   end
 
   def catalog_tab_conditions(record)
@@ -296,10 +285,6 @@ module CatalogHelper
 
   def catalog_provision?(record, type)
     record.prov_type == catalog_provision_types[type]
-  end
-
-  def tab_label(item)
-    {:name => item, :text => catalog_tabs_types[item]}
   end
 
   # Method which return true if workflows are behing prototype flag.

--- a/app/helpers/request_info_helper.rb
+++ b/app/helpers/request_info_helper.rb
@@ -6,9 +6,7 @@ module RequestInfoHelper
   PROV_FIELDS = [:src_vm_id, :placement_host_name, :placement_ds_name, :attached_ds, :sysprep_custom_spec, :customization_template_id, :pxe_image_id, :iso_image_id, :windows_image_id].freeze
 
   def provision_tab_configuration(workflow)
-    prov_tab_labels = workflow.provisioning_tab_list.map do |dialog|
-      {:name => dialog[:name], :text => dialog[:description]}
-    end
+    prov_tab_labels = workflow.provisioning_tab_list.pluck(:name)
     return prov_tab_labels, workflow.get_dialog_order
   end
 

--- a/app/helpers/utilization_helper.rb
+++ b/app/helpers/utilization_helper.rb
@@ -1,24 +1,12 @@
 module UtilizationHelper
   def utilization_tab_configuration
-    [:summary, :details, :report].map do |item|
-      {:name => item, :text => utilization_tabs_types[item]}
-    end
+    [:summary, :details, :report]
   end
 
   def utilization_tab_content(key_name, &block)
-    if utilization_tabs_types[key_name]
+    if utilization_tab_configuration.include?(key_name)
       class_name = key_name == :summary ? 'tab_content active' : 'tab_content'
       tag.div(:id => key_name, :class => class_name, &block)
     end
-  end
-
-  private
-
-  def utilization_tabs_types
-    {
-      :summary => _('Summary'),
-      :details => _('Details'),
-      :report  => _('Report'),
-    }
   end
 end

--- a/app/javascript/components/miq-custom-tab/helper.js
+++ b/app/javascript/components/miq-custom-tab/helper.js
@@ -1,0 +1,49 @@
+/** Tab labels used for catalog summary and edit pages */
+const catalog = {
+  basic: __('Basic Information'),
+  detail: __('Details'),
+  resource: __('Selected Resources'),
+  request: __('Request Info'),
+  provision: __('Provisioning'),
+  retirement: __('Retirement'),
+};
+
+/** Tab labels used for Utilization page. */
+const utilization = {
+  summary: __('Summary'),
+  details: __('Details'),
+  report: __('Report'),
+};
+
+/** Tab labels used for request info contents under catalog page. */
+const requestInfo = {
+  requester: __('Requester'),
+  purpose: __('Purpose'),
+  service: __('Catalog'),
+  environment: __('Environment'),
+  hardware: __('Properties'),
+  customize: __('Customize'),
+  schedule: __('Schedule'),
+  volumes: __('Volumes'),
+  network: __('Network'),
+};
+
+/** Function to select the tab labels. */
+export const labelConfig = (type) => {
+  const configMap = {
+    CATALOG_SUMMARY: catalog,
+    CATALOG_EDIT: catalog,
+    UTILIZATION: utilization,
+    CATALOG_REQUEST_INFO: requestInfo,
+  };
+
+  return configMap[type];
+};
+
+/** Function to find the tab text from the selectedLabels and label */
+export const tabText = (selectedLabels, label) => {
+  if (selectedLabels) {
+    return selectedLabels[label] ? selectedLabels[label] : label;
+  }
+  return __('Unknown');
+};

--- a/app/javascript/components/miq-custom-tab/index.jsx
+++ b/app/javascript/components/miq-custom-tab/index.jsx
@@ -3,10 +3,20 @@ import PropTypes from 'prop-types';
 import { Tabs, Tab } from 'carbon-components-react';
 import { useDispatch } from 'react-redux';
 import { miqCustomTabActions } from '../../miq-redux/actions/miq-custom-tab-actions';
+import { labelConfig, tabText } from './helper';
 
 const MiqCustomTab = ({ containerId, tabLabels, type }) => {
   const dispatch = useDispatch();
   const [data, setData] = useState({ loading: false });
+
+  /** Labels used for a Tab found from the 'type'. */
+  const selectedLabels = labelConfig(type);
+
+  /** Configuration for tabs using this component.
+   * type: Unique string used to identify the tab component.
+   * js: Returns a function that gets executed on tab onClick event.
+   * url: Redirects to the specified url on tab onClick event.
+   */
   const tabConfigurations = (name) => [
     { type: 'AE-RESOLVE-OPTIONS' },
     { type: 'CATALOG_SUMMARY' },
@@ -56,7 +66,7 @@ const MiqCustomTab = ({ containerId, tabLabels, type }) => {
   };
 
   /** Function to load tab contents after a url is executed.
-   *  After the url is executed, the selected tab contents are displayes using the staticContents function.
+   *  After the url is executed, the selected tab contents are displays using the staticContents function.
   */
   const dynamicContents = (name, config) => {
     clearTabContents();
@@ -66,7 +76,7 @@ const MiqCustomTab = ({ containerId, tabLabels, type }) => {
     });
   };
 
-  /** Function to hande tab click events. */
+  /** Function to handle tab click events. */
   const onTabSelect = (name) => {
     if (!data.loading) {
       miqSparkleOn();
@@ -77,8 +87,8 @@ const MiqCustomTab = ({ containerId, tabLabels, type }) => {
   };
 
   /** Function to render the tabs from the tabLabels props */
-  const renderTabs = () => tabLabels.map(({ name, text }) => (
-    <Tab key={`tab${name}`} label={`${text}`} onClick={() => onTabSelect(name)} />
+  const renderTabs = () => tabLabels.map((label) => (
+    <Tab key={`tab${label}`} label={`${tabText(selectedLabels, label)}`} onClick={() => onTabSelect(label)} />
   ));
 
   return (
@@ -92,9 +102,6 @@ export default MiqCustomTab;
 
 MiqCustomTab.propTypes = {
   containerId: PropTypes.string.isRequired,
-  tabLabels: PropTypes.arrayOf(PropTypes.shape({
-    name: PropTypes.string,
-    text: PropTypes.string,
-  })).isRequired,
+  tabLabels: PropTypes.arrayOf(PropTypes.string).isRequired,
   type: PropTypes.string.isRequired,
 };

--- a/app/javascript/spec/miq-custom-tab/__snapshots__/miq-custom-tab.spec.js.snap
+++ b/app/javascript/spec/miq-custom-tab/__snapshots__/miq-custom-tab.spec.js.snap
@@ -18,18 +18,9 @@ exports[`MiqCustomTab component should render tabs for catalog edit page 1`] = `
       containerId="catalog-edit-tabs"
       tabLabels={
         Array [
-          Object {
-            "name": "basic",
-            "text": "Basic Information",
-          },
-          Object {
-            "name": "detail",
-            "text": "Details",
-          },
-          Object {
-            "name": "resource",
-            "text": "Selected Resources",
-          },
+          "basic",
+          "detail",
+          "resource",
         ]
       }
       type="CATALOG_EDIT"
@@ -278,18 +269,9 @@ exports[`MiqCustomTab component should render tabs for catalog summary page 1`] 
       containerId="catalog-tabs"
       tabLabels={
         Array [
-          Object {
-            "name": "basic",
-            "text": "Basic Information",
-          },
-          Object {
-            "name": "detail",
-            "text": "Details",
-          },
-          Object {
-            "name": "resource",
-            "text": "Selected Resources",
-          },
+          "basic",
+          "detail",
+          "resource",
         ]
       }
       type="CATALOG_SUMMARY"
@@ -538,34 +520,13 @@ exports[`MiqCustomTab component should render tabs for request info page under c
       containerId="request-info-tabs"
       tabLabels={
         Array [
-          Object {
-            "name": "requester",
-            "text": "Requester",
-          },
-          Object {
-            "name": "purpose",
-            "text": "Purpose",
-          },
-          Object {
-            "name": "service",
-            "text": "Catalog",
-          },
-          Object {
-            "name": "environment",
-            "text": "Environment",
-          },
-          Object {
-            "name": "hardware",
-            "text": "Properties",
-          },
-          Object {
-            "name": "customize",
-            "text": "Customize",
-          },
-          Object {
-            "name": "schedule",
-            "text": "Schedule",
-          },
+          "requester",
+          "purpose",
+          "service",
+          "environment",
+          "hardware",
+          "customize",
+          "schedule",
         ]
       }
       type="CATALOG_REQUEST_INFO"

--- a/app/javascript/spec/miq-custom-tab/miq-custom-tab.spec.js
+++ b/app/javascript/spec/miq-custom-tab/miq-custom-tab.spec.js
@@ -23,11 +23,7 @@ describe('MiqCustomTab component', () => {
   };
 
   it('should render tabs for catalog summary page', () => {
-    const tabLabels = [
-      { name: 'basic', text: _('Basic Information') },
-      { name: 'detail', text: _('Details') },
-      { name: 'resource', text: _('Selected Resources') },
-    ];
+    const tabLabels = ['basic', 'detail', 'resource'];
     const wrapper = reduxMount(<MiqCustomTab
       containerId="catalog-tabs"
       tabLabels={tabLabels}
@@ -38,15 +34,7 @@ describe('MiqCustomTab component', () => {
   });
 
   it('should render tabs for request info page under catalog summary page', () => {
-    const tabLabels = [
-      { name: 'requester', text: _('Requester') },
-      { name: 'purpose', text: _('Purpose') },
-      { name: 'service', text: _('Catalog') },
-      { name: 'environment', text: _('Environment') },
-      { name: 'hardware', text: _('Properties') },
-      { name: 'customize', text: _('Customize') },
-      { name: 'schedule', text: _('Schedule') },
-    ];
+    const tabLabels = ['requester', 'purpose', 'service', 'environment', 'hardware', 'customize', 'schedule'];
     const wrapper = reduxMount(<MiqCustomTab
       containerId="request-info-tabs"
       tabLabels={tabLabels}
@@ -57,11 +45,7 @@ describe('MiqCustomTab component', () => {
   });
 
   it('should render tabs for catalog edit page', () => {
-    const tabLabels = [
-      { name: 'basic', text: _('Basic Information') },
-      { name: 'detail', text: _('Details') },
-      { name: 'resource', text: _('Selected Resources') },
-    ];
+    const tabLabels = ['basic', 'detail', 'resource'];
     const wrapper = reduxMount(<MiqCustomTab
       containerId="catalog-edit-tabs"
       tabLabels={tabLabels}


### PR DESCRIPTION
`yarn run jest -t 'MiqCustomTab component' --testPathPattern app/javascript/spec/miq-custom-tab/miq-custom-tab.spec.js`

**Before**
The data used in test case had objects like these,  eg: ` { name: 'requester', text: __('Requester') }`

The `text` was returning an object when we marked the string for translation which resulted in invalid prop types.
```
 Warning: Failed prop type: Invalid prop `tabLabels[0].text` of type `object` supplied to `MiqCustomTab`, expected `string`.
        in MiqCustomTab
```




**After**

- Refactored the component.
- Removed a few helper methods.
- Fixed the test cases.
- Verified that all `MiqCustomTab` is working as expected.

```
PASS  app/javascript/spec/miq-custom-tab/miq-custom-tab.spec.js
  MiqCustomTab component
    ✓ should render tabs for catalog summary page (129ms)
    ✓ should render tabs for request info page under catalog summary page (40ms)
    ✓ should render tabs for catalog edit page (22ms)
```