### PR TITLE
Remove current workflow state if its done

### DIFF
--- a/app/javascript/components/request-workflow-status/data.js
+++ b/app/javascript/components/request-workflow-status/data.js
@@ -89,7 +89,7 @@ export const workflowStatusData = (response) => {
     return undefined;
   }
   const rows = response.context ? rowData(response.context) : [];
-  if (response.context && response.context.State) {
+  if (response.context && response.context.State && !response.context.State.FinishedTime) {
     const state = response.context.State;
     const currentTime = new Date(); // Date Object for current time
     const oldTime = Date.parse(state.EnteredTime); // ms since start time to entered time in UTC


### PR DESCRIPTION
Follow up to pr: #9191 

When the current state is done its value is not removed from the context.State but also exists in the context.StateHistory. This pr prevents this state from rendering in the table as both a past state and current state and instead will only render it as a past state.

Before:
<img width="1398" alt="Screenshot 2024-05-24 at 10 21 57 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/60aca443-18e7-48c4-bad8-a817e1da81a6">

After:
<img width="1391" alt="Screenshot 2024-05-24 at 10 22 57 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/d10bc9d4-7b0a-472e-8ffa-e29ed0bd1892">
