### PR TITLE
Fix workflow states table

### DIFF
--- a/app/javascript/components/request-workflow-status/data.js
+++ b/app/javascript/components/request-workflow-status/data.js
@@ -5,6 +5,7 @@ export const workflowStateTypes = {
   failure: { text: 'failure', tagType: 'red' },
   failed: { text: 'failed', tagType: 'gray' },
   pending: { text: 'pending', tagType: 'gray' },
+  running: { text: 'running', tagType: 'gray' },
 };
 
 /** Function to get the header data of workflow states table. */

--- a/app/javascript/components/request-workflow-status/request-workflow-status-item.jsx
+++ b/app/javascript/components/request-workflow-status/request-workflow-status-item.jsx
@@ -87,11 +87,14 @@ const RequestWorkflowStatusItem = ({ recordId }) => {
   /** Function to render the status of workflow. */
   const renderStatusTag = () => {
     const status = workflowStateTypes[data.responseData.status];
-    return (
-      <Tag type={status.tagType} title={status.text}>
-        {status.text.toUpperCase()}
-      </Tag>
-    );
+    if (typeof (status) === 'object' && status.tagType && status.text) {
+      return (
+        <Tag type={status.tagType} title={status.text}>
+          {status.text.toUpperCase()}
+        </Tag>
+      );
+    }
+    return null;
   };
 
   /** Function to render the status of workflow status. */
@@ -117,13 +120,18 @@ const RequestWorkflowStatusItem = ({ recordId }) => {
   );
 
   /** Function to render the list. */
-  const renderList = ({ headers, rows }) => (
-    <MiqDataTable
-      headers={headers}
-      rows={rows}
-      mode="request-workflow-status"
-    />
-  );
+  const renderList = ({ headers, rows }) => {
+    rows.forEach((row) => {
+      row.id = `${row.id}+${row.duration}`;
+    });
+    return (
+      <MiqDataTable
+        headers={headers}
+        rows={rows}
+        mode="request-workflow-status"
+      />
+    );
+  };
 
   return (
     <>


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/9185

Fixes a bug where the Workflow States Table breaks when the workflow item status is "running".

Before:
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/6a9948d3-dfab-4cf2-a308-ce2ed43bc623)

After:
<img width="1401" alt="Screenshot 2024-05-14 at 5 00 13 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/a704016b-d423-4ff7-8d84-e17b186924ba">

When the status is running the rows override each other since they have the same id. So made changes to the ids to prevent this and fix the table.

<img width="1403" alt="Screenshot 2024-05-14 at 5 01 14 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/84c32438-bc7f-41a8-aa09-2b83d73be15d">
