### PR TITLE
Fixed schedule summary page request value

### DIFF
--- a/app/helpers/settings_schedule_helper.rb
+++ b/app/helpers/settings_schedule_helper.rb
@@ -75,7 +75,7 @@ module SettingsScheduleHelper
     ]
 
     if schedule.next_run_on.present?
-      rows.push(row_data(_('Request'), schedule.filter[:uri_parts][:message]))
+      rows.push(row_data(_('Request'), schedule.filter[:parameters][:request]))
     else
       rows.push(row_data(_('Request'), ''))
     end


### PR DESCRIPTION
Fixed a bug where the message value was being displayed for both the message and request field on the schedule summary page.

Before:
<img width="1409" alt="Screenshot 2024-04-26 at 11 07 06 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/a49515a4-f474-4412-b2a7-87f6c9c716ef">

After:
<img width="1407" alt="Screenshot 2024-04-26 at 10 51 58 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/8c21e2c6-a107-405c-a90f-322c47e1a795">
