### PR TITLE
Fix TreeSelector test

### DIFF
--- a/app/javascript/components/tree-view/selector.jsx
+++ b/app/javascript/components/tree-view/selector.jsx
@@ -98,7 +98,6 @@ const TreeViewSelector = ({
         modalHeading={label}
         primaryButtonText={selectLabel}
         secondaryButtonText={closeLabel}
-        iconDescription={closeLabel}
         primaryButtonDisabled={!active}
         onRequestSubmit={changeValue}
         onSecondarySubmit={closeModal}

--- a/app/javascript/spec/tree-view/__snapshots__/selector.spec.js.snap
+++ b/app/javascript/spec/tree-view/__snapshots__/selector.spec.js.snap
@@ -234,7 +234,6 @@ exports[`TreeSelector component should render correctly 1`] = `
       </div>
       <Modal
         hasScrollingContent={false}
-        iconDescription="Close"
         modalHeading="tree-selector"
         modalLabel=""
         onKeyDown={[Function]}
@@ -282,7 +281,6 @@ exports[`TreeSelector component should render correctly 1`] = `
                 aria-label="close"
                 className="bx--modal-close"
                 onClick={[Function]}
-                title="Close"
                 type="button"
               >
                 <ForwardRef(Close20)

--- a/app/javascript/spec/tree-view/selector.spec.js
+++ b/app/javascript/spec/tree-view/selector.spec.js
@@ -39,6 +39,10 @@ const RendererWrapper = ({ initialValue, onSubmit = () => {}, ...props }) => (
 describe('TreeSelector component', () => {
   it('should render correctly', async(done) => {
     const wrapper = mount(<RendererWrapper />);
+    await act(async() => {
+      wrapper.find(TreeViewSelector);
+      wrapper.update();
+    });
     setImmediate(() => {
       expect(toJson(wrapper.find(TreeViewSelector))).toMatchSnapshot();
       done();


### PR DESCRIPTION
`yarn run jest -t 'TreeSelector component' --testPathPattern app/javascript/spec/tree-view/selector.spec.js
`

**Before**
```
console.warn node_modules/carbon-components-react/lib/internal/warning.js:30
    Warning: The iconDescription prop is no longer needed and can be safely removed. This prop will be removed in the next major release of Carbon.

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to TreeViewBase inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in TreeViewBase (created by TreeViewSelector)
        in div (created by Modal)
        in div (created by Modal)
        in div (created by Modal)
        in Modal (created by TreeViewSelector)
        in fieldset (created by FormGroup)
        in FormGroup (created by TreeViewSelector)
        in TreeViewSelector (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by FormRenderer)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by RendererWrapper)
        in RendererWrapper (created by WrapperComponent)
        in WrapperComponent

 PASS  app/javascript/spec/tree-view/selector.spec.js
  TreeSelector component
    ✓ should render correctly (98ms)
    ✓ should set the value upon selection in the modal (54ms)
    ✓ should clear the value upon clicking the clear button (29ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   1 passed, 1 total
Time:        4.047s

```
**After**
 ```
PASS  app/javascript/spec/tree-view/selector.spec.js
  TreeSelector component
    ✓ should render correctly (97ms)
    ✓ should set the value upon selection in the modal (42ms)
    ✓ should clear the value upon clicking the clear button (26ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   1 passed, 1 total
Time:        4.075s, estimated 5s

```