### PR TITLE
Fix RemoveCatalogItemModal test

### DIFF
--- a/app/javascript/spec/remove-catalog-item-modal/remove-catalog-item-modal.spec.js
+++ b/app/javascript/spec/remove-catalog-item-modal/remove-catalog-item-modal.spec.js
@@ -11,8 +11,8 @@ import '../helpers/miqSparkle';
 import '../helpers/sprintf';
 
 describe('RemoveCatalogItemModal', () => {
-  const item1 = 123;
-  const item2 = 456;
+  const item1 = '123';
+  const item2 = '456';
   const url1 = `/api/service_templates/${item1}?attributes=services`;
   const url2 = `/api/service_templates/${item2}?attributes=services`;
   const apiResponse1 = {


### PR DESCRIPTION
`yarn run jest -t 'RemoveCatalogItemModal' --testPathPattern app/javascript/spec/remove-catalog-item-modal/remove-catalog-item-modal.spec.js`


Before
```
PASS  app/javascript/spec/remove-catalog-item-modal/remove-catalog-item-modal.spec.js
  RemoveCatalogItemModal
    ✓ should correctly set component state for single catalog item (47ms)
    ✓ should correctly set component state for multiple catalog items (20ms)
    ✓ should correctly render modal for single catalog item (8ms)
    ✓ should correctly render modal for multiple catalog items (4ms)
    ✓ should correctly render modal for duplicate catalog items (3ms)
    ✓ correctly initializes buttons (6ms)
    ✓ removeCatalogItems() works correctly (6ms)

  console.error node_modules/prop-types/checkPropTypes.js:20
    Warning: Failed prop type: Invalid prop `recordId` of type `number` supplied to `RemoveCatalogItemModal`, expected `string`.
        in RemoveCatalogItemModal (created by Connect(RemoveCatalogItemModal))
        in Connect(RemoveCatalogItemModal) (created by WrapperComponent)
        in WrapperComponent
```
After

```
 PASS  app/javascript/spec/remove-catalog-item-modal/remove-catalog-item-modal.spec.js
  RemoveCatalogItemModal
    ✓ should correctly set component state for single catalog item (44ms)
    ✓ should correctly set component state for multiple catalog items (12ms)
    ✓ should correctly render modal for single catalog item (8ms)
    ✓ should correctly render modal for multiple catalog items (9ms)
    ✓ should correctly render modal for duplicate catalog items (3ms)
    ✓ correctly initializes buttons (5ms)
    ✓ removeCatalogItems() works correctly (8ms)

Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
Snapshots:   3 passed, 3 total
Time:        3.739s

```