### PR TITLE
Fix publish virtual-machines purpose tags style

### DIFF
--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -289,10 +289,10 @@
             = field_hash[:notes]
       - elsif [:tag_ids, :vm_tags].include?(field)
         -# tree control for tags fields
-        .col-md-10
+        .col-md-10.tagging-container
           = react('TaggingWrapperConnected',
             :tags    => @tags,
-            :options => { :type => 'provision', :hideHeaders => true, :hideButtons => true,
+            :options => { :type => 'provision', :hideHeaders => false, :hideButtons => true,
                           :url => url, :isDisabled => @tags[:isDisabled]})
           - unless field_hash[:notes_display] == :hide || field_hash[:notes].blank?
             -# Display notes if available


### PR DESCRIPTION
- Go to `Compute / Infrastructure / Virtual Machines / `
- Select a checkbox from the list
- From the Toolbar, Select` Lifecycle / Publish selected VM to a Template`
- Click on the `Purpose` Tab

Before
<img width="1530" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/a5fa1ddc-43f7-432a-9215-db7166f2f5e8">

After
<img width="770" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/849717f0-1a20-421f-8a8e-d73f55a1718b">
