### PR TITLE
Don't double require rails environment

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,8 +2,6 @@ require 'simplecov'
 SimpleCov.start
 
 ENV["RAILS_ENV"] ||= 'test'
-require 'pathname'
-require Pathname.new(__dir__).join("manageiq/config/environment").to_s
 require 'rails-controller-testing'
 require 'rspec/rails'
 


### PR DESCRIPTION
The .rspec file will require core's spec_helper first, which will load the environment, followed by ui-classic's spec_helper, which tries to load the environment again.  Before the spec/spec_helper rubocop change in bdb223b37c, the require lines resolved to the same string. However, the rubocop change to switch from __dir__ to __FILE__ caused those requires to resolve to different strings. This happens because __dir__ applies realpath for symlinks, whereas it does not do this for __FILE__.

Regardless, we shouldn't be doing this double-require, so this commit just deletes those offending lines.

@jrafanie @kbrock Please review.