### PR TITLE
Fix PxeIsoDatastoreForm test

### DIFF
--- a/app/javascript/spec/pxe-iso-datastore-form/__snapshots__/pxe-iso-datastore-form.spec.js.snap
+++ b/app/javascript/spec/pxe-iso-datastore-form/__snapshots__/pxe-iso-datastore-form.spec.js.snap
@@ -22,11 +22,11 @@ exports[`Pxe Iso Datastore Form Component should render adding a new iso datasto
     emses={
       Array [
         Object {
-          "id": "1",
+          "id": 1,
           "name": "provider 1",
         },
         Object {
-          "id": "2",
+          "id": 2,
           "name": "provider 2",
         },
       ]

--- a/app/javascript/spec/pxe-iso-datastore-form/pxe-iso-datastore-form.spec.js
+++ b/app/javascript/spec/pxe-iso-datastore-form/pxe-iso-datastore-form.spec.js
@@ -7,27 +7,25 @@ import { mount } from '../helpers/mountForm';
 import PxeIsoDatastoreForm from '../../components/pxe-iso-datastore-form/index';
 
 describe('Pxe Iso Datastore Form Component', () => {
-
   const emses = [
     {
       name: 'provider 1',
-      id: '1',
+      id: 1,
     },
     {
       name: 'provider 2',
-      id: '2',
+      id: 2,
     },
   ];
 
-  it('should render adding a new iso datastore', async (done) => {
+  it('should render adding a new iso datastore', async(done) => {
     let wrapper;
 
-    await act(async () => {
+    await act(async() => {
       wrapper = mount(<PxeIsoDatastoreForm emses={emses} />);
     });
     wrapper.update();
     expect(toJson(wrapper)).toMatchSnapshot();
     done();
   });
-
 });


### PR DESCRIPTION
`yarn run jest -t 'Pxe Iso Datastore Form Component' --testPathPattern app/javascript/spec/pxe-iso-datastore-form/pxe-iso-datastore-form.spec.js`

Before
```
Pxe Iso Datastore Form Component
    ✓ should render adding a new iso datastore (88ms)

  console.error node_modules/prop-types/checkPropTypes.js:20
    Warning: Failed prop type: Invalid prop `emses[0].id` of type `string` supplied to `PxeIsoDatastoreForm`, expected `number`.
        in PxeIsoDatastoreForm

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   1 passed, 1 total
Time:        3.892s

```
After
 ```
PASS  app/javascript/spec/pxe-iso-datastore-form/pxe-iso-datastore-form.spec.js
  Pxe Iso Datastore Form Component
    ✓ should render adding a new iso datastore (78ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   1 passed, 1 total
Time:        4.044s

```