### PR TITLE
Fix output page toolbar bugs

### DIFF
--- a/app/controllers/ansible_repository_controller.rb
+++ b/app/controllers/ansible_repository_controller.rb
@@ -48,10 +48,14 @@ class AnsibleRepositoryController < ApplicationController
         page.replace("gtl_div", :partial => "layouts/gtl")
       end
     when "ansible_repository_reload" # repository reload
-      show
-      render :update do |page|
-        page << javascript_prologue
-        page.replace("main_div", :template => "ansible_repository/show")
+      if @display == "output"
+        show
+        show_output
+        @display = "output" # reset @display back to "output" after show changes it to "main"
+        render_update("output_div", "output", true)
+      else
+        show
+        render_update("main_div", "show", false)
       end
     when "ansible_repository_tag" # tag repositories
       tag(self.class.model)
@@ -145,6 +149,17 @@ class AnsibleRepositoryController < ApplicationController
   end
 
   private
+
+  def render_update(div_id, partial, is_partial)
+    render :update do |page|
+      page << javascript_prologue
+      if is_partial
+        page.replace(div_id, :partial => "ansible_repository/#{partial}")
+      else
+        page.replace(div_id, :template => "ansible_repository/#{partial}")
+      end
+    end
+  end
 
   def textual_group_list
     [%i[properties relationships options smart_management]]

--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -3,17 +3,17 @@ module ApplicationController::Tags
 
   def nested_page?
     (@display == "repositories" && params[:controller] == "ansible_credential") ||
-    (@display == "playbooks" && params[:controller] == "ansible_repository") ||
-    (@display == "repositories" && params[:controller] == "workflow_credential") ||
-    (@display == "workflows" && params[:controller] == "workflow_repository")
+      (@display == "playbooks" && params[:controller] == "ansible_repository") ||
+      (@display == "repositories" && params[:controller] == "workflow_credential") ||
+      (@display == "workflows" && params[:controller] == "workflow_repository")
   end
 
   # Edit user, group or tenant tags
   def tagging_edit(db = nil, assert = true)
     if nested_page?
       assert_privileges("#{controller_for_common_methods}_tag")
-    else
-      assert_privileges("#{@display && @display != "main" ? @display.singularize : controller_for_common_methods}_tag") if assert
+    elsif assert
+      assert_privileges("#{@display && @display != "main" && @display != "output" ? @display.singularize : controller_for_common_methods}_tag")
     end
     @explorer = true if request.xml_http_request? # Ajax request means in explorer
 

--- a/app/controllers/workflow_repository_controller.rb
+++ b/app/controllers/workflow_repository_controller.rb
@@ -53,10 +53,14 @@ class WorkflowRepositoryController < ApplicationController
         page.replace("gtl_div", :partial => "layouts/gtl")
       end
     when "workflow_repository_reload" # repository reload
-      show
-      render :update do |page|
-        page << javascript_prologue
-        page.replace("main_div", :template => "workflow_repository/show")
+      if @display == "output"
+        show
+        show_output
+        @display = "output" # reset @display back to "output" after show changes it to "main"
+        render_update("output_div", "output", true)
+      else
+        show
+        render_update("main_div", "show", false)
       end
     when "ansible_repository_tag" # tag repositories
       tag(self.class.model)
@@ -145,6 +149,17 @@ class WorkflowRepositoryController < ApplicationController
   end
 
   private
+
+  def render_update(div_id, partial, is_partial)
+    render :update do |page|
+      page << javascript_prologue
+      if is_partial
+        page.replace(div_id, :partial => "workflow_repository/#{partial}")
+      else
+        page.replace(div_id, :template => "workflow_repository/#{partial}")
+      end
+    end
+  end
 
   def textual_group_list
     [%i[properties relationships options smart_management]]

--- a/app/helpers/application_helper/toolbar/ansible_repository_center.rb
+++ b/app/helpers/application_helper/toolbar/ansible_repository_center.rb
@@ -22,7 +22,6 @@ class ApplicationHelper::Toolbar::AnsibleRepositoryCenter < ApplicationHelper::T
           N_('Refresh this Repository'),
           N_('Refresh this Repository'),
           :klass   => ApplicationHelper::Button::EmbeddedAnsible,
-          :url     => "repository_refresh",
           :confirm => N_("Refresh this Repository?"),
           :enabled => true,
         ),

--- a/app/helpers/application_helper/toolbar/workflow_repository_center.rb
+++ b/app/helpers/application_helper/toolbar/workflow_repository_center.rb
@@ -23,7 +23,6 @@ class ApplicationHelper::Toolbar::WorkflowRepositoryCenter < ApplicationHelper::
                        N_('Refresh this Repository'),
                        N_('Refresh this Repository'),
                        :klass   => ApplicationHelper::Button::EmbeddedWorkflow,
-                       :url     => "repository_refresh",
                        :confirm => N_("Refresh this Repository?"),
                        :enabled => true,
                      ),

--- a/app/views/ansible_repository/_output.html.haml
+++ b/app/views/ansible_repository/_output.html.haml
@@ -1,5 +1,7 @@
-- if @record.last_update_error.nil?
-  = _('No output for the last refresh.')
-- else
-  %pre
-    = @record.last_update_error
+#flash_msg_div
+#output_div
+  - if @record.last_update_error.nil?
+    = _('No output for the last refresh.')
+  - else
+    %pre
+      = @record.last_update_error

--- a/app/views/workflow_repository/_output.html.haml
+++ b/app/views/workflow_repository/_output.html.haml
@@ -1,5 +1,7 @@
-- if @record.last_update_error.nil?
-  = _('No output for the last refresh.')
-- else
-  %pre
-    = @record.last_update_error
+#flash_msg_div
+#output_div
+  - if @record.last_update_error.nil?
+    = _('No output for the last refresh.')
+  - else
+    %pre
+      = @record.last_update_error


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/8839

To access the Refresh Output Page navigate to Embedded Ansible / Repositories or Embedded Workflows / Repositories page. If a Repository with an error status exists click on it, if not create a repository with a bad URL to get an error status. Then once on the Repository show screen click on the blue text in the Status row that says Error.

On the Refresh Output screen for the Embedded Ansible and Embedded Workflows Repository Pages there is several issues with the toolbar that are fixed by this pr.

Before:
1) Clicking the refresh button displays the Repository page instead of refreshing the Refresh Output page.
2) Clicking Configuration -> Refresh this Repository does not do anything
3) Clicking Policy -> Edit Tags leads to an error page:
<img width="1421" alt="Screenshot 2024-04-24 at 11 27 14 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/cc9345aa-a100-4ca6-89dd-7446c0110d9e">

After:
1) Clicking the refresh button will refresh the Refresh Output page
2) Clicking Configuration -> Refresh this Repository will initiate a refresh of that repository:
<img width="1408" alt="Screenshot 2024-04-24 at 11 31 12 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/1403cc9c-4e38-44e2-88d4-4dabf39c8a18">
3) Clicking Policy -> Edit Tags leads to the edit tags page for this repository:
<img width="1414" alt="Screenshot 2024-04-24 at 11 32 12 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/1c74c10d-77a0-442d-a783-83720bb9c75d">

