### PR TITLE
Fix company tags style

### DIFF
--- a/app/stylesheet/application-webpack.scss
+++ b/app/stylesheet/application-webpack.scss
@@ -14,6 +14,7 @@
 @import './ddf_override.scss';
 @import './menu.scss';
 @import './miq-custom-tab.scss';
+@import './miq-custom-accordion.scss';
 @import './miq-data-table.scss';
 @import './miq-table-toolbar.scss';
 @import './miq-structured-list.scss';

--- a/app/stylesheet/miq-custom-accordion.scss
+++ b/app/stylesheet/miq-custom-accordion.scss
@@ -1,0 +1,21 @@
+.miq-custom-accordion
+ {
+   border: 1px solid #e0e0e0;
+
+   li button.bx--accordion__heading {
+     background: #e0e0e0;
+   }
+   .bx--accordion__item:last-child{
+     border: 0;
+   }
+
+   .bx--accordion__content {
+     padding: 20px;
+     margin: 0;
+
+     .custom-accordion-buttons {
+       display: flex;
+       justify-content: flex-end;
+     }
+   }
+ }


### PR DESCRIPTION
**Before**
- The two sections are colliding.
<img width="1537" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/b9d616b6-3ef1-46f2-bb05-a9566749eff5">

<img width="563" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/35e96f8e-113d-4245-8cfd-5806095741a2">


**After**
- Both sections are wrapped into accordion container.
- The stylesheet introduced can be reused in other places in the future (like https://github.com/ManageIQ/manageiq-ui-classic/pull/9059 and others)
- Changed the browser confirmation box

<img width="1530" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/eb32fc36-8362-4d79-89c6-e9b16f9aa801">
<img width="935" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/8dcfc4b4-7553-4130-81d5-4e822270f1a2">

