### PR TITLE
Fix MiqStructuredList test

### DIFF
--- a/app/javascript/components/miq-structured-list/index.jsx
+++ b/app/javascript/components/miq-structured-list/index.jsx
@@ -48,7 +48,7 @@ const MiqStructuredList = ({
 export default MiqStructuredList;
 
 MiqStructuredList.propTypes = {
-  title: PropTypes.string,
+  title: PropTypes.oneOfType([PropTypes.string, PropTypes.shape({})]),
   headers: PropTypes.arrayOf(PropTypes.any),
   rows: PropTypes.arrayOf(PropTypes.any),
   onClick: PropTypes.func,


### PR DESCRIPTION
`yarn run jest -t 'MiqEventDefinitionStructuredList' --testPathPattern app/javascript/spec/miq-event-definition/miq-event-definition.spec.js`

Before
```
PASS  app/javascript/spec/miq-event-definition/miq-event-definition.spec.js
  MiqEventDefinitionStructuredList
    ✓ should render event definition info structured list (10ms)
    ✓ should render event definition policy structured list (2ms)

  console.error node_modules/prop-types/checkPropTypes.js:20
    Warning: Failed prop type: Invalid prop `title` of type `object` supplied to `MiqStructuredList`, expected `string`.
        in MiqStructuredList

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   2 passed, 2 total
Time:        3.778s
```

After
```
 PASS  app/javascript/spec/miq-event-definition/miq-event-definition.spec.js
  MiqEventDefinitionStructuredList
    ✓ should render event definition info structured list (8ms)
    ✓ should render event definition policy structured list (1ms)

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   2 passed, 2 total
Time:        3.725s
```