### PR TITLE
Add current state to workflow states table and format duration time

### DIFF
--- a/app/javascript/components/miq-data-table/miq-table-cell.jsx
+++ b/app/javascript/components/miq-data-table/miq-table-cell.jsx
@@ -10,6 +10,7 @@ import {
   CellAction, hasIcon, hasImage, hasButton, hasTextInput, hasToggle, hasLink, isObject, isArray, isNumber, decimalCount,
 } from './helper';
 import { customOnClickHandler } from '../../helpers/custom-click-handler';
+import { carbonizeIcon } from '../../menu/icon';
 
 const MiqTableCell = ({
   cell, onCellClick, row, truncate,
@@ -74,6 +75,20 @@ const MiqTableCell = ({
     );
   };
 
+  const returnIcon = (icon, style, styledIconClass, longerTextClass, index = undefined) => {
+    const extraProps = {};
+    if (index !== undefined) {
+      extraProps.key = index.toString();
+    }
+    if (icon.startsWith('carbon--')) {
+      const IconElement = carbonizeIcon(icon);
+      return (
+        <IconElement aria-label={icon} className={classNames('icon', 'carbon-icons-style', icon)} style={style} {...extraProps} />
+      );
+    }
+    return (<i className={classNames('fa-lg', 'icon', icon, styledIconClass, longerTextClass)} style={style} {...extraProps} />);
+  };
+
   /** Function to render icon(s) in cell. */
   const renderIcon = (icon, style, showText) => {
     const hasBackground = Object.keys(style).includes('background');
@@ -83,8 +98,8 @@ const MiqTableCell = ({
       <div className={cellClass}>
         {
           typeof (icon) === 'string'
-            ? <i className={classNames('fa-lg', 'icon', icon, styledIconClass, longerTextClass)} style={style} />
-            : icon.map((i, index) => <i className={classNames('fa-lg', 'icon', i)} key={index.toString()} />)
+            ? returnIcon(icon, style, styledIconClass, longerTextClass)
+            : icon.map((i, index) => returnIcon(i, style, styledIconClass, longerTextClass, index))
         }
         {showText && truncateText}
       </div>

--- a/app/stylesheet/miq-data-table.scss
+++ b/app/stylesheet/miq-data-table.scss
@@ -1,3 +1,9 @@
+:root {
+  --green: #2d7623;
+  --red: #cc0000;
+  --yellow: #ec7a08;
+}
+
 .tenant-quota-data-table {
   .miq-data-table {
     margin-bottom: 32px;
@@ -113,7 +119,7 @@
       }
 
       .icon.fa-ruby {
-        color: #cc0000 !important;
+        color: var(--red) !important;
       }
 
       span {
@@ -387,3 +393,20 @@ table.miq_preview {
   }
 }
 
+.request-workflow-status {
+  .carbon-icons-style {
+    margin-right: 5px;
+  }
+
+  .carbon--CheckmarkOutline {
+    color: var(--green);
+  }
+
+  .carbon--MisuseOutline {
+    color: var(--red);
+  }
+
+  .carbon--PlayOutline {
+    color: var(--yellow)
+  }
+}


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/9189

Adds the current state to the workflow states table. Also, formats the duration time to be displays as a string in days hours minutes seconds format instead of just seconds.

Before:
<img width="1407" alt="Screenshot 2024-05-17 at 9 43 27 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/4704c8c0-df4c-415c-a3e2-552e55896a62">

After:
<img width="1409" alt="Screenshot 2024-05-23 at 4 53 58 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/1ee35fa9-16bf-4862-bd8d-86c2c1f549ec">
