### PR TITLE
Show volume templates in image list view

### DIFF
--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -160,7 +160,7 @@ module Mixins
     end
 
     def display_images
-      nested_list(ManageIQ::Providers::CloudManager::Template, :named_scope => :without_volume_templates)
+      nested_list(ManageIQ::Providers::CloudManager::Template)
     end
 
     # options:


### PR DESCRIPTION
In the case of the IBM CIC provider, the count of images on the provider dashboard screen was not matching the number of images seen on the list view. This is because the count on the dashboard screen was accounting for `::Openstack::CloudManager::VolumeSnapshotTemplate` and `::Openstack::CloudManager::VolumeTemplate` whereas the list view was not. (CIC is a subclass of Openstack)

It was decided that the count on the dashboard is correct and that the list view should be showing the volume templates.

<img width="1446" alt="Screenshot 2024-05-29 at 11 38 02 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/48186199/45ce060d-2d56-4a13-a6b6-f02efd31d0e0">

Before:
<img width="1459" alt="Screenshot 2024-05-29 at 11 27 57 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/48186199/72b95a46-73fd-4e0c-9a0c-0e915debc142">

After:
<img width="1458" alt="Screenshot 2024-05-29 at 11 22 54 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/48186199/4df080bb-1f02-4763-a415-05ca3e60ee12">

@miq-bot add_reviewer @agrare, @kbrock
@miq-bot assign @agrare 
@miq-bot add_label bug, radjabov/yes?

