### PR TITLE
Fix ZoneForm test

### DIFF
--- a/app/javascript/spec/zone-form/__snapshots__/zone-form.spec.js.snap
+++ b/app/javascript/spec/zone-form/__snapshots__/zone-form.spec.js.snap
@@ -155,7 +155,7 @@ exports[`zone Form Component should render editing a zone form 1`] = `
     href="http://localhost:3000/api/zones/68"
     id="68"
     name="test add zone name"
-    recordId={68}
+    recordId="68"
   >
     <Connect(MiqFormRenderer)
       buttonsLabels={

--- a/app/javascript/spec/zone-form/zone-form.spec.js
+++ b/app/javascript/spec/zone-form/zone-form.spec.js
@@ -7,15 +7,13 @@ import { act } from 'react-dom/test-utils';
 import { mount } from '../helpers/mountForm';
 import ZoneForm from '../../components/zone-form/index';
 
-
-const zoneForm = require('../../components/zone-form/index');
 describe('zone Form Component', () => {
   const zone = {
     authentications: [],
     created_on: '2021-05-13T19:47:24Z',
     description: 'test add zone',
     href: 'http://localhost:3000/api/zones/68',
-    id: "68",
+    id: '68',
     name: 'test add zone name',
   };
 
@@ -35,7 +33,7 @@ describe('zone Form Component', () => {
     fetchMock.get('/api/zones/68?attributes=authentications', zone);
     let wrapper;
     await act(async() => {
-      wrapper = mount(<ZoneForm recordId={68} {...zone} />);
+      wrapper = mount(<ZoneForm recordId="68" {...zone} />);
     });
     wrapper.update();
     expect(toJson(wrapper)).toMatchSnapshot();


### PR DESCRIPTION
`yarn run jest -t 'zone Form Component' --testPathPattern app/javascript/spec/zone-form/zone-form.spec.js`

Before
```
console.error node_modules/prop-types/checkPropTypes.js:20
    Warning: Failed prop type: Invalid prop `recordId` of type `number` supplied to `ZoneForm`, expected `string`.
        in ZoneForm

 PASS  app/javascript/spec/zone-form/zone-form.spec.js
  zone Form Component
    ✓ should render a new Zone form (9ms)
    ✓ should render editing a zone form (118ms)

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   2 passed, 2 total
Time:        3.996s

```

After
 ```
PASS  app/javascript/spec/zone-form/zone-form.spec.js
  zone Form Component
    ✓ should render a new Zone form (16ms)
    ✓ should render editing a zone form (222ms)

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   2 passed, 2 total
Time:        8.743s

```