### PR TITLE
Fix embedded page toolbars

### DIFF
--- a/app/controllers/ansible_credential_controller.rb
+++ b/app/controllers/ansible_credential_controller.rb
@@ -30,15 +30,28 @@ class AnsibleCredentialController < ApplicationController
 
   def button
     case params[:pressed]
-    when 'embedded_automation_manager_credentials_add'
+    when "ansible_repositories_reload" # nested list reload
+      javascript_redirect(:action => 'show', :id => params[:id], :display => 'repositories')
+    when 'embedded_configuration_script_source_refresh' # refresh repositories from nested list
+      repository_refresh
+    when 'embedded_automation_manager_credentials_add' # add credential
       javascript_redirect(:action => 'new')
-    when 'embedded_automation_manager_credentials_edit'
+    when 'embedded_configuration_script_source_add' # add repository from nested list
+      javascript_redirect(:controller => "ansible_repository", :action => 'new')
+    when 'embedded_automation_manager_credentials_edit' # edit credential
       javascript_redirect(:action => 'edit', :id => params[:miq_grid_checks])
-    when 'ansible_credential_tag'
+    when 'embedded_configuration_script_source_edit' # edit repository from nested list
+      javascript_redirect(:controller => "ansible_repository", :action => 'edit', :id => params[:miq_grid_checks])
+    when 'ansible_credential_tag' # tag credentials
       tag(self.class.model)
-    when "ansible_repository_tag" # repositories from nested list
+    when "ansible_repository_tag" # tag repositories from nested list
       tag(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource)
     end
+  end
+
+  def check_button_rbac
+    # Allow reload to skip RBAC check
+    %w[ansible_repositories_reload].include?(params[:pressed]) || super
   end
 
   def new
@@ -55,6 +68,23 @@ class AnsibleCredentialController < ApplicationController
                     :url  => "/ansible_credential/edit/#{params[:id]}")
     @in_a_form = true
     @id = auth.id
+  end
+
+  def repository_refresh
+    assert_privileges("embedded_configuration_script_source_refresh")
+    checked = find_checked_items
+    checked[0] = params[:id] if checked.blank? && params[:id]
+
+    AnsibleRepositoryController.model.where(:id => checked).each do |repo|
+      repo.sync_queue
+      add_flash(_("Refresh of Repository \"%{name}\" was successfully initiated.") % {:name => repo.name})
+    rescue StandardError => ex
+      add_flash(_("Unable to refresh Repository \"%{name}\": %{details}") % {:name    => repo.name,
+                                                                             :details => ex},
+                :error)
+    end
+
+    javascript_flash
   end
 
   def toolbar

--- a/app/controllers/ansible_repository_controller.rb
+++ b/app/controllers/ansible_repository_controller.rb
@@ -34,26 +34,28 @@ class AnsibleRepositoryController < ApplicationController
 
   def button
     case params[:pressed]
-    when "embedded_configuration_script_source_edit"
+    when 'embedded_configuration_script_source_refresh' # refresh repositories
+      repository_refresh
+    when "embedded_configuration_script_source_edit" # edit repository
       id = params[:miq_grid_checks]
       javascript_redirect(:action => 'edit', :id => id)
-    when "embedded_configuration_script_source_add"
+    when "embedded_configuration_script_source_add" # add repository
       javascript_redirect(:action => 'new')
-    when "ansible_repositories_reload"
+    when "ansible_repositories_reload" # repositories reload
       show_list
       render :update do |page|
         page << javascript_prologue
         page.replace("gtl_div", :partial => "layouts/gtl")
       end
-    when "ansible_repository_reload"
+    when "ansible_repository_reload" # repository reload
       show
       render :update do |page|
         page << javascript_prologue
         page.replace("main_div", :template => "ansible_repository/show")
       end
-    when "ansible_repository_tag"
+    when "ansible_repository_tag" # tag repositories
       tag(self.class.model)
-    when "embedded_configuration_script_payload_tag" # playbooks from nested list
+    when "embedded_configuration_script_payload_tag" # tag playbooks from nested list
       tag(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook)
     end
   end

--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -1,9 +1,20 @@
 module ApplicationController::Tags
   extend ActiveSupport::Concern
 
+  def nested_page?
+    (@display == "repositories" && params[:controller] == "ansible_credential") ||
+    (@display == "playbooks" && params[:controller] == "ansible_repository") ||
+    (@display == "repositories" && params[:controller] == "workflow_credential") ||
+    (@display == "workflows" && params[:controller] == "workflow_repository")
+  end
+
   # Edit user, group or tenant tags
   def tagging_edit(db = nil, assert = true)
