### PR TITLE
Fix variable table spacing

### DIFF
--- a/app/stylesheet/miq-structured-list.scss
+++ b/app/stylesheet/miq-structured-list.scss
@@ -263,7 +263,11 @@
     width: 100%;
   }
 
-  .miq-structured-list-accordion {
+  .miq-structured-list-accordion {      
+    .list_header {
+      width: 50%;
+    }
+
     width: 50%;
   }
   


### PR DESCRIPTION
Before:
<img width="837" alt="VariableTableBefore" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/48e6c2ce-f160-41db-8fd4-2937d80617d2">

After:
<img width="845" alt="VariableTableAfter" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/4e6042db-e9a8-4f9d-b9b6-23f5850a0184">
