### PR TITLE
Fix MiqStructuredListSub test

### DIFF
--- a/app/javascript/components/miq-structured-list/miq-structured-list-body/value-types/miq-structured-list-sub.jsx
+++ b/app/javascript/components/miq-structured-list/miq-structured-list-body/value-types/miq-structured-list-sub.jsx
@@ -18,7 +18,7 @@ export default MiqStructuredListSub;
 
 MiqStructuredListSub.propTypes = {
   row: PropTypes.shape({
-    subItems: PropTypes.shape({}).isRequired,
+    sub_items: PropTypes.arrayOf(PropTypes.any).isRequired,
   }).isRequired,
   clickEvents: PropTypes.bool.isRequired,
   onClick: PropTypes.func,


### PR DESCRIPTION
`yarn run jest -t 'MultilinkTable' --testPathPattern app/javascript/spec/textual_summary/tests/multilink_table.test.js
`

Before
```
 PASS  app/javascript/spec/textual_summary/tests/multilink_table.test.js
  MultilinkTable
    ✓ renders just fine (126ms)

  console.error node_modules/prop-types/checkPropTypes.js:20
    Warning: Failed prop type: The prop `row.subItems` is marked as required in `MiqStructuredListSub`, but its value is `undefined`.
        in MiqStructuredListSub (created by MiqStructuredListBodyValue)
        in MiqStructuredListBodyValue (created by MiqStructuredListBody)
        in div (created by StructuredListRow)
        in StructuredListRow (created by FeatureToggle(StructuredListRow))
        in FeatureToggle(StructuredListRow) (created by MiqStructuredListBody)
        in div (created by StructuredListBody)
        in StructuredListBody (created by FeatureToggle(StructuredListBody))
        in FeatureToggle(StructuredListBody) (created by MiqStructuredListBody)
        in MiqStructuredListBody (created by MiqStructuredList)
        in div (created by StructuredListWrapper)
        in StructuredListWrapper (created by FeatureToggle(StructuredListWrapper))
        in FeatureToggle(StructuredListWrapper) (created by MiqStructuredList)
        in div (created by AccordionItem)
        in li (created by AccordionItem)
        in AccordionItem (created by MiqStructuredList)
        in ul (created by Accordion)
        in Accordion (created by MiqStructuredList)
        in MiqStructuredList (created by MultilinkTable)
        in MultilinkTable (created by WrapperComponent)
        in WrapperComponent

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   1 passed, 1 total
Time:        4.653s
```


After
 ```
PASS  app/javascript/spec/textual_summary/tests/multilink_table.test.js
  MultilinkTable
    ✓ renders just fine (113ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   1 passed, 1 total
Time:        4.312s
```