### PR TITLE
Fix request page tags bug

### DIFF
--- a/app/views/miq_request/_request_dialog_details.html.haml
+++ b/app/views/miq_request/_request_dialog_details.html.haml
@@ -32,7 +32,9 @@
 
     - when 'DialogFieldTagControl'
       - value = wf.value(field.name) || '' # it returns in format Clasification::id
-      - classifications = value.split(',').map { |c| Classification.find_by(:id => c.split('::').second).description }
+      - classifications = value.split(',').map do |c|
+        - classification = Classification.find_by(id: c.split('::').second)
+        - classification.description if classification
       - if classifications.empty?
         = h('')
       -else


### PR DESCRIPTION
When the request page is displaying a dialog with a tag field that points to a tag value that was deleted or doesn't exist it runs into a UI error. This pr adds a check to see if the value exists to ensure it doesn't run into the error screen.

Before:
<img width="1411" alt="Screenshot 2024-05-02 at 10 54 55 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/f4891ef4-1639-424f-943c-2ef4db1de482">

After:
<img width="1388" alt="Screenshot 2024-05-02 at 11 08 53 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/bd16463a-df17-4ee2-9589-8584c34dba44">
