### PR TITLE
Fix ansible tower and embedded workflows lists

### DIFF
--- a/app/controllers/configuration_script_controller.rb
+++ b/app/controllers/configuration_script_controller.rb
@@ -14,8 +14,8 @@ class ConfigurationScriptController < ApplicationController
   menu_section :at
   feature_for_actions controller_name, *ADV_SEARCH_ACTIONS
 
-  def self.table_name
-    @table_name ||= "configuration_script"
+  def self.model
+    ManageIQ::Providers::ExternalAutomationManager::ConfigurationScript
   end
 
   def button

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -399,6 +399,8 @@ module ApplicationHelper
       action = "show"
     when "ServiceResource", "ServiceTemplate"
       controller = "catalog"
+    when "ManageIQ::Providers::ExternalAutomationManager::ConfigurationScript"
+      controller = "configuration_script"
     when "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook"
       controller = "ansible_playbook"
     when "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential"

--- a/app/helpers/application_helper/title.rb
+++ b/app/helpers/application_helper/title.rb
@@ -85,6 +85,8 @@ module ApplicationHelper
         _("Utilization")
       when /^miq_request/
         _("Requests")
+      when "configuration_script"
+        _("Templates")
       when "manageiq/providers/ansible_tower/automation_manager/playbook"
         _("Playbooks (Ansible Tower)")
       when "manageiq/providers/embedded_ansible/automation_manager/playbook"

--- a/app/javascript/oldjs/services/dialog_editor_http_service.js
+++ b/app/javascript/oldjs/services/dialog_editor_http_service.js
@@ -34,7 +34,7 @@ ManageIQ.angular.app.service('DialogEditorHttp', ['$http', 'API', function($http
 
   /** Function to load all available workflows when 'Embedded Workflow' is selected for dynamic field. */
   this.loadAvailableWorkflows = () => {
-    const url = '/api/configuration_script_payloads/?expand=resources&attributes=configuration_script_source.name';
+    const url = '/api/configuration_script_payloads/?expand=resources&attributes=configuration_script_source.name&collection_class=ManageIQ::Providers::Workflows::AutomationManager::Workflow';
     return API.get(url);
   };
 


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/8987
Also needs this pr: https://github.com/ManageIQ/manageiq/pull/23032 to fix the title

Before:
On the Automation / Automation / Templates screen the list is showing Workflow instances in the list.
<img width="1400" alt="Screenshot 2024-05-08 at 2 00 58 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/670cd869-f1f8-4156-9b58-4dd2a008207d">

On the Automation / Embedded Automate / Customization / Create or Edit Service Dialog screen when using a dynamic drop down with embedded workflows it shows ansible repositories in the list.
<img width="926" alt="Screenshot 2024-05-08 at 2 04 02 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/3e9d8f5d-7bd7-483a-978d-73fc2c7f139e">

After:
Workflow instances no longer show up in the Ansible Tower Templates list.
<img width="1410" alt="Screenshot 2024-05-08 at 2 04 49 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/fc29b64f-d8a8-4327-b4e1-935ba39ca2f3">

The embedded workflows list on the service dialog for dynamic drop downs now only shows embedded workflow repositories.
<img width="981" alt="Screenshot 2024-05-08 at 2 06 09 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/2711c360-2f6e-4641-ad9e-88c86a89d65d">
