### PR TITLE
Fix HostEditForm test

### DIFF
--- a/app/javascript/spec/host-edit-form/helper-data.js
+++ b/app/javascript/spec/host-edit-form/helper-data.js
@@ -1,4 +1,4 @@
-export const samepleInitialValues = {
+export const sampleInitialValues = {
   id: '1',
   name: '10.197.65.254',
   hostname: null,
@@ -7,7 +7,7 @@ export const samepleInitialValues = {
   type: 'ManageIQ::Providers::IbmPowerHmc::InfraManager::Host',
 };
 
-export const sampleSingleReponse = {
+export const sampleSingleResponse = {
   data: {
     form_schema: {
       fields: [

--- a/app/javascript/spec/host-edit-form/host-edit-form.spec.js
+++ b/app/javascript/spec/host-edit-form/host-edit-form.spec.js
@@ -2,79 +2,59 @@ import React from 'react';
 import toJson from 'enzyme-to-json';
 import fetchMock from 'fetch-mock';
 import { act } from 'react-dom/test-utils';
-import { Button } from 'carbon-components-react';
 import HostEditForm from '../../components/host-edit-form/host-edit-form';
-import { samepleInitialValues, sampleSingleReponse, sampleMultiResponse } from './helper-data';
+import { sampleInitialValues, sampleSingleResponse, sampleMultiResponse } from './helper-data';
 
-import { mount, shallow } from '../helpers/mountForm';
+import { mount } from '../helpers/mountForm';
 import '../../oldjs/miq_application'; // for miqJqueryRequest
 import '../helpers/miqSparkle';
 
 describe('Show Edit Host Form Component', () => {
-  let submitSpy;
-
   const id = [1];
   const ids = [1, 2, 3];
 
   beforeEach(() => {
-    // fetchMock
-    //   .once('/api/event_streams', sampleReponse);
-    // submitSpy = jest.spyOn(window, 'miqJqueryRequest');
   });
 
   afterEach(() => {
     fetchMock.reset();
     fetchMock.restore();
-    // submitSpy.mockRestore();
   });
 
-  /*
- * Render Form
- */
-
+  /** Render Form */
   it('should render form for *one* host', async(done) => {
     let wrapper;
-    fetchMock
-      .get(`/api/hosts/${id[0]}?expand=resources&attributes=authentications`, samepleInitialValues)
-      .mock(`/api/hosts/${id[0]}`, sampleSingleReponse);
     await act(async() => {
+      fetchMock
+        .get(`/api/hosts/${id[0]}?expand=resources&attributes=authentications`, sampleInitialValues)
+        .mock(`/api/hosts/${id[0]}`, sampleSingleResponse);
       wrapper = mount(<HostEditForm ids={id} />);
     });
-    setImmediate(() => {
-      wrapper.update();
-      expect(toJson(wrapper)).toMatchSnapshot();
-      done();
+
+    // Wrap AsyncCredentials updates in act(...)
+    await act(async() => {
+      setImmediate(() => {
+        wrapper.update();
+        expect(toJson(wrapper)).toMatchSnapshot();
+        done();
+      });
     });
   });
 
   it('should render form for multiple hosts', async(done) => {
     let wrapper;
-    fetchMock.get(`/api/hosts?expand=resources&attributes=id,name&filter[]=id=[${ids}]`, sampleMultiResponse);
     await act(async() => {
+      fetchMock.get(`/api/hosts?expand=resources&attributes=id,name&filter[]=id=[${ids}]`, sampleMultiResponse);
       wrapper = mount(<HostEditForm ids={ids} />);
     });
-    setImmediate(() => {
-      wrapper.update();
-      expect(toJson(wrapper)).toMatchSnapshot();
-      done();
+
+    // Wrap AsyncCredentials updates in act(...)
+    await act(async() => {
+      setImmediate(() => {
+        wrapper.update();
+        expect(toJson(wrapper)).toMatchSnapshot();
+        done();
+      });
     });
   });
-
-  /*
- * Submit Logic
- */
-
-//   it('should not submit values when form is empty', async(done) => {
-//     let wrapper;
-//     await act(async() => {
-//       wrapper = mount(<TimelineOptions url="sample/url" />);
-//     });
-//     setImmediate(() => {
-//       wrapper.update();
-//       expect(wrapper.find(Button)).toHaveLength(1);
-//       wrapper.find(Button).first().simulate('click');
-//       expect(submitSpy).toHaveBeenCalledTimes(0);
-//       done();
-//     });
-//   });
 });


### PR DESCRIPTION
`yarn run jest -t 'Show Edit Host Form Component' --testPathPattern app/javascript/spec/host-edit-form/host-edit-form.spec.js`

Before
```
 PASS  app/javascript/spec/host-edit-form/host-edit-form.spec.js
  Show Edit Host Form Component
    ✓ should render form for *one* host (233ms)
    ✓ should render form for multiple hosts (28ms)

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to AsyncCredentials inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in AsyncCredentials (created by ValidateHostCredentials)
        in ValidateHostCredentials (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by Tabs)
        in div (created by Tabs)
        in div (created by TabContent)
        in TabContent (created by Tabs)
        in Tabs (created by Tabs)
        in Tabs (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by SubForm)
        in div (created by SubForm)
        in SubForm (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by FormRenderer)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by HostEditForm)
        in HostEditForm
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to AsyncCredentials inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in AsyncCredentials (created by ValidateHostCredentials)
        in ValidateHostCredentials (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by Tabs)
        in div (created by Tabs)
        in div (created by TabContent)
        in TabContent (created by Tabs)
        in Tabs (created by Tabs)
        in Tabs (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by SubForm)
        in div (created by SubForm)
        in SubForm (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by FormRenderer)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by HostEditForm)
        in HostEditForm
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to AsyncCredentials inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in AsyncCredentials (created by ValidateHostCredentials)
        in ValidateHostCredentials (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by Tabs)
        in div (created by Tabs)
        in div (created by TabContent)
        in TabContent (created by Tabs)
        in Tabs (created by Tabs)
        in Tabs (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by SubForm)
        in div (created by SubForm)
        in SubForm (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by FormRenderer)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by HostEditForm)
        in HostEditForm
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to AsyncCredentials inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in AsyncCredentials (created by ValidateHostCredentials)
        in ValidateHostCredentials (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by Tabs)
        in div (created by Tabs)
        in div (created by TabContent)
        in TabContent (created by Tabs)
        in Tabs (created by Tabs)
        in Tabs (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by SubForm)
        in div (created by SubForm)
        in SubForm (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by FormRenderer)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by HostEditForm)
        in HostEditForm
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to AsyncCredentials inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in AsyncCredentials (created by ValidateHostCredentials)
        in ValidateHostCredentials (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by Tabs)
        in div (created by Tabs)
        in div (created by TabContent)
        in TabContent (created by Tabs)
        in Tabs (created by Tabs)
        in Tabs (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by SubForm)
        in div (created by SubForm)
        in SubForm (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by FormRenderer)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by HostEditForm)
        in HostEditForm
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to AsyncCredentials inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in AsyncCredentials (created by ValidateHostCredentials)
        in ValidateHostCredentials (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by Tabs)
        in div (created by Tabs)
        in div (created by TabContent)
        in TabContent (created by Tabs)
        in Tabs (created by Tabs)
        in Tabs (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by SubForm)
        in div (created by SubForm)
        in SubForm (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by FormRenderer)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by HostEditForm)
        in HostEditForm
        in Provider (created by WrapperComponent)
        in WrapperComponent

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   2 passed, 2 total
Time:        3.968s
```

After
```
 PASS  app/javascript/spec/host-edit-form/host-edit-form.spec.js
  Show Edit Host Form Component
    ✓ should render form for *one* host (176ms)
    ✓ should render form for multiple hosts (25ms)

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   2 passed, 2 total
Time:        3.835s
```