### PR TITLE
Fix CustomButtonForm test case

### DIFF
--- a/app/javascript/spec/custom-buttom-form/__snapshots__/custom-button-form.spec.js.snap
+++ b/app/javascript/spec/custom-buttom-form/__snapshots__/custom-button-form.spec.js.snap
@@ -412,7 +412,7 @@ exports[`Custom Button form component should edit a generic object custom button
         "parse_provider_category",
       ]
     }
-    recId="128"
+    recId={128}
     url="/generic_object_definition/show_list"
   >
     <Loading
@@ -459,7 +459,7 @@ exports[`Custom Button form component should edit a generic object custom button
 </Provider>
 `;
 
-exports[`Custom Button form component should render the adding form for generic objbuttons 1`] = `
+exports[`Custom Button form component should render the adding form for generic obj buttons 1`] = `
 <div
   className="col-md-12 button-form"
 >
@@ -871,7 +871,7 @@ exports[`Custom Button form component should render the editing form for generic
         "parse_provider_category",
       ]
     }
-    recId="128"
+    recId={128}
     url="/generic_object_definition/show_list"
   >
     <Loading

--- a/app/javascript/spec/custom-buttom-form/custom-button-form.spec.js
+++ b/app/javascript/spec/custom-buttom-form/custom-button-form.spec.js
@@ -92,7 +92,7 @@ describe('Custom Button form component', () => {
     submitSpy.mockRestore();
   });
 
-  it('should render the adding form for generic objbuttons', () => {
+  it('should render the adding form for generic obj buttons', () => {
     const wrapper = shallow(<CustomButtonForm
       url="/generic_object_definition/show_list"
       appliesToClass="GenericObjectDefinition"
@@ -115,7 +115,7 @@ describe('Custom Button form component', () => {
     let wrapper;
     await act(async() => {
       wrapper = mount(<CustomButtonForm
-        recId="128"
+        recId={128}
         url="/generic_object_definition/show_list"
         appliesToClass="GenericObjectDefinition"
         distinctInstances={distinctInstances}
@@ -202,7 +202,7 @@ describe('Custom Button form component', () => {
     let wrapper;
     await act(async() => {
       wrapper = mount(<CustomButtonForm
-        recId="128"
+        recId={128}
         url="/generic_object_definition/show_list"
         appliesToClass="GenericObjectDefinition"
         distinctInstances={distinctInstances}


### PR DESCRIPTION
`yarn run jest -t 'Custom Button form component' --testPathPattern app/javascript/spec/custom-buttom-form/custom-button-form.spec.js`

Before
```
console.error node_modules/prop-types/checkPropTypes.js:20
    Warning: Failed prop type: Invalid prop `recId` of type `string` supplied to `CustomButtonForm`, expected `number`.
        in CustomButtonForm

  console.error node_modules/prop-types/checkPropTypes.js:20
    Warning: Failed prop type: Invalid prop `recId` of type `string` supplied to `FormTemplate`, expected `number`.
        in FormTemplate (created by FormTemplate)
        in FormTemplate (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by CustomButtonForm)
        in div (created by CustomButtonForm)
        in CustomButtonForm
        in Provider (created by WrapperComponent)
        in WrapperComponent

 PASS  app/javascript/spec/custom-buttom-form/custom-button-form.spec.js
  Custom Button form component
    ✓ should render the adding form for generic objbuttons (15ms)
    ✓ should render the editing form for generic object custom buttons (217ms)
    ✓ should add a new generic object custom button (4ms)
    ✓ should edit a generic object custom button (115ms)
```

After
```
PASS  app/javascript/spec/custom-buttom-form/custom-button-form.spec.js
  Custom Button form component
    ✓ should render the adding form for generic obj buttons (14ms)
    ✓ should render the editing form for generic object custom buttons (151ms)
    ✓ should add a new generic object custom button (3ms)
    ✓ should edit a generic object custom button (82ms)

```