### PR TITLE
Fix workflow credentials side menu

### DIFF
--- a/app/controllers/workflow_credential_controller.rb
+++ b/app/controllers/workflow_credential_controller.rb
@@ -12,7 +12,7 @@ class WorkflowCredentialController < ApplicationController
   include Mixins::BreadcrumbsMixin
   include Mixins::WorkflowCheckPrototypeMixin
 
-  menu_section :workflow_credentials
+  menu_section :embedded_workflow_credentials
 
   def self.display_methods
     %w[repositories]


### PR DESCRIPTION
Fixed issue with workflow credentials page side nav menu item. When on this page the blue indicator showing what page you are on was missing as well as the sub menu would not be open when on looking at the side nav menu while on this page.

Before:
<img width="1698" alt="Screenshot 2024-03-21 at 12 39 44 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/e4dafc9b-7e32-41b3-b6cc-2b3970784ab4">
<img width="1095" alt="Screenshot 2024-03-21 at 12 03 01 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/06c91f69-45a7-479f-a4cb-c3d39152bf7f">

After:
<img width="1699" alt="Screenshot 2024-03-21 at 12 38 36 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/866a751a-3072-4ec6-9ad2-46be43dc19bb">
<img width="991" alt="Screenshot 2024-03-21 at 12 00 26 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/41a0bc3a-4840-4c78-a3c9-0d00f545995f">