### PR TITLE
Fix MiqAlertSetStructuredList test case

### DIFF
--- a/app/javascript/spec/miq-alert-set/__snapshots__/miq-alert-set.spec.js.snap
+++ b/app/javascript/spec/miq-alert-set/__snapshots__/miq-alert-set.spec.js.snap
@@ -1,110 +1,150 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MiqAlertSetStructuredList should render alert set alerts structured list 1`] = `
-<FeatureToggle(StructuredListWrapper)
-  ariaLabel="Structured list"
-  className="miq-structured-list miq_alert_set"
+<Accordion
+  align="start"
+  className="miq-structured-list-accordion miq_alert_set"
 >
-  <MiqStructuredListBody
-    clickEvents={false}
-    mode="miq_alert_set"
-    rows={
-      Array [
-        Object {
-          "cells": Array [
+  <AccordionItem
+    open={true}
+    title="Alerts"
+  >
+    <FeatureToggle(StructuredListWrapper)
+      ariaLabel="Structured list"
+      className="miq-structured-list miq_alert_set"
+    >
+      <MiqStructuredListBody
+        clickEvents={false}
+        mode="miq_alert_set"
+        rows={
+          Array [
             Object {
-              "icon": "pficon pficon-warning-triangle-o",
-              "value": "Alert description",
+              "cells": Array [
+                Object {
+                  "icon": "pficon pficon-warning-triangle-o",
+                  "value": "Alert description",
+                },
+              ],
+              "onclick": Object {
+                "url": "/miq_alert/show/1",
+              },
+              "title": "View this Alert",
             },
-          ],
-          "onclick": Object {
-            "url": "/miq_alert/show/1",
-          },
-          "title": "View this Alert",
-        },
-      ]
-    }
-  />
-</FeatureToggle(StructuredListWrapper)>
+          ]
+        }
+      />
+    </FeatureToggle(StructuredListWrapper)>
+  </AccordionItem>
+</Accordion>
 `;
 
 exports[`MiqAlertSetStructuredList should render alert set assigned structured list 1`] = `
-<FeatureToggle(StructuredListWrapper)
-  ariaLabel="Structured list"
-  className="miq-structured-list miq_alert_set_assigned"
+<Accordion
+  align="start"
+  className="miq-structured-list-accordion miq_alert_set_assigned"
 >
-  <MiqStructuredListBody
-    clickEvents={false}
-    mode="miq_alert_set_assigned"
-    rows={
-      Array [
-        Object {
-          "label": "The Enterprise",
-        },
-        Object {
-          "label": "Object class",
-          "value": Array [
+  <AccordionItem
+    open={true}
+    title="Assigned To"
+  >
+    <FeatureToggle(StructuredListWrapper)
+      ariaLabel="Structured list"
+      className="miq-structured-list miq_alert_set_assigned"
+    >
+      <MiqStructuredListBody
+        clickEvents={false}
+        mode="miq_alert_set_assigned"
+        rows={
+          Array [
             Object {
-              "value": "path1",
+              "label": "The Enterprise",
             },
             Object {
-              "value": "path2",
+              "label": "Object class",
+              "value": Array [
+                Object {
+                  "value": "path1",
+                },
+                Object {
+                  "value": "path2",
+                },
+                Object {
+                  "value": "path3",
+                },
+              ],
             },
-            Object {
-              "value": "path3",
-            },
-          ],
-        },
-      ]
-    }
-  />
-</FeatureToggle(StructuredListWrapper)>
+          ]
+        }
+      />
+    </FeatureToggle(StructuredListWrapper)>
+  </AccordionItem>
+</Accordion>
 `;
 
 exports[`MiqAlertSetStructuredList should render alert set info structured list 1`] = `
-<FeatureToggle(StructuredListWrapper)
-  ariaLabel="Structured list"
-  className="miq-structured-list miq_alert_set_info"
+<Accordion
+  align="start"
+  className="miq-structured-list-accordion miq_alert_set_info"
 >