-    assert_privileges("#{@display && @display != "main" ? @display.singularize : controller_for_common_methods}_tag") if assert
+    if nested_page?
+      assert_privileges("#{controller_for_common_methods}_tag")
+    else
+      assert_privileges("#{@display && @display != "main" ? @display.singularize : controller_for_common_methods}_tag") if assert
+    end
     @explorer = true if request.xml_http_request? # Ajax request means in explorer
 
     @tagging = session[:tag_db] = params[:db] || db if params[:db] || db

--- a/app/controllers/workflow_credential_controller.rb
+++ b/app/controllers/workflow_credential_controller.rb
@@ -32,15 +32,28 @@ class WorkflowCredentialController < ApplicationController
 
   def button
     case params[:pressed]
-    when 'embedded_automation_manager_credentials_add'
+    when 'workflow_repositories_reload'
+      javascript_redirect(:action => 'show', :id => params[:id], :display => 'repositories')
+    when 'embedded_configuration_script_source_refresh' # refresh repositories from nested list
+      repository_refresh
+    when 'embedded_automation_manager_credentials_add' # add credential
       javascript_redirect(:action => 'new')
-    when 'embedded_automation_manager_credentials_edit'
+    when 'embedded_configuration_script_source_add' # add repository from nested list
+      javascript_redirect(:controller => 'workflow_repository', :action => 'new')
+    when 'embedded_automation_manager_credentials_edit' # edit credential
       javascript_redirect(:action => 'edit', :id => params[:miq_grid_checks])
-    when 'ansible_credential_tag'
+    when 'embedded_configuration_script_source_edit' # edit repository from nested list
+      javascript_redirect(:controller => 'workflow_repository', :action => 'edit', :id => params[:miq_grid_checks])
+    when 'ansible_credential_tag' # tag credentials
       tag(self.class.model)
-    when "workflow_repository_tag" # repositories from nested list
+    when "ansible_repository_tag" # tag repositories from nested list
       tag(ManageIQ::Providers::Workflows::AutomationManager::ConfigurationScriptSource)
     end
+  end
+
+  def check_button_rbac
+    # Allow reload to skip RBAC check
+    %w[workflow_repositories_reload].include?(params[:pressed]) || super
   end
 
   def new
@@ -57,6 +70,23 @@ class WorkflowCredentialController < ApplicationController
                     :url  => "/workflow_credential/edit/#{params[:id]}")
     @in_a_form = true
     @id = auth.id
+  end
+
+  def repository_refresh
+    assert_privileges("embedded_configuration_script_source_refresh")
+    checked = find_checked_items
+    checked[0] = params[:id] if checked.blank? && params[:id]
+
+    WorkflowRepositoryController.model.where(:id => checked).each do |repo|
+      repo.sync_queue
+      add_flash(_("Refresh of Repository \"%{name}\" was successfully initiated.") % {:name => repo.name})
+    rescue StandardError => ex
+      add_flash(_("Unable to refresh Repository \"%{name}\": %{details}") % {:name    => repo.name,
+                                                                             :details => ex},
+                :error)
+    end
+
+    javascript_flash
   end
 
   def toolbar

--- a/app/controllers/workflow_repository_controller.rb
+++ b/app/controllers/workflow_repository_controller.rb
@@ -37,26 +37,30 @@ class WorkflowRepositoryController < ApplicationController
 
   def button
     case params[:pressed]
-    when "embedded_configuration_script_source_edit"
+    when 'embedded_configuration_script_source_refresh' # refresh repositories
+      repository_refresh
+    when "embedded_configuration_script_source_edit" # edit repository
       id = params[:miq_grid_checks]
       javascript_redirect(:action => 'edit', :id => id)
-    when "embedded_configuration_script_source_add"
+    when "embedded_configuration_script_source_add" # add repository
       javascript_redirect(:action => 'new')
-    when "workflow_repositories_reload"
+    when "embedded_configuration_script_payload_map_credentials" # map credentials from nested list
+      javascript_redirect(:controller => 'workflow', :action => 'map_credentials', :id => params[:miq_grid_checks])
+    when "workflow_repositories_reload" # repositories reload
       show_list
       render :update do |page|
         page << javascript_prologue
         page.replace("gtl_div", :partial => "layouts/gtl")
       end
-    when "workflow_repository_reload"
+    when "workflow_repository_reload" # repository reload
       show
       render :update do |page|
         page << javascript_prologue
         page.replace("main_div", :template => "workflow_repository/show")
       end
-    when "ansible_repository_tag"
+    when "ansible_repository_tag" # tag repositories
       tag(self.class.model)
-    when "embedded_configuration_script_payload_tag" # workflows from nested list
+    when "embedded_configuration_script_payload_tag" # tag workflows from nested list
       tag(ManageIQ::Providers::Workflows::AutomationManager::Workflow)
     end
   end

