### PR TITLE
Fix CloudVolumeActions test

### DIFF
--- a/app/javascript/spec/cloud-volume-actions-form/__snapshots__/cloud-volume-actions-form.spec.js.snap
+++ b/app/javascript/spec/cloud-volume-actions-form/__snapshots__/cloud-volume-actions-form.spec.js.snap
@@ -3772,7 +3772,7 @@ exports[`Cloud Volume Restore from backup form component should render the cloud
                                                 </IsRequired>
                                               }
                                               loadOptions={[Function]}
-                                              loadOptionsChangeCounter={1}
+                                              loadOptionsChangeCounter={0}
                                               loadingMessage="Loading..."
                                               name="backup_id"
                                               onBlur={[Function]}
@@ -3785,11 +3785,13 @@ exports[`Cloud Volume Restore from backup form component should render the cloud
                                               value=""
                                             >
                                               <ClearedSelect
+                                                className=""
+                                                closeMenuOnSelect={true}
+                                                hideSelectedOptions={false}
                                                 id="backup_id"
                                                 invalidText=""
                                                 isClearable={false}
-                                                isDisabled={true}
-                                                isFetching={true}
+                                                isFetching={false}
                                                 isSearchable={false}
                                                 labelText={
                                                   <IsRequired>
@@ -3803,10 +3805,11 @@ exports[`Cloud Volume Restore from backup form component should render the cloud
                                                 onFocus={[Function]}
                                                 onInputChange={[Function]}
                                                 options={Array []}
-                                                placeholder="Loading..."
+                                                placeholder="<Choose>"
                                                 value=""
                                               >
                                                 <Select
+                                                  className=""
                                                   disabled={false}
                                                   helperText=""
                                                   id="backup_id"
@@ -3857,23 +3860,7 @@ exports[`Cloud Volume Restore from backup form component should render the cloud
                                                           onChange={[Function]}
                                                           onFocus={[Function]}
                                                           value=""
-                                                        >
-                                                          <SelectItem
-                                                            disabled={false}
-                                                            hidden={false}
-                                                            text="Loading..."
-                                                            value=""
-                                                          >
-                                                            <option
-                                                              className="bx--select-option"
-                                                              disabled={false}
-                                                              hidden={false}
-                                                              value=""
-                                                            >
-                                                              Loading...
-                                                            </option>
-                                                          </SelectItem>
-                                                        </select>
+                                                        />
                                                         <ForwardRef(ChevronDown16)
                                                           className="bx--select__arrow"
                                                         >
@@ -4011,9 +3998,7 @@ exports[`Cloud Volume Restore from backup form component should render the cloud
                                 "dirtyFieldsSinceLastSubmit": Object {},
                                 "dirtySinceLastSubmit": false,
                                 "error": undefined,
-                                "errors": Object {
-                                  "backup_id": "Required",
-                                },
+                                "errors": Object {},
                                 "form": Object {
                                   "batch": [Function],
                                   "blur": [Function],
@@ -4049,12 +4034,10 @@ exports[`Cloud Volume Restore from backup form component should render the cloud
                                   "subscribe": [Function],
                                 },
                                 "hasSubmitErrors": false,
-                                "hasValidationErrors": true,
+                                "hasValidationErrors": false,
                                 "initialValues": Object {},
-                                "invalid": true,
-                                "modified": Object {
-                                  "backup_id": false,
-                                },
+                                "invalid": false,
+                                "modified": Object {},
                                 "modifiedSinceLastSubmit": false,
                                 "pristine": true,
                                 "submitError": undefined,
@@ -4062,15 +4045,11 @@ exports[`Cloud Volume Restore from backup form component should render the cloud
                                 "submitFailed": false,
                                 "submitSucceeded": false,
                                 "submitting": false,
-                                "touched": Object {
-                                  "backup_id": false,
-                                },
-                                "valid": false,
+                                "touched": Object {},
+                                "valid": true,
                                 "validating": false,
                                 "values": Object {},
-                                "visited": Object {
-                                  "backup_id": false,
-                                },
+                                "visited": Object {},
                               }
                             }
                             onCancel={[Function]}
@@ -4892,7 +4871,7 @@ exports[`Cloud Volume Restore from backup form component when restoring cloud vo
                                                 </IsRequired>
                                               }
                                               loadOptions={[Function]}
-                                              loadOptionsChangeCounter={1}
+                                              loadOptionsChangeCounter={0}
                                               loadingMessage="Loading..."
                                               name="backup_id"
                                               onBlur={[Function]}
@@ -4905,11 +4884,13 @@ exports[`Cloud Volume Restore from backup form component when restoring cloud vo
                                               value=""
                                             >
                                               <ClearedSelect
+                                                className=""
+                                                closeMenuOnSelect={true}
+                                                hideSelectedOptions={false}
                                                 id="backup_id"
                                                 invalidText=""
                                                 isClearable={false}
-                                                isDisabled={true}
-                                                isFetching={true}
+                                                isFetching={false}
                                                 isSearchable={false}
                                                 labelText={
                                                   <IsRequired>
@@ -4923,10 +4904,11 @@ exports[`Cloud Volume Restore from backup form component when restoring cloud vo
                                                 onFocus={[Function]}
                                                 onInputChange={[Function]}
                                                 options={Array []}
-                                                placeholder="Loading..."
+                                                placeholder="<Choose>"
                                                 value=""
                                               >
                                                 <Select
+                                                  className=""
                                                   disabled={false}
                                                   helperText=""
                                                   id="backup_id"
@@ -4977,23 +4959,7 @@ exports[`Cloud Volume Restore from backup form component when restoring cloud vo
                                                           onChange={[Function]}
                                                           onFocus={[Function]}
                                                           value=""
-                                                        >
-                                                          <SelectItem
-                                                            disabled={false}
-                                                            hidden={false}
-                                                            text="Loading..."
-                                                            value=""
-                                                          >
-                                                            <option
-                                                              className="bx--select-option"
-                                                              disabled={false}
-                                                              hidden={false}
-                                                              value=""
-                                                            >
-                                                              Loading...
-                                                            </option>
-                                                          </SelectItem>
-                                                        </select>
+                                                        />
                                                         <ForwardRef(ChevronDown16)
                                                           className="bx--select__arrow"
                                                         >
@@ -5131,9 +5097,7 @@ exports[`Cloud Volume Restore from backup form component when restoring cloud vo
                                 "dirtyFieldsSinceLastSubmit": Object {},
                                 "dirtySinceLastSubmit": false,
                                 "error": undefined,
-                                "errors": Object {
-                                  "backup_id": "Required",
-                                },
+                                "errors": Object {},
                                 "form": Object {
                                   "batch": [Function],
                                   "blur": [Function],
@@ -5169,12 +5133,10 @@ exports[`Cloud Volume Restore from backup form component when restoring cloud vo
                                   "subscribe": [Function],
                                 },
                                 "hasSubmitErrors": false,
-                                "hasValidationErrors": true,
+                                "hasValidationErrors": false,
                                 "initialValues": Object {},
-                                "invalid": true,
-                                "modified": Object {
-                                  "backup_id": false,
-                                },
+                                "invalid": false,
+                                "modified": Object {},
                                 "modifiedSinceLastSubmit": false,
                                 "pristine": true,
                                 "submitError": undefined,
@@ -5182,15 +5144,11 @@ exports[`Cloud Volume Restore from backup form component when restoring cloud vo
                                 "submitFailed": false,
                                 "submitSucceeded": false,
                                 "submitting": false,
-                                "touched": Object {
-                                  "backup_id": false,
-                                },
-                                "valid": false,
+                                "touched": Object {},
+                                "valid": true,
                                 "validating": false,
                                 "values": Object {},
-                                "visited": Object {
-                                  "backup_id": false,
-                                },
+                                "visited": Object {},
                               }
                             }
                             onCancel={[Function]}

--- a/app/javascript/spec/cloud-volume-actions-form/cloud-volume-actions-form.spec.js
+++ b/app/javascript/spec/cloud-volume-actions-form/cloud-volume-actions-form.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import toJson from 'enzyme-to-json';
 import fetchMock from 'fetch-mock';
+import { act } from 'react-dom/test-utils';
 import { mount } from '../helpers/mountForm';
 import CloudVolumeActions from '../../components/cloud-volume-actions-form';
 import miqRedirectBack from '../../helpers/miq-redirect-back';
@@ -16,8 +17,20 @@ const expectedKeys = {
   cancel: ['url', 'message'],
 };
 
+describe('create form data object has keys containing', () => {
+  const cloudVolume = { ...record, type: CloudVolumeActionTypes.CREATE_BACKUP };
+  const data = formData(cloudVolume.recordId, cloudVolume.name, cloudVolume.type);
+  it('matches the expected type and object keys of formData', () => {
+    expect(data.type).toEqual(CloudVolumeActionTypes.CREATE_BACKUP);
+    expect(Object.keys(data)).toEqual(expect.arrayContaining(expectedKeys.main));
+    expect(Object.keys(data.cancel)).toEqual(expect.arrayContaining(expectedKeys.cancel));
+    expect(Object.keys(data.save)).toEqual(expect.arrayContaining(expectedKeys.save));
+  });
+});
+
 describe('Cloud Volume Backup Create form component', () => {
   const cloudVolume = { ...record, type: CloudVolumeActionTypes.CREATE_BACKUP };
+  const data = formData(cloudVolume.recordId, cloudVolume.name, cloudVolume.type);
   const createBackupComponent = (
     <CloudVolumeActions
       recordId={cloudVolume.recordId}
@@ -26,18 +39,7 @@ describe('Cloud Volume Backup Create form component', () => {
     />
   );
 
-  const data = formData(cloudVolume.recordId, cloudVolume.name, cloudVolume.type);
-
-  describe('create form data object has keys containing', () => {
-    it('matches the expected type and object keys of formData', () => {
-      expect(data.type).toEqual(CloudVolumeActionTypes.CREATE_BACKUP);
-      expect(Object.keys(data)).toEqual(expect.arrayContaining(expectedKeys.main));
-      expect(Object.keys(data.cancel)).toEqual(expect.arrayContaining(expectedKeys.cancel));
-      expect(Object.keys(data.save)).toEqual(expect.arrayContaining(expectedKeys.save));
-    });
-  });
-
-  it('should render the cloud volume backup create form', () => {
+  it('should render the cloud volume backup create form', async() => {
     const wrapper = mount(createBackupComponent);
     expect(toJson(wrapper)).toMatchSnapshot();
   });
@@ -90,20 +92,29 @@ describe('Cloud Volume Restore from backup form component', () => {
     });
   });
 
-  it('should render the cloud volume backup restore form', () => {
-    const wrapper = mount(restoreFromBackupComponent);
+  it('should render the cloud volume backup restore form', async() => {
+    let wrapper;
+    await act(async() => {
+      wrapper = mount(restoreFromBackupComponent);
+    });
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
-  it('when restoring cloud volume from backup', () => {
+  it('when restoring cloud volume from backup', async() => {
+    let wrapper;
     fetchMock.postOnce(data.save.postUrl, { backup_id: '1' });
-    const wrapper = mount(restoreFromBackupComponent);
+    await act(async() => {
+      wrapper = mount(restoreFromBackupComponent);
+    });
 
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
-  it('should call miqRedirectBack when the restore from backup form is cancelled', () => {
-    const wrapper = mount(restoreFromBackupComponent);
+  it('should call miqRedirectBack when the restore from backup form is cancelled', async() => {
+    let wrapper;
+    await act(async() => {
+      wrapper = mount(restoreFromBackupComponent);
+    });
     wrapper.find('button').last().simulate('click');
     expect(miqRedirectBack).toHaveBeenCalledWith(data.cancel.message, 'success', data.cancel.url);
   });


### PR DESCRIPTION
`yarn run jest -t 'Cloud Volume Restore from backup form component' --testPathPattern app/javascript/spec/cloud-volume-actions-form/cloud-volume-actions-form.spec.js`

**Before**
```

 PASS  app/javascript/spec/cloud-volume-actions-form/cloud-volume-actions-form.spec.js
  Cloud Volume Backup Create form component
    ○ skipped should render the cloud volume backup create form
    ○ skipped when adding a new backup of cloud volume
    ○ skipped should call miqRedirectBack when the create form is cancelled
    create form data object has keys containing
      ○ skipped matches the expected type and object keys of formData
  Cloud Volume Restore from backup form component
    ✓ should render the cloud volume backup restore form (78ms)
    ✓ when restoring cloud volume from backup (30ms)
    ✓ should call miqRedirectBack when the restore from backup form is cancelled (22ms)
    restore from backup form data object has keys containing
      ✓ matches the expected type and object keys of formData (6ms)
  Cloud Volume Snapshot Create form component
    ○ skipped should render the cloud volume snapshot create form
    ○ skipped when adding a new snapshot of cloud volume
    ○ skipped should call miqRedirectBack when the create form is cancelled
    create form data object has keys containing
      ○ skipped matches the expected type and object keys of formData

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to Select inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in Select (created by Select)
        in Select (created by SelectWithOnChange)
        in SelectWithOnChange (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by SubForm)
        in div (created by SubForm)
        in SubForm (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by FormRenderer)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by CloudVolumeActions)
        in CloudVolumeActions
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to Select inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in Select (created by Select)
        in Select (created by SelectWithOnChange)
        in SelectWithOnChange (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by SubForm)
        in div (created by SubForm)
        in SubForm (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by FormRenderer)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by CloudVolumeActions)
        in CloudVolumeActions
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to Select inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in Select (created by Select)
        in Select (created by SelectWithOnChange)
        in SelectWithOnChange (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by SubForm)
        in div (created by SubForm)
        in SubForm (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by FormRenderer)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by CloudVolumeActions)
        in CloudVolumeActions
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to Select inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in Select (created by Select)
        in Select (created by SelectWithOnChange)
        in SelectWithOnChange (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by SubForm)
        in div (created by SubForm)
        in SubForm (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by FormRenderer)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by CloudVolumeActions)
        in CloudVolumeActions
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to Select inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in Select (created by Select)
        in Select (created by SelectWithOnChange)
        in SelectWithOnChange (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by SubForm)
        in div (created by SubForm)
        in SubForm (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by FormRenderer)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by CloudVolumeActions)
        in CloudVolumeActions
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to Select inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in Select (created by Select)
        in Select (created by SelectWithOnChange)
        in SelectWithOnChange (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by SubForm)
        in div (created by SubForm)
        in SubForm (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by FormRenderer)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by CloudVolumeActions)
        in CloudVolumeActions
        in Provider (created by WrapperComponent)
        in WrapperComponent

Test Suites: 1 passed, 1 total
Tests:       8 skipped, 4 passed, 12 total
Snapshots:   2 passed, 2 total
Time:        5.56s

```

**After**
```
PASS  app/javascript/spec/cloud-volume-actions-form/cloud-volume-actions-form.spec.js
  create form data object has keys containing
    ○ skipped matches the expected type and object keys of formData
  Cloud Volume Backup Create form component
    ○ skipped should render the cloud volume backup create form
    ○ skipped when adding a new backup of cloud volume
    ○ skipped should call miqRedirectBack when the create form is cancelled
  Cloud Volume Restore from backup form component
    ✓ should render the cloud volume backup restore form (85ms)
    ✓ when restoring cloud volume from backup (32ms)
    ✓ should call miqRedirectBack when the restore from backup form is cancelled (22ms)
    restore from backup form data object has keys containing
      ✓ matches the expected type and object keys of formData (7ms)
  Cloud Volume Snapshot Create form component
    ○ skipped should render the cloud volume snapshot create form
    ○ skipped when adding a new snapshot of cloud volume
    ○ skipped should call miqRedirectBack when the create form is cancelled
    create form data object has keys containing
      ○ skipped matches the expected type and object keys of formData

Test Suites: 1 passed, 1 total
Tests:       8 skipped, 4 passed, 12 total
Snapshots:   2 passed, 2 total
Time:        5.386s

```
