### PR TITLE
Fix guest devices summary page

### DIFF
--- a/app/controllers/guest_device_controller.rb
+++ b/app/controllers/guest_device_controller.rb
@@ -3,6 +3,7 @@ class GuestDeviceController < ApplicationController
   include Mixins::GenericShowMixin
   include Mixins::MoreShowActions
   include Mixins::GenericSessionMixin
+  include Mixins::BreadcrumbsMixin
 
   before_action :check_privileges
   before_action :get_session_data
@@ -17,6 +18,12 @@ class GuestDeviceController < ApplicationController
 
   def model
     self.class.model
+  end
+
+  def download_summary_pdf
+    assert_privileges('embedded_automation_manager_credentials_view')
+
+    super
   end
 
   def self.table_name
@@ -34,4 +41,12 @@ class GuestDeviceController < ApplicationController
     ]
   end
   helper_method(:textual_group_list)
+
+  def breadcrumbs_options
+    {
+      :breadcrumbs => [
+        {:title => _("Guest Devices"), :url => controller_url},
+      ],
+    }
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1308,6 +1308,7 @@ Rails.application.routes.draw do
         show_list
         show
         quick_search
+        download_summary_pdf
       ],
 
       :post   =>  %w[


### PR DESCRIPTION
Fixed guest devices summary page. Fixed the issue with the breadcrumbs missing and the print summary button not working.

Before:
<img width="697" alt="Screenshot 2024-05-28 at 2 05 56 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/2c210a24-e2a5-45c0-bd9b-0396aebfb67b">
<img width="1431" alt="Screenshot 2024-05-28 at 2 07 14 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/e29df38a-f30b-4f68-979f-3daf533f558c">


After:
<img width="1216" alt="Screenshot 2024-05-28 at 2 09 29 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/58ba532b-e13b-49cb-a95f-11893a1ec61b">
<img width="1496" alt="Screenshot 2024-05-28 at 2 08 24 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/92085cc1-d157-422b-8d89-c97ca8bf2fb6">