--- a/app/helpers/application_helper/toolbar/ansible_repositories_center.rb
+++ b/app/helpers/application_helper/toolbar/ansible_repositories_center.rb
@@ -22,7 +22,6 @@ class ApplicationHelper::Toolbar::AnsibleRepositoriesCenter < ApplicationHelper:
           N_('Refresh Selected Ansible Repositories'),
           N_('Refresh Selected Ansible Repositories'),
           :klass        => ApplicationHelper::Button::EmbeddedAnsible,
-          :url          => "repository_refresh",
           :confirm      => N_("Refresh selected Ansible Repositories?"),
           :enabled      => false,
           :url_parms    => 'unused_div',

--- a/app/helpers/application_helper/toolbar/workflow_repositories_center.rb
+++ b/app/helpers/application_helper/toolbar/workflow_repositories_center.rb
@@ -25,7 +25,6 @@ class ApplicationHelper::Toolbar::WorkflowRepositoriesCenter < ApplicationHelper
                        N_('Refresh Selected Workflow Repositories'),
                        N_('Refresh Selected Workflow Repositories'),
                        :klass        => ApplicationHelper::Button::EmbeddedWorkflow,
-                       :url          => "repository_refresh",
                        :confirm      => N_("Refresh selected Workflow Repositories?"),
                        :enabled      => false,
                        :url_parms    => 'unused_div',

--- a/spec/controllers/workflow_credential_controller_spec.rb
+++ b/spec/controllers/workflow_credential_controller_spec.rb
@@ -67,7 +67,7 @@ describe WorkflowCredentialController do
     end
 
     context 'tagging one or more workflow repositories from nested list' do
-      let(:params) { {:pressed => "workflow_repository_tag"} }
+      let(:params) { {:pressed => "ansible_repository_tag"} }
 
       before do
         controller.instance_variable_set(:@display, "repositories")


### PR DESCRIPTION
Fixed the embedded ansible and embedded workflow nested list toolbars.

Affected pages:
Embedded Ansible Credentials / Embedded Workflow Credentials page -> Click a credential from the list -> Click the blue number link beside repositories for the linked repositories. This leads to the nested repository list.
<img width="1441" alt="Screenshot 2024-03-25 at 3 08 56 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/f9d70e5c-126c-4652-b570-614b2e68e5c2">
<img width="1443" alt="EmbeddedWorkflowsRepositoriesNestedList" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/98bdfc5d-f5e5-4349-89df-6f17bc41d800">

Embedded Ansible Repositories / Embedded Workflows Workflows  page -> Click a repository from the list -> Click the blue number link beside playbooks / workflows for the linked playbooks / workflows. This leads to the nested playbooks / workflows list.
<img width="1449" alt="EmbeddedAnsiblePlaybooksNestedList" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/192cda2b-edc1-4166-af6f-85679d4147d2">
<img width="1443" alt="EmbeddedWorkflowsWorkflowsNestedList" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/c0dd65e0-273a-4be4-8ad7-a669d3327ef6">

Before (Nested Repositories):
Refresh Page button, Refresh Selected Repositories button, Add Repository Button, Edit Repository Button for the nested repository pages previously did nothing.

After (Nested Repositories):
Refresh Page button will now refresh the page, Refresh Selected Repositories button will queue the refresh for the selected repositories, and the Add / Edit buttons lead to the appropriate pages.

Before (Workflows):
Map credentials to this workflow button for the nested workflows page previously did nothing.

After (Nested Workflows):
Map credentials to this workflow button now leads to the appropriate page.

This pr also fixes the Edit tags button on these pages.

Before (Nested Repositories):
<img width="1404" alt="Screenshot 2024-03-25 at 2 55 52 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/a27cea97-16e3-43d8-b21d-70194a2b484d">
<img width="1423" alt="Screenshot 2024-03-25 at 2 58 17 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/de13d63a-9524-468f-8b9b-04fcbb4c899e">

After (Nested Repositories):
<img width="1456" alt="Screenshot 2024-03-25 at 2 56 07 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/e6f50109-7dd0-4781-b6c5-689f52d18a99">
<img width="1435" alt="Screenshot 2024-03-25 at 2 58 37 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/3c5aea47-7164-493c-b8ca-b37d5855f367">

Before (Nested Playbooks / Workflows):
<img width="1441" alt="Screenshot 2024-03-25 at 2 56 58 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/36830897-7cf2-47da-aff7-c3e8a63bf39a">
<img width="1439" alt="Screenshot 2024-03-25 at 2 59 43 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/928e991e-d245-458d-958a-aaa71573b598">

After (Nested Playbooks / Workflows):
<img width="1446" alt="Screenshot 2024-03-25 at 2 57 08 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/2d789733-9f4c-40fc-9b8f-761bb1966367">
<img width="1443" alt="Screenshot 2024-03-25 at 3 00 24 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/be9fac75-07c3-4ea3-9d8a-dc1495171573">