-  <MiqStructuredListBody
-    clickEvents={false}
-    mode="miq_alert_set_info"
-    rows={
-      Array [
-        Object {
-          "label": "Description",
-          "value": "bar",
-        },
-        Object {
-          "label": "Mode",
-          "value": "Mode",
-        },
-      ]
-    }
-  />
-</FeatureToggle(StructuredListWrapper)>
+  <AccordionItem
+    open={true}
+    title="Basic Information"
+  >
+    <FeatureToggle(StructuredListWrapper)
+      ariaLabel="Structured list"
+      className="miq-structured-list miq_alert_set_info"
+    >
+      <MiqStructuredListBody
+        clickEvents={false}
+        mode="miq_alert_set_info"
+        rows={
+          Array [
+            Object {
+              "label": "Description",
+              "value": "bar",
+            },
+            Object {
+              "label": "Mode",
+              "value": "Mode",
+            },
+          ]
+        }
+      />
+    </FeatureToggle(StructuredListWrapper)>
+  </AccordionItem>
+</Accordion>
 `;
 
 exports[`MiqAlertSetStructuredList should render alert set notes structured list 1`] = `
-<FeatureToggle(StructuredListWrapper)
-  ariaLabel="Structured list"
-  className="miq-structured-list miq_alert_set_notes"
+<Accordion
+  align="start"
+  className="miq-structured-list-accordion miq_alert_set_notes"
 >
-  <MiqStructuredListBody
-    clickEvents={false}
-    mode="miq_alert_set_notes"
-    rows={
-      Array [
-        Object {
-          "value": Object {
-            "input": "text_area",
-            "readonly": true,
-            "rows": 4,
-            "text": "text area description",
-          },
-        },
-      ]
-    }
-  />
-</FeatureToggle(StructuredListWrapper)>
+  <AccordionItem
+    open={true}
+    title="Notes"
+  >
+    <FeatureToggle(StructuredListWrapper)
+      ariaLabel="Structured list"
+      className="miq-structured-list miq_alert_set_notes"
+    >
+      <MiqStructuredListBody
+        clickEvents={false}
+        mode="miq_alert_set_notes"
+        rows={
+          Array [
+            Object {
+              "value": Object {
+                "input": "text_area",
+                "readonly": true,
+                "rows": 4,
+                "text": "text area description",
+              },
+            },
+          ]
+        }
+      />
+    </FeatureToggle(StructuredListWrapper)>
+  </AccordionItem>
+</Accordion>
 `;

--- a/app/javascript/spec/miq-alert-set/miq-alert-set.data.js
+++ b/app/javascript/spec/miq-alert-set/miq-alert-set.data.js
@@ -1,17 +1,17 @@
 export const infoData = {
-  title: _('Basic Information'),
+  title: __('Basic Information'),
   mode: 'miq_alert_set_info',
   items: [
-    { label: _('Description'), value: 'bar' },
-    { label: _('Mode'), value: 'Mode' },
+    { label: __('Description'), value: 'bar' },
+    { label: __('Mode'), value: 'Mode' },
   ],
 };
 
 export const alertSetAssignedData = {
-  title: _('Assigned To'),
+  title: __('Assigned To'),
   mode: 'miq_alert_set_assigned',
   items: [
-    { label: _('The Enterprise') },
+    { label: __('The Enterprise') },
     {
       label: 'Object class',
       value: [
@@ -24,7 +24,7 @@ export const alertSetAssignedData = {
 };
 
 export const alertSetNotes = {
-  title: _('Notes'),
+  title: __('Notes'),
   mode: 'miq_alert_set_notes',
   items: [
     {
@@ -36,9 +36,9 @@ export const alertSetNotes = {
 };
 
 export const alertSetAlerts = {
-  title: _('Alerts'),
+  title: __('Alerts'),
   mode: 'miq_alert_set',
-  message: _('This Action is not assigned to any Policies.'),
+  message: __('This Action is not assigned to any Policies.'),
   items: [
     {
       cells: [


### PR DESCRIPTION
Before
 ```
PASS  app/javascript/spec/miq-alert-set/miq-alert-set.spec.js
  MiqAlertSetStructuredList
    ✓ should render alert set info structured list (11ms)
    ✓ should render alert set assigned structured list (1ms)
    ✓ should render alert set notes structured list (1ms)
    ✓ should render alert set alerts structured list

  console.error node_modules/prop-types/checkPropTypes.js:20
    Warning: Failed prop type: Invalid prop `title` of type `object` supplied to `MiqStructuredList`, expected `string`.
        in MiqStructuredList
```

After
```
PASS  app/javascript/spec/miq-alert-set/miq-alert-set.spec.js
  MiqAlertSetStructuredList
    ✓ should render alert set info structured list (8ms)
    ✓ should render alert set assigned structured list (2ms)
    ✓ should render alert set notes structured list (1ms)
    ✓ should render alert set alerts structured list (1ms)
```