### PR TITLE
Hide policy simulation button

### DIFF
--- a/app/helpers/application_helper/toolbar/miq_templates_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_templates_center.rb
@@ -77,15 +77,16 @@ class ApplicationHelper::Toolbar::MiqTemplatesCenter < ApplicationHelper::Toolba
           :send_checked => true,
           :enabled      => false,
           :onwhen       => "1+"),
-        button(
-          :miq_template_policy_sim,
-          'fa fa-play-circle-o fa-lg',
-          N_('View Policy Simulation for the selected Templates'),
-          N_('Policy Simulation'),
-          :url_parms    => "main_div",
-          :send_checked => true,
-          :enabled      => false,
-          :onwhen       => "1+"),
+        # TODO: Add this button back when the page is fixed
+        # button(
+        #   :miq_template_policy_sim,
+        #   'fa fa-play-circle-o fa-lg',
+        #   N_('View Policy Simulation for the selected Templates'),
+        #   N_('Policy Simulation'),
+        #   :url_parms    => "main_div",
+        #   :send_checked => true,
+        #   :enabled      => false,
+        #   :onwhen       => "1+"),
         button(
           :miq_template_tag,
           'pficon pficon-edit fa-lg',

--- a/app/helpers/application_helper/toolbar/template_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/template_clouds_center.rb
@@ -107,15 +107,16 @@ class ApplicationHelper::Toolbar::TemplateCloudsCenter < ApplicationHelper::Tool
           :send_checked => true,
           :enabled      => false,
           :onwhen       => "1+"),
-        button(
-          :image_policy_sim,
-          'fa fa-play-circle-o fa-lg',
-          N_('View Policy Simulation for the selected items'),
-          N_('Policy Simulation'),
-          :url_parms    => "main_div",
-          :send_checked => true,
-          :enabled      => false,
-          :onwhen       => "1+"),
+        # TODO: Add this button back when the page is fixed
+        # button(
+        #   :image_policy_sim,
+        #   'fa fa-play-circle-o fa-lg',
+        #   N_('View Policy Simulation for the selected items'),
+        #   N_('Policy Simulation'),
+        #   :url_parms    => "main_div",
+        #   :send_checked => true,
+        #   :enabled      => false,
+        #   :onwhen       => "1+"),
         button(
           :image_tag,
           'pficon pficon-edit fa-lg',

--- a/app/helpers/application_helper/toolbar/template_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/template_infras_center.rb
@@ -87,15 +87,16 @@ class ApplicationHelper::Toolbar::TemplateInfrasCenter < ApplicationHelper::Tool
           :send_checked => true,
           :enabled      => false,
           :onwhen       => "1+"),
-        button(
-          :miq_template_policy_sim,
-          'fa fa-play-circle-o fa-lg',
-          N_('View Policy Simulation for the selected Templates'),
-          N_('Policy Simulation'),
-          :url_parms    => "main_div",
-          :send_checked => true,
-          :enabled      => false,
-          :onwhen       => "1+"),
+        # TODO: Add this button back when the page is fixed
+        # button(
+        #   :miq_template_policy_sim,
+        #   'fa fa-play-circle-o fa-lg',
+        #   N_('View Policy Simulation for the selected Templates'),
+        #   N_('Policy Simulation'),
+        #   :url_parms    => "main_div",
+        #   :send_checked => true,
+        #   :enabled      => false,
+        #   :onwhen       => "1+"),
         button(
           :miq_template_tag,
           'pficon pficon-edit fa-lg',

--- a/app/helpers/application_helper/toolbar/vm_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_clouds_center.rb
@@ -96,15 +96,16 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           :send_checked => true,
           :enabled      => false,
           :onwhen       => "1+"),
-        button(
-          :instance_policy_sim,
-          'fa fa-play-circle-o fa-lg',
-          N_('View Policy Simulation for the selected items'),
-          N_('Policy Simulation'),
-          :url_parms    => "main_div",
-          :send_checked => true,
-          :enabled      => false,
-          :onwhen       => "1+"),
+        # TODO: Add this button back when the page is fixed
+        # button(
+        #   :instance_policy_sim,
+        #   'fa fa-play-circle-o fa-lg',
+        #   N_('View Policy Simulation for the selected items'),
+        #   N_('Policy Simulation'),
+        #   :url_parms    => "main_div",
+        #   :send_checked => true,
+        #   :enabled      => false,
+        #   :onwhen       => "1+"),
         button(
           :instance_tag,
           'pficon pficon-edit fa-lg',

--- a/app/helpers/application_helper/toolbar/vm_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_infras_center.rb
@@ -124,15 +124,16 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           :send_checked => true,
           :enabled      => false,
           :onwhen       => "1+"),
