### PR TITLE
Fix for vault credentials in service-catalog's provisioning and retirement summary

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -193,7 +193,6 @@ module CatalogHelper
       rows.push(row_data(_('Playbook'), info[:playbook]))
       rows.push(row_data(_('Machine Credential'), info[:machine_credential]))
       rows.push(row_data(_('Vault Credential'), info[:vault_credential]))
-      rows.push(row_data(_('Vault Credential'), info[:vault_credential]))
       rows.push(row_data(_('Cloud Credential'), info[:cloud_credential]))
       rows.push(row_data(_('Max TTL (mins)'), record.config_info[type][:execution_ttl]))
       rows.push(row_data(_('Hosts'), record.config_info[type][:hosts]))

--- a/app/javascript/components/ansible-playbook-edit-catalog-form/schema.js
+++ b/app/javascript/components/ansible-playbook-edit-catalog-form/schema.js
@@ -163,8 +163,8 @@ const provisionTabSchema = (
       },
       {
         component: componentTypes.SELECT,
-        id: 'config_info.provision.vault_credentials',
-        name: 'config_info.provision.vault_credentials',
+        id: 'config_info.provision.vault_credential_id',
+        name: 'config_info.provision.vault_credential_id',
         label: __('Vault Credential'),
         options: transformGeneralOptions(vaultCredentials),
         condition: {
@@ -371,8 +371,8 @@ const retirementTabSchema = (
       },
       {
         component: componentTypes.SELECT,
-        id: 'config_info.retirement.vault_credentials',
-        name: 'config_info.retirement.vault_credentials',
+        id: 'config_info.retirement.vault_credential_id',
+        name: 'config_info.retirement.vault_credential_id',
         label: __('Vault Credential'),
         options: transformGeneralOptions(vaultCredentials),
         condition: {


### PR DESCRIPTION
Related PR - https://github.com/ManageIQ/manageiq-schema/pull/734

**Before**

- Catalog item > Provisions

![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/160720663/62954e41-70d4-44ba-9c41-9f31027b0e2e)

- Catalog item > Retirement

![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/160720663/e3788c46-90a7-4821-81c9-7292f75e5528)

In both provisioning and retirement, 'Vault Credentials' were empty and displayed twice.

**After**

- - Catalog item > Provisions

![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/160720663/2a3d5c4c-4eee-4905-bbf8-79ca237e5cd2)

- Catalog item > Retirement

![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/160720663/a25e96fd-115d-4954-818b-227424775205)

- The duplicate vault credentials column has been eliminated.




**Reason**
```

`#<ServiceTemplateAnsiblePlaybook id: 171, name: "playbook testing", description: "palybook testing", guid: "cfd1d461-cd05-4284-8ce5-6501f6dae4d0", type: "ServiceTemplateAnsiblePlaybook", service_template_id: nil, options: {:config_info=>

{:provision=>{:repository_id=>"39", :playbook_id=>"739", :credential_id=>"173", :vault_credential_id=>"194", :execution_ttl=>"", :log_output=>"always", :verbosity=>"0", :extra_vars=>{}, :dialog_id=>"49", :hosts=>"localhost", :fqname=>"/Service/Generic/StateMachines/GenericLifecycle/provision"}, 

:retirement=>{:repository_id=>"38", :playbook_id=>"648", :credential_id=>"173", :vault_credential_id=>"194", :log_output=>"on_error", :verbosity=>"0", :remove_resources=>"no_with_playbook", :hosts=>"localhost", :fqname=>"/Service/Generic/StateMachines/GenericLifecycle/Retire_Advanced_Resource_None"}}}, 

created_at: "2024-05-03 10:39:47.175428000 +0000", updated_at: "2024-05-14 11:24:08.943383000 +0000", display: true, evm_owner_id: nil, miq_group_id: 2, service_type: "atomic", prov_type: "generic_ansible_playbook", provision_cost: nil, service_template_catalog_id: 8, long_description: "", tenant_id: 1, generic_subtype: nil, deleted_on: nil, internal: false, zone_id: 5, currency_id: 20, price: 10.0>`

```

In both provisioning and retirement, the value passed is '`vault_credential_id`', but '`vault_credential_id`' does not exist; it should be '`vault_credentials`'