### PR TITLE
Remove multiple title for provisioning pages

### DIFF
--- a/app/stylesheet/miq-data-table.scss
+++ b/app/stylesheet/miq-data-table.scss
@@ -253,10 +253,15 @@
 .provision-instance-container {
   display: flex;
   flex-direction: column;
+  margin-top: 20px;
 
   .provision-instance-list {
-    height: calc(100vh - 255px);
+    height: calc(100vh - 200px);
     overflow: auto;
+
+    .miq-data-table {
+      margin-top: 0;
+    }
   }
   .provision-instance-actions {
 

--- a/app/views/miq_request/_pre_prov.html.haml
+++ b/app/views/miq_request/_pre_prov.html.haml
@@ -4,9 +4,6 @@
   - id = @edit[:req_id] || "new"
   - hide_deprecated_url = url_for_only_path(:action => "vm_pre_prov", :template_klass => params[:template_klass], :id => id.to_s)
 
-  %h3
-    = _("Provision %{what} based on the selected %{type}") % {:what => ui_lookup(:tables => request.parameters[:controller]), :type => typ}
-  %label
   = react('FilterProvisionInstance', {:hideDeprecated => @edit[:hide_deprecated_templates], :searchText => params[:search_text] || '', :url => hide_deprecated_url, :showCheckbox => show_checkbox})
 
   .provision-instance-container


### PR DESCRIPTION
Before
<img width="1530" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/b9a6bf14-8e79-490d-aafa-5eac8b815cc6">
<img width="1537" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/658ba615-0e7b-4eeb-9f52-656d7d553a96">

After

1. Removed extra title
2. Removed extra space at the top-right corner of the data-table where scroll bar is extended

<img width="898" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/d715c07a-ee8b-4961-836f-35111e36dfc5">

<img width="770" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/0cc3dbdb-5873-415d-9f78-fb89de9feb5c">