-        button(
-          :vm_policy_sim,
-          'fa fa-play-circle-o fa-lg',
-          N_('View Policy Simulation for the selected items'),
-          N_('Policy Simulation'),
-          :url_parms    => "main_div",
-          :send_checked => true,
-          :enabled      => false,
-          :onwhen       => "1+"),
+        # TODO: Add this button back when the page is fixed
+        # button(
+        #   :vm_policy_sim,
+        #   'fa fa-play-circle-o fa-lg',
+        #   N_('View Policy Simulation for the selected items'),
+        #   N_('Policy Simulation'),
+        #   :url_parms    => "main_div",
+        #   :send_checked => true,
+        #   :enabled      => false,
+        #   :onwhen       => "1+"),
         button(
           :vm_tag,
           'pficon pficon-edit fa-lg',

--- a/app/helpers/application_helper/toolbar/vms_center.rb
+++ b/app/helpers/application_helper/toolbar/vms_center.rb
@@ -75,15 +75,16 @@ class ApplicationHelper::Toolbar::VmsCenter < ApplicationHelper::Toolbar::Basic
           :send_checked => true,
           :enabled      => false,
           :onwhen       => "1+"),
-        button(
-          :vm_policy_sim,
-          'fa fa-play-circle-o fa-lg',
-          N_('View Policy Simulation for the selected items'),
-          N_('Policy Simulation'),
-          :url_parms    => "main_div",
-          :send_checked => true,
-          :enabled      => false,
-          :onwhen       => "1+"),
+        # TODO: Add this button back when the page is fixed
+        # button(
+        #   :vm_policy_sim,
+        #   'fa fa-play-circle-o fa-lg',
+        #   N_('View Policy Simulation for the selected items'),
+        #   N_('Policy Simulation'),
+        #   :url_parms    => "main_div",
+        #   :send_checked => true,
+        #   :enabled      => false,
+        #   :onwhen       => "1+"),
         button(
           :vm_tag,
           'pficon pficon-edit fa-lg',

--- a/app/helpers/application_helper/toolbar/x_miq_template_center.rb
+++ b/app/helpers/application_helper/toolbar/x_miq_template_center.rb
@@ -54,6 +54,7 @@ class ApplicationHelper::Toolbar::XMiqTemplateCenter < ApplicationHelper::Toolba
           N_('Manage Policies for this Template'),
           N_('Manage Policies'),
           :klass => ApplicationHelper::Button::VmTemplatePolicy),
+        # TODO: Add this button back when the page is fixed
         button(
           :miq_template_policy_sim,
           'fa fa-play-circle-o fa-lg',

--- a/app/helpers/application_helper/toolbar/x_template_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/x_template_cloud_center.rb
@@ -71,11 +71,12 @@ class ApplicationHelper::Toolbar::XTemplateCloudCenter < ApplicationHelper::Tool
                        'pficon pficon-edit fa-lg',
                        N_('Manage Policies for this Image'),
                        N_('Manage Policies')),
-                     button(
-                       :image_policy_sim,
-                       'fa fa-play-circle-o fa-lg',
-                       N_('View Policy Simulation for this Image'),
-                       N_('Policy Simulation')),
+                    # TODO: Add this button back when the page is fixed
+                    #  button(
+                    #    :image_policy_sim,
+                    #    'fa fa-play-circle-o fa-lg',
+                    #    N_('View Policy Simulation for this Image'),
+                    #    N_('Policy Simulation')),
                      button(
                        :image_tag,
                        'pficon pficon-edit fa-lg',

--- a/app/helpers/application_helper/toolbar/x_vm_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_center.rb
@@ -103,12 +103,13 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
           N_('Manage Policies for this VM'),
           N_('Manage Policies'),
           :klass => ApplicationHelper::Button::VmTemplatePolicy),
-        button(
-          :vm_policy_sim,
-          'fa fa-play-circle-o fa-lg',
-          N_('View Policy Simulation for this VM'),
-          N_('Policy Simulation'),
-          :klass => ApplicationHelper::Button::VmTemplatePolicy),
+        # TODO: Add this button back when the page is fixed
+        # button(
+        #   :vm_policy_sim,
+        #   'fa fa-play-circle-o fa-lg',
+        #   N_('View Policy Simulation for this VM'),
+        #   N_('Policy Simulation'),
+        #   :klass => ApplicationHelper::Button::VmTemplatePolicy),
         button(
           :vm_tag,
           'pficon pficon-edit fa-lg',

--- a/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
@@ -129,11 +129,12 @@ class ApplicationHelper::Toolbar::XVmCloudCenter < ApplicationHelper::Toolbar::B
           'pficon pficon-edit fa-lg',
           N_('Manage Policies for this Instance'),
           N_('Manage Policies')),
-        button(
-          :instance_policy_sim,
-          'fa fa-play-circle-o fa-lg',
-          N_('View Policy Simulation for this Instance'),
-          N_('Policy Simulation')),
+        # TODO: Add this button back when the page is fixed
+        # button(
+        #   :instance_policy_sim,
+        #   'fa fa-play-circle-o fa-lg',
+        #   N_('View Policy Simulation for this Instance'),
+        #   N_('Policy Simulation')),
         button(
           :instance_tag,
           'pficon pficon-edit fa-lg',


### PR DESCRIPTION
Hide the policy simulation button on IM for the vms, templates, instances and images pages. The policy simulation page is currently broken. As we discuss how to progress with this page whether it is to fix the page, redesign and convert the page to react or delete the page all together we will hide the button that leads to this page.