### PR TITLE
Fixed missing surveys table

### DIFF
--- a/app/controllers/configuration_script_controller.rb
+++ b/app/controllers/configuration_script_controller.rb
@@ -45,7 +45,7 @@ class ConfigurationScriptController < ApplicationController
   private
 
   def textual_group_list
-    [%i[properties tags]]
+    [%i[properties variables tags surveys]]
   end
   helper_method :textual_group_list
 

--- a/app/helpers/configuration_script_helper.rb
+++ b/app/helpers/configuration_script_helper.rb
@@ -4,7 +4,55 @@ module ConfigurationScriptHelper
   def textual_group_properties
     TextualGroup.new(
       _("Properties"),
-      %i[hostname ipmi_present ipaddress mac_address provider_name zone]
+      %i[configuration_script_name configuration_script_region]
+    )
+  end
+
+  def textual_configuration_script_name
+    {:label => _("Name"), :value => @record.name}
+  end
+
+  def textual_configuration_script_region
+    {:label => _("Region"), :value => @record.region_description}
+  end
+
+  def textual_group_variables
+    variables = Array(@record.variables).collect do |item|
+      [
+        item[0].to_s,
+        item[1].to_s
+      ]
+    end
+    TextualMultilabel.new(
+      _('Variables (%{count})') % {:count => @record.variables.count},
+      :additional_table_class => "table-fixed",
+      :labels                 => [_('Name'), _('Value')],
+      :values                 => variables
+    )
+  end
+
+  def textual_group_surveys
+    return unless @record.survey_spec['spec']
+
+    headers = [_('Question Name'), _('Question Description'), _('Variable'),
+               _('Type'),  _('Min'), _('Max'), _('Default'), _('Required'), _('Choices')]
+    items = @record.survey_spec['spec'].collect do |item|
+      [
+        item['question_name'],
+        item['question_description'],
+        item['variable'],
+        item['type'],
+        item['min'],
+        item['max'],
+        item['default'],
+        item['required'],
+        item['choices']
+      ]
+    end
+    TextualTable.new(
+      _("Surveys"),
+      items,
+      headers
     )
   end
 
@@ -71,14 +119,6 @@ module ConfigurationScriptHelper
        configuration_script_region]
   end
 
-  def textual_configuration_script_name
-    {:label => _("Name"), :value => @record.name}
-  end
-
-  def textual_configuration_script_region
-    {:label => _("Region"), :value => @record.region_description}
-  end
-
   def textual_configuration_script_variables
     textual_variables(@record.variables)
   end
@@ -132,4 +172,3 @@ module ConfigurationScriptHelper
     TextualTags.new(_("Smart Management"), %i[tags])
   end
 end
-#

--- a/app/views/configuration_script/show.html.haml
+++ b/app/views/configuration_script/show.html.haml
@@ -1,13 +1,2 @@
 = render :partial => "layouts/flash_msg"
-.row
-  .col-md-12.col-lg-8
-    = react 'GenericGroupWrapper', expand_generic_group(TextualGroup.new(_('Properties'), textual_configuration_script_group_properties), @record)
-  .col-md-12.col-lg-8
-    = react 'TableListViewWrapper', TextualListview.data(textual_configuration_script_variables)
-  .col-md-12.col-lg-8
-    #tag_group
-    :javascript
-      ManageIQ.component.componentFactory('TagGroup', '#tag_group', #{textual_tags_render_data(@record).to_json});
-  .col-md-12.col-lg-8
-    - if @record.survey_spec&.dig("spec")
-      = react 'TableListViewWrapper', TextualListview.data(textual_configuration_script_survey)
+= render :partial => "layouts/textual_groups_generic"


### PR DESCRIPTION
Fixed a bug where the surveys table is not rendering data on the Automation / Ansible Tower / Templates / Summary Page.

Before:
<img width="1026" alt="Screenshot 2024-04-02 at 3 57 05 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/91153989-9282-4895-a590-db5422928bc0">

After:
<img width="894" alt="Screenshot 2024-04-02 at 3 57 44 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/f4b8df26-6893-499c-b181-b5949e189bbd">
