### PR TITLE
Fix CopyCatalogForm test

### DIFF
--- a/app/javascript/spec/copy-catalog-form/copy-catalog-form.spec.js
+++ b/app/javascript/spec/copy-catalog-form/copy-catalog-form.spec.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import fetchMock from 'fetch-mock';
+import { act } from 'react-dom/test-utils'; // Import act
 import CopyCatalogForm from '../../components/copy-catalog-form/copy-catalog-form';
-
 import '../helpers/miqAjaxButton';
-import MiqFormRenderer from '../../forms/data-driven-form';
 import { mount } from '../helpers/mountForm';
 
 describe('Copy catalog form', () => {
@@ -22,43 +21,39 @@ describe('Copy catalog form', () => {
     copySavedUrl = '/catalog/servicetemplate_copy_saved';
     spyMiqAjaxButton = jest.spyOn(window, 'miqAjaxButton');
 
-    fetchMock
-      .getOnce('/catalog/servicetemplates_names', { names: ['Template1', 'Template2'] });
+    fetchMock.getOnce('/catalog/servicetemplates_names', { names: ['Template1', 'Template2'] });
   });
 
   afterEach(() => {
     fetchMock.restore();
   });
 
-  it('should handle cancel', (done) => {
+  it('should handle cancel', async () => {
     const wrapper = mount(<CopyCatalogForm {...initialProps} />);
 
-    setImmediate(() => {
+    await act(async() => {
+      await new Promise((resolve) => setImmediate(resolve));
       wrapper.update();
       wrapper.find('button.bx--btn--secondary').first().simulate('click');
-      expect(spyMiqAjaxButton).toHaveBeenCalledWith(cancelUrl);
-      done();
     });
+
+    expect(spyMiqAjaxButton).toHaveBeenCalledWith(cancelUrl);
   });
 
-  it('should handle submit', (done) => {
+  it('should handle submit', async() => {
     const postData = '{"id":"10000000000000","name":"Copy of Template1","copy_tags":false}';
-    fetchMock
-      .postOnce('/catalog/save_copy_catalog', {})
+    fetchMock.postOnce('/catalog/save_copy_catalog', {});
 
     const wrapper = mount(<CopyCatalogForm {...initialProps} />);
 
-    setTimeout(() => {
-
+    await act(async() => {
+      await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait for the form to initialize
       wrapper.update();
-      setTimeout(() => {
-        wrapper.find('form').simulate('submit');
-        setImmediate(() => {
-          expect(spyMiqAjaxButton).toHaveBeenCalledWith(copySavedUrl);
-          expect(fetchMock.lastOptions().body).toEqual(postData);
-          done();
-        });
-      }, 1000);
-    }, 1000);
+      wrapper.find('form').simulate('submit');
+      await new Promise((resolve) => setImmediate(resolve)); // Wait for any asynchronous actions triggered by submit
+    });
+
+    expect(spyMiqAjaxButton).toHaveBeenCalledWith(copySavedUrl);
+    expect(fetchMock.lastOptions().body).toEqual(postData);
   });
 });


### PR DESCRIPTION
`yarn run jest -t 'Copy catalog form' --testPathPattern app/javascript/spec/copy-catalog-form/copy-catalog-form.spec.js`

Before
```
console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to TextField inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in TextField (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by FormRenderer)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by CopyCatalogForm)
        in div (created by FlexGrid)
        in GridSettings (created by FlexGrid)
        in FlexGrid (created by Grid)
        in Grid (created by CopyCatalogForm)
        in CopyCatalogForm
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to FormSpy inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in FormSpy (created by FormTemplate)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by CopyCatalogForm)
        in div (created by FlexGrid)
        in GridSettings (created by FlexGrid)
        in FlexGrid (created by Grid)
        in Grid (created by CopyCatalogForm)
        in CopyCatalogForm
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to TextField inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in TextField (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by FormRenderer)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by CopyCatalogForm)
        in div (created by FlexGrid)
        in GridSettings (created by FlexGrid)
        in FlexGrid (created by Grid)
        in Grid (created by CopyCatalogForm)
        in CopyCatalogForm
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to FormSpy inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in FormSpy (created by FormTemplate)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by CopyCatalogForm)
        in div (created by FlexGrid)
        in GridSettings (created by FlexGrid)
        in FlexGrid (created by Grid)
        in Grid (created by CopyCatalogForm)
        in CopyCatalogForm
        in Provider (created by WrapperComponent)
        in WrapperComponent

 PASS  app/javascript/spec/copy-catalog-form/copy-catalog-form.spec.js
  Copy catalog form
    ✓ should handle cancel (78ms)
    ✓ should handle submit (2021ms)

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        5.81s
```

After
```
 PASS  app/javascript/spec/copy-catalog-form/copy-catalog-form.spec.js
  Copy catalog form
    ✓ should handle cancel (84ms)
    ✓ should handle submit (1027ms)

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        5.249s
```