### PR TITLE
Fix child services link

### DIFF
--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -1,3 +1,19 @@
 module ServiceHelper
   include TextualSummary
+
+  def child_service_summary(child_services)
+    rows = []
+    data = {:title => _("Child Services"), :mode => "miq_child_services"}
+    child_services.sort_by { |o| o.name.downcase }.each do |service|
+      rows.push(
+        {
+          :cells   => [{:icon => 'pficon pficon-service', :value => service.name}],
+          :title   => _("View this Service"),
+          :onclick => {:url => "/service/show/#{service.id}"},
+        }
+      )
+    end
+    data[:rows] = rows
+    miq_structured_list(data)
+  end
 end

--- a/app/views/service/_svcs_show.html.haml
+++ b/app/views/service/_svcs_show.html.haml
@@ -22,16 +22,7 @@
         - unless child_services.blank?
           .row
             .col-md-12.col-lg-6
-              %h3
-                = _('Child Services')
-              %table.table.table-striped.table-bordered.table-hover
-                %tbody
-                  - child_services.sort_by { |o| o.name.downcase }.each do |s|
-                    %tr{:onclick => "miqTreeSelect('s-#{s.id}');", :title => _("View this Service")}
-                      %td.table-view-pf-select
-                        %i.pficon.pficon-service
-                      %td
-                        = h(s.name)
+              = child_service_summary(child_services)
         .row
           .col-md-12
             %h3


### PR DESCRIPTION
Note:

- This PR is targeting the fix for `master` branch.
- PR for Petrosian branch - https://github.com/ManageIQ/manageiq-ui-classic/pull/9209 since there were a lot of code refactoring done at the `MiqStructuredList` component lately.

**Before**
- HAML list was used for child services summary.
- ![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/4242692/73bbb1e1-678c-43d5-b710-04be129b168a)
- Click event on the child services will return an error.
```
[----] I, [2024-06-14T10:42:00.965059 #38561:60784]  INFO -- : Started POST "/service/tree_select/?id=s-132" for ::1 at 2024-06-14 10:42:00 +0530
[----] F, [2024-06-14T10:42:01.109760 #38561:60784] FATAL -- :   
ActionController::RoutingError (No route matches [POST] "/service/tree_select"):
 
```

**After**
- Converted the child service summary from HAML to React.
- Click on the child service row will redirect the page to the corresponding service summary page.
- ![Screenshot 2024-06-14 at 10 36 30 AM](https://github.com/ManageIQ/manageiq-ui-classic/assets/4242692/ece48aa1-7278-4736-8d78-0ca71d55bc2f)
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/4242692/571d1cfc-3105-4d91-94c3-9043c26e99d0)
