### PR TITLE
Fix CopyDashboardForm test

### DIFF
--- a/app/javascript/spec/copy-dashboard-form/copy-dashboard-form.spec.js
+++ b/app/javascript/spec/copy-dashboard-form/copy-dashboard-form.spec.js
@@ -113,7 +113,7 @@ describe('Copy Dashboard form', () => {
     done();
   });
 
-  it('should handle submit', async(done) => {
+  it('should handle submit', async() => {
     fetchMock
       .getOnce(baseUrl, dashboardData)
       .getOnce(apiUrl, apiData)
@@ -133,16 +133,19 @@ describe('Copy Dashboard form', () => {
     await act(async() => {
       wrapper.find('input[name="name"]').simulate('change', { target: { value: 'new_name' } });
       wrapper.find('input[name="group_id"]').simulate('change', { target: { value: '80s' } });
-      wrapper.find('form').simulate('submit');
     });
 
-    setTimeout(() => {
-      expect(spyMiqAjaxButton).toHaveBeenCalledWith(
-        '/report/dashboard_render',
-        { group: 'current group', name: 'new_name', original_name: 'original_name' },
-      );
-      expect(fetchMock.calls()).toHaveLength(4);
-      done();
-    }, 500);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    wrapper.update();
+
+    await act(async() => {
+      setTimeout(() => {
+        expect(spyMiqAjaxButton).toHaveBeenCalledWith(
+          '/report/dashboard_render',
+          { group: 'current group', name: 'new_name', original_name: 'original_name' },
+        );
+        expect(fetchMock.calls()).toHaveLength(4);
+      }, 500);
+    });
   });
 });


### PR DESCRIPTION
`yarn run jest -t 'Copy Dashboard form' --testPathPattern app/javascript/spec/copy-dashboard-form/copy-dashboard-form.spec.js`

Before
```
console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to TextField inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in TextField (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by SubForm)
        in div (created by SubForm)
        in SubForm (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by FormRenderer)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by CopyDashboardForm)
        in div (created by FlexGrid)
        in GridSettings (created by FlexGrid)
        in FlexGrid (created by Grid)
        in Grid (created by CopyDashboardForm)
        in CopyDashboardForm
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to FormSpy inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in FormSpy (created by FormTemplate)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by CopyDashboardForm)
        in div (created by FlexGrid)
        in GridSettings (created by FlexGrid)
        in FlexGrid (created by Grid)
        in Grid (created by CopyDashboardForm)
        in CopyDashboardForm
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to TextField inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in TextField (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by SubForm)
        in div (created by SubForm)
        in SubForm (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by FormRenderer)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by CopyDashboardForm)
        in div (created by FlexGrid)
        in GridSettings (created by FlexGrid)
        in FlexGrid (created by Grid)
        in Grid (created by CopyDashboardForm)
        in CopyDashboardForm
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to FormSpy inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in FormSpy (created by FormTemplate)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by CopyDashboardForm)
        in div (created by FlexGrid)
        in GridSettings (created by FlexGrid)
        in FlexGrid (created by Grid)
        in Grid (created by CopyDashboardForm)
        in CopyDashboardForm
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to TextField inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in TextField (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by SubForm)
        in div (created by SubForm)
        in SubForm (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by FormRenderer)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by CopyDashboardForm)
        in div (created by FlexGrid)
        in GridSettings (created by FlexGrid)
        in FlexGrid (created by Grid)
        in Grid (created by CopyDashboardForm)
        in CopyDashboardForm
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to FormSpy inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in FormSpy (created by FormTemplate)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by CopyDashboardForm)
        in div (created by FlexGrid)
        in GridSettings (created by FlexGrid)
        in FlexGrid (created by Grid)
        in Grid (created by CopyDashboardForm)
        in CopyDashboardForm
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to FormSpy inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in FormSpy (created by FormTemplate)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by CopyDashboardForm)
        in div (created by FlexGrid)
        in GridSettings (created by FlexGrid)
        in FlexGrid (created by Grid)
        in Grid (created by CopyDashboardForm)
        in CopyDashboardForm
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to FormSpy inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in FormSpy (created by FormTemplate)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by CopyDashboardForm)
        in div (created by FlexGrid)
        in GridSettings (created by FlexGrid)
        in FlexGrid (created by Grid)
        in Grid (created by CopyDashboardForm)
        in CopyDashboardForm
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to ReactFinalForm inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by CopyDashboardForm)
        in div (created by FlexGrid)
        in GridSettings (created by FlexGrid)
        in FlexGrid (created by Grid)
        in Grid (created by CopyDashboardForm)
        in CopyDashboardForm
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to TextField inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in TextField (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by SubForm)
        in div (created by SubForm)
        in SubForm (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by FormRenderer)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by CopyDashboardForm)
        in div (created by FlexGrid)
        in GridSettings (created by FlexGrid)
        in FlexGrid (created by Grid)
        in Grid (created by CopyDashboardForm)
        in CopyDashboardForm
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to TextField inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in TextField (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by SubForm)
        in div (created by SubForm)
        in SubForm (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by FormRenderer)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by CopyDashboardForm)
        in div (created by FlexGrid)
        in GridSettings (created by FlexGrid)
        in FlexGrid (created by Grid)
        in Grid (created by CopyDashboardForm)
        in CopyDashboardForm
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to Select inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in Select (created by SelectWithOnChange)
        in SelectWithOnChange (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by SubForm)
        in div (created by SubForm)
        in SubForm (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by FormRenderer)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by CopyDashboardForm)
        in div (created by FlexGrid)
        in GridSettings (created by FlexGrid)
        in FlexGrid (created by Grid)
        in Grid (created by CopyDashboardForm)
        in CopyDashboardForm
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to FormSpy inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in FormSpy (created by FormTemplate)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by CopyDashboardForm)
        in div (created by FlexGrid)
        in GridSettings (created by FlexGrid)
        in FlexGrid (created by Grid)
        in Grid (created by CopyDashboardForm)
        in CopyDashboardForm
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to ReactFinalForm inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by CopyDashboardForm)
        in div (created by FlexGrid)
        in GridSettings (created by FlexGrid)
        in FlexGrid (created by Grid)
        in Grid (created by CopyDashboardForm)
        in CopyDashboardForm
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to TextField inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in TextField (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by SubForm)
        in div (created by SubForm)
        in SubForm (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by FormRenderer)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by CopyDashboardForm)
        in div (created by FlexGrid)
        in GridSettings (created by FlexGrid)
        in FlexGrid (created by Grid)
        in Grid (created by CopyDashboardForm)
        in CopyDashboardForm
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to TextField inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in TextField (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by SubForm)
        in div (created by SubForm)
        in SubForm (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by FormRenderer)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by CopyDashboardForm)
        in div (created by FlexGrid)
        in GridSettings (created by FlexGrid)
        in FlexGrid (created by Grid)
        in Grid (created by CopyDashboardForm)
        in CopyDashboardForm
        in Provider (created by WrapperComponent)
        in WrapperComponent

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: An update to Select inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in Select (created by SelectWithOnChange)
        in SelectWithOnChange (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by SubForm)
        in div (created by SubForm)
        in SubForm (created by SingleField)
        in FormFieldHideWrapper (created by SingleField)
        in FormConditionWrapper (created by SingleField)
        in SingleField (created by FormRenderer)
        in form (created by Form)
        in Form (created by Form)
        in Form (created by FormTemplate)
        in FormTemplate (created by WrappedFormTemplate)
        in WrappedFormTemplate
        in Unknown (created by ReactFinalForm)
        in ReactFinalForm (created by FormRenderer)
        in FormRenderer (created by MiqFormRenderer)
        in MiqFormRenderer (created by Connect(MiqFormRenderer))
        in Connect(MiqFormRenderer) (created by CopyDashboardForm)
        in div (created by FlexGrid)
        in GridSettings (created by FlexGrid)
        in FlexGrid (created by Grid)
        in Grid (created by CopyDashboardForm)
        in CopyDashboardForm
        in Provider (created by WrapperComponent)
        in WrapperComponent

 PASS  app/javascript/spec/copy-dashboard-form/copy-dashboard-form.spec.js
  Copy Dashboard form
    ✓ should render correctly and set initialValue (107ms)
    ✓ should handle error (6ms)
    ✓ should handle cancel (28ms)
    ✓ should handle submit (544ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        4.985s
```


After


```

 PASS  app/javascript/spec/copy-dashboard-form/copy-dashboard-form.spec.js
  Copy Dashboard form
    ✓ should render correctly and set initialValue (98ms)
    ✓ should handle error (5ms)
    ✓ should handle cancel (24ms)
    ✓ should handle submit (32ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        4.155s
```