### PR TITLE
Fix workflow credentials page link to repositories

### DIFF
--- a/app/views/workflow_credential/show.html.haml
+++ b/app/views/workflow_credential/show.html.haml
@@ -1,2 +1,5 @@
 #main_div
-  = render :partial => 'layouts/textual_groups_generic'
+  - if %w[repositories].include?(@display)
+    = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
+  - else
+    = render :partial => 'layouts/textual_groups_generic'


### PR DESCRIPTION
Fix link to the repositories table on the workflow credentials page.

Before:
Clicking on the number for the repositories won't load the new page.
![Screenshot 2024-03-20 at 10 45 13 AM](https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/16e042dd-9072-4b8e-9546-4750c3e4dec5)

After:
Clicking on the number for the repositories loads the table for the repositories linked to this credential.
![Screenshot 2024-03-20 at 10 45 40 AM](https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/041ccc03-3b0e-4b5a-82e0-db5834d112ba)
