### PR TITLE
Fix NotificationMessage test case

### DIFF
--- a/app/javascript/spec/notification-message/__snapshots__/notification-message.spec.js.snap
+++ b/app/javascript/spec/notification-message/__snapshots__/notification-message.spec.js.snap
@@ -9,7 +9,7 @@ exports[`NotificationMessage component blank message should not render message 1
 
 exports[`NotificationMessage component invalid type should not render message 1`] = `
 <NotificationMessage
-  message={"No message will be displayed"}
+  message="No message will be displayed"
   type="unknown"
 >
   <div
@@ -19,7 +19,7 @@ exports[`NotificationMessage component invalid type should not render message 1`
       className="pficon fa fa-regular fa-question-circle"
     />
     <strong>
-      <Component />
+      No message will be displayed
     </strong>
   </div>
 </NotificationMessage>
@@ -27,7 +27,7 @@ exports[`NotificationMessage component invalid type should not render message 1`
 
 exports[`NotificationMessage component should render error message 1`] = `
 <NotificationMessage
-  message={"Error message goes here"}
+  message="Error message goes here"
   type="error"
 >
   <div
@@ -37,7 +37,7 @@ exports[`NotificationMessage component should render error message 1`] = `
       className="pficon pficon-error-circle-o"
     />
     <strong>
-      <Component />
+      Error message goes here
     </strong>
   </div>
 </NotificationMessage>
@@ -45,7 +45,7 @@ exports[`NotificationMessage component should render error message 1`] = `
 
 exports[`NotificationMessage component should render information message 1`] = `
 <NotificationMessage
-  message={"Information message goes here"}
+  message="Information message goes here"
   type="info"
 >
   <div
@@ -55,7 +55,7 @@ exports[`NotificationMessage component should render information message 1`] = `
       className="pficon pficon-info"
     />
     <strong>
-      <Component />
+      Information message goes here
     </strong>
   </div>
 </NotificationMessage>
@@ -63,7 +63,7 @@ exports[`NotificationMessage component should render information message 1`] = `
 
 exports[`NotificationMessage component should render success message 1`] = `
 <NotificationMessage
-  message={"Success message goes here"}
+  message="Success message goes here"
   type="success"
 >
   <div
@@ -73,7 +73,7 @@ exports[`NotificationMessage component should render success message 1`] = `
       className="pficon pficon-ok"
     />
     <strong>
-      <Component />
+      Success message goes here
     </strong>
   </div>
 </NotificationMessage>
@@ -81,7 +81,7 @@ exports[`NotificationMessage component should render success message 1`] = `
 
 exports[`NotificationMessage component should render warning message 1`] = `
 <NotificationMessage
-  message={"Warning message goes here"}
+  message="Warning message goes here"
   type="warning"
 >
   <div
@@ -91,7 +91,7 @@ exports[`NotificationMessage component should render warning message 1`] = `
       className="pficon pficon-warning-triangle-o"
     />
     <strong>
-      <Component />
+      Warning message goes here
     </strong>
   </div>
 </NotificationMessage>
@@ -99,7 +99,7 @@ exports[`NotificationMessage component should render warning message 1`] = `
 
 exports[`NotificationMessage component unknown error type message should be rendered with blank type 1`] = `
 <NotificationMessage
-  message={"Message goes here"}
+  message="Message goes here"
   type=""
 >
   <div
@@ -109,7 +109,7 @@ exports[`NotificationMessage component unknown error type message should be rend
       className="pficon fa fa-regular fa-question-circle"
     />
     <strong>
-      <Component />
+      Message goes here
     </strong>
   </div>
 </NotificationMessage>
@@ -117,7 +117,7 @@ exports[`NotificationMessage component unknown error type message should be rend
 
 exports[`NotificationMessage component unknown error type message should be rendered with no type 1`] = `
 <NotificationMessage
-  message={"Message goes here"}
+  message="Message goes here"
 >
   <div
     className="miq-notification-message-container alert alert-info"
@@ -126,7 +126,7 @@ exports[`NotificationMessage component unknown error type message should be rend
       className="pficon fa fa-regular fa-question-circle"
     />
     <strong>
-      <Component />
+      Message goes here
     </strong>
   </div>
 </NotificationMessage>

--- a/app/javascript/spec/notification-message/notification-message.spec.js
+++ b/app/javascript/spec/notification-message/notification-message.spec.js
@@ -5,35 +5,35 @@ import NotificationMessage from '../../components/notification-message';
 
 describe('NotificationMessage component', () => {
   it('should render error message', () => {
-    const wrapper = mount(<NotificationMessage type="error" message={_('Error message goes here')} />);
+    const wrapper = mount(<NotificationMessage type="error" message={__('Error message goes here')} />);
     expect(toJson(wrapper)).toMatchSnapshot();
     expect(wrapper.find('.alert-danger')).toHaveLength(1);
     expect(wrapper.find('.pficon-error-circle-o')).toHaveLength(1);
   });
 
   it('should render information message', () => {
-    const wrapper = mount(<NotificationMessage type="info" message={_('Information message goes here')} />);
+    const wrapper = mount(<NotificationMessage type="info" message={__('Information message goes here')} />);
     expect(wrapper.find('.alert-info')).toHaveLength(1);
     expect(wrapper.find('.pficon-info')).toHaveLength(1);
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
   it('should render success message', () => {
-    const wrapper = mount(<NotificationMessage type="success" message={_('Success message goes here')} />);
+    const wrapper = mount(<NotificationMessage type="success" message={__('Success message goes here')} />);
     expect(wrapper.find('.alert-success')).toHaveLength(1);
     expect(wrapper.find('.pficon-ok')).toHaveLength(1);
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
   it('should render warning message', () => {
-    const wrapper = mount(<NotificationMessage type="warning" message={_('Warning message goes here')} />);
+    const wrapper = mount(<NotificationMessage type="warning" message={__('Warning message goes here')} />);
     expect(wrapper.find('.alert-warning')).toHaveLength(1);
     expect(wrapper.find('.pficon-warning-triangle-o')).toHaveLength(1);
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
   it('invalid type should not render message', () => {
-    const wrapper = mount(<NotificationMessage type="unknown" message={_('No message will be displayed')} />);
+    const wrapper = mount(<NotificationMessage type="unknown" message={__('No message will be displayed')} />);
     expect(wrapper.find('.miq-notification-message-container')).toHaveLength(1);
     expect(wrapper.find('.fa-question-circle')).toHaveLength(1);
     expect(toJson(wrapper)).toMatchSnapshot();
@@ -46,14 +46,14 @@ describe('NotificationMessage component', () => {
   });
 
   it('unknown error type message should be rendered with blank type', () => {
-    const wrapper = mount(<NotificationMessage type="" message={_('Message goes here')} />);
+    const wrapper = mount(<NotificationMessage type="" message={__('Message goes here')} />);
     expect(wrapper.find('.miq-notification-message-container')).toHaveLength(1);
     expect(wrapper.find('.fa-question-circle')).toHaveLength(1);
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
   it('unknown error type message should be rendered with no type', () => {
-    const wrapper = mount(<NotificationMessage message={_('Message goes here')} />);
+    const wrapper = mount(<NotificationMessage message={__('Message goes here')} />);
     expect(wrapper.find('.miq-notification-message-container')).toHaveLength(1);
     expect(wrapper.find('.fa-question-circle')).toHaveLength(1);
     expect(toJson(wrapper)).toMatchSnapshot();


### PR DESCRIPTION
`yarn run jest -t 'NotificationMessage component' --testPathPattern app/javascript/spec/notification-message/notification-message.spec.js`

Before
```
PASS  app/javascript/spec/notification-message/notification-message.spec.js
  NotificationMessage component
    ✓ should render error message (40ms)
    ✓ should render information message (4ms)
    ✓ should render success message (2ms)
    ✓ should render warning message (3ms)
    ✓ invalid type should not render message (3ms)
    ✓ blank message should not render message (2ms)
    ✓ unknown error type message should be rendered with blank type (3ms)
    ✓ unknown error type message should be rendered with no type (3ms)

  console.error node_modules/prop-types/checkPropTypes.js:20
    Warning: Failed prop type: Invalid prop `message` of type `object` supplied to `NotificationMessage`, expected `string`.
        in NotificationMessage
```

After
```
PASS  app/javascript/spec/notification-message/notification-message.spec.js
  NotificationMessage component
    ✓ should render error message (35ms)
    ✓ should render information message (4ms)
    ✓ should render success message (3ms)
    ✓ should render warning message (3ms)
    ✓ invalid type should not render message (3ms)
    ✓ blank message should not render message (2ms)
    ✓ unknown error type message should be rendered with blank type (3ms)
    ✓ unknown error type message should be rendered with no type (2ms)
```