### PR TITLE
stub_supports uses specific class

### DIFF
--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -644,14 +644,14 @@ describe ApplicationController do
       before { controller.instance_variable_set(:@reconfigitems, [vm]) }
 
       context "when vm supports reconfiguring disks" do
-        before { stub_supports(Vm, :reconfigure_disks) }
+        before { stub_supports(vm.class, :reconfigure_disks) }
         it "enables reconfigure disks" do
           expect(controller.send(:item_supports?, :reconfigure_disks)).to be_truthy
         end
       end
 
       context "when vm does not supports reconfiguring disks" do
-        before { stub_supports_not(Vm, :reconfigure_disks) }
+        before { stub_supports_not(vm.class, :reconfigure_disks) }
         it "disables reconfigure disks" do
           expect(controller.send(:item_supports?, :reconfigure_disks)).to be_falsey
         end
@@ -659,7 +659,7 @@ describe ApplicationController do
     end
 
     context "when multiple vms selected" do
-      before { stub_supports(Vm, :reconfigure_disks) }
+      before { stub_supports(vm.class, :reconfigure_disks) }
       let(:vm1) { FactoryBot.create(:vm_redhat) }
 
       it "disables reconfigure disks" do

--- a/spec/controllers/cloud_object_store_object_spec.rb
+++ b/spec/controllers/cloud_object_store_object_spec.rb
@@ -97,7 +97,7 @@ describe CloudObjectStoreObjectController do
     end
 
     it "delete shows expected flash" do
-      stub_supports(CloudObjectStoreObject, :delete)
+      stub_supports(object.class, :delete)
 
       post :button, :params => {
         :pressed => "cloud_object_store_object_delete", :format => :js, :id => object.id

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -91,8 +91,8 @@ describe StorageController do
         host = FactoryBot.create(:host)
         command = button.split('_', 2)[1]
 
-        stub_supports_all_others(Host)
-        stub_supports(Host, command)
+        stub_supports_all_others(host.class)
+        stub_supports(host.class, command)
 
         controller.params = {:pressed => button, :miq_grid_checks => host.id.to_s}
         controller.instance_variable_set(:@lastaction, "show_list")

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -332,9 +332,8 @@ describe VmInfraController do
   end
 
   it 'can set retirement date' do
-    # allow the other supports (from other buttons) to still work:
-    allow_any_instance_of(Vm).to receive(:supports?).and_call_original
-    stub_supports(Vm, :retire)
+    stub_supports_all_others(vm_vmware.class)
+    stub_supports(vm_vmware.class, :retire)
     get :show, :params => {:id => vm_vmware.id}
     expect(response).to redirect_to(:action => 'explorer')
 

--- a/spec/helpers/application_helper/buttons/vm_retire_now_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_retire_now_spec.rb
@@ -3,7 +3,7 @@ describe ApplicationHelper::Button::VmRetireNow do
     context "when record is retireable" do
       before do
         @record = FactoryBot.create(:vm_vmware)
-        stub_supports(Vm, :retire)
+        stub_supports(@record.class, :retire)
       end
 
       it_behaves_like "will not be skipped for this record"
@@ -12,7 +12,7 @@ describe ApplicationHelper::Button::VmRetireNow do
     context "when record is not retiretable" do
       before do
         @record = FactoryBot.create(:vm_vmware)
-        stub_supports_not(Vm, :retire)
+        stub_supports_not(@record.class, :retire)
       end
 
       it_behaves_like "will be skipped for this record"

--- a/spec/helpers/application_helper/buttons/vm_retire_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_retire_spec.rb
@@ -3,7 +3,7 @@ describe ApplicationHelper::Button::VmRetire do
     context "when record is retireable" do
       before do
         @record = FactoryBot.create(:vm_vmware)
-        stub_supports(Vm, :retire)
+        stub_supports(@record.class, :retire)
       end
 
       it_behaves_like "will not be skipped for this record"
@@ -12,7 +12,7 @@ describe ApplicationHelper::Button::VmRetire do
     context "when record is not retiretable" do
       before do
         @record = FactoryBot.create(:vm_vmware)
-        stub_supports_not(Vm, :retire)
+        stub_supports_not(@record.class, :retire)
       end
 
       it_behaves_like "will be skipped for this record"

--- a/spec/helpers/application_helper/buttons/volume_detach_spec.rb
+++ b/spec/helpers/application_helper/buttons/volume_detach_spec.rb
@@ -1,31 +1,32 @@
 describe ApplicationHelper::Button::VolumeDetach do
+  let(:record) { CloudVolume.new }
   let(:button) do
     described_class.new(
-      setup_view_context_with_sandbox({}), {}, {"record" => CloudVolume.new}, {}
+      setup_view_context_with_sandbox({}), {}, {"record" => record}, {}
     )
   end
 
   describe '#disabled?' do
     it "when the detach action is supported, then the button is enabled" do
-      stub_supports(CloudVolume, :detach)
+      stub_supports(record.class, :detach)
       expect(button.disabled?).to be false
     end
 
     it "when the detach action is not supported, then the button is disabled" do
-      stub_supports_not(CloudVolume, :detach, "unavailable")
+      stub_supports_not(record.class, :detach, "unavailable")
       expect(button.disabled?).to be true
     end
   end
 
   describe '#calculate_properties' do
     it "when the detach action is not supported, then the button has the error in the title" do
-      stub_supports_not(CloudVolume, :detach, "unavailable")
+      stub_supports_not(record.class, :detach, "unavailable")
       button.calculate_properties
       expect(button[:title]).to eq("unavailable")
     end
 
     it "when the detach action is not supported, the button has no error in the title" do
-      stub_supports(CloudVolume, :detach)
+      stub_supports(record.class, :detach)
       button.calculate_properties
       expect(button[:title]).to be nil
     end


### PR DESCRIPTION
part of:
- https://github.com/ManageIQ/manageiq/pull/22898

No reason to hardcode classes in the specs here
Also, the new `stub_supports` expects specific provider classes to be called out and will not work with a generic reference

