### PR TITLE
Fix TimelineTable test case

### DIFF
--- a/app/javascript/components/timeline-options/timeline-table.jsx
+++ b/app/javascript/components/timeline-options/timeline-table.jsx
@@ -51,20 +51,31 @@ const TimelineTable = ({ data }) => {
    * for the VM & Templates page
    */
 
-  const TimestampLabel = (
+  const renderTimeStampLabel = () => (
     <label className="bx--label">
-      {sprintf(__('This is a group of events that happened on %s.'), Date(data[0].timestamp))}
+      {
+        sprintf(__('This is a group of events that happened on %s.'), Date(data[0].timestamp))
+      }
     </label>
   );
 
   return (
     <div className="timeline-data-table">
-      {TimestampLabel}
-      <MiqDataTable
-        rows={data}
-        headers={headers}
-        truncateText={false}
-      />
+      {
+        data && data.length > 0 && (
+          <>
+            {
+              data[0].timeline && renderTimeStampLabel()
+            }
+            <MiqDataTable
+              rows={data}
+              headers={headers}
+              truncateText={false}
+            />
+          </>
+        )
+      }
+
     </div>
 
   );

--- a/app/javascript/spec/timeline-options-form/timeline-table.spec.js
+++ b/app/javascript/spec/timeline-options-form/timeline-table.spec.js
@@ -12,7 +12,7 @@ describe('Show Timeline Page', () => {
   it('should render empty page', async(done) => {
     let wrapper;
     await act(async() => {
-      wrapper = mount(<TimelineTable />);
+      wrapper = mount(<TimelineTable data={[]} />);
     });
     setImmediate(() => {
       wrapper.update();


### PR DESCRIPTION
Before
 ```
PASS  app/javascript/spec/timeline-options-form/timeline-table.spec.js
  Show Timeline Page
    ✓ should render empty page (65ms)
    ✓ should render a table with data (16ms)

  console.error node_modules/prop-types/checkPropTypes.js:20
    Warning: Failed prop type: The prop `rows[0].id` is marked as required in `DataTable`, but its value is `undefined`.
        in DataTable (created by MiqDataTable)
        in MiqDataTable (created by TimelineTable)
        in div (created by TimelineTable)
        in TimelineTable
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react/cjs/react.development.js:315
    Warning: Each child in a list should have a unique "key" prop.
    
    Check the render method of `DataTable`. See https://fb.me/react-warning-keys for more information.
        in TableRow (created by DataTable)
        in DataTable (created by MiqDataTable)
        in div (created by MiqDataTable)
        in MiqDataTable (created by TimelineTable)
        in div (created by TimelineTable)
        in TimelineTable
        in Provider (created by WrapperComponent)
        in WrapperComponent

```

After
```
 PASS  app/javascript/spec/timeline-options-form/timeline-table.spec.js
  Show Timeline Page
    ✓ should render empty page (27ms)
    ✓ should render a table with data (35ms)
```
