### PR TITLE
Add annotations on container summary pages that contain labels

### DIFF
--- a/app/controllers/container_group_controller.rb
+++ b/app/controllers/container_group_controller.rb
@@ -16,7 +16,7 @@ class ContainerGroupController < ApplicationController
   def textual_group_list
     [
       %i[properties container_labels container_node_selectors volumes],
-      %i[relationships conditions smart_management]
+      %i[relationships conditions smart_management annotations]
     ]
   end
   helper_method :textual_group_list

--- a/app/controllers/container_node_controller.rb
+++ b/app/controllers/container_node_controller.rb
@@ -15,7 +15,7 @@ class ContainerNodeController < ApplicationController
   def textual_group_list
     [
       %i[properties container_labels compliance miq_custom_attributes],
-      %i[relationships conditions smart_management]
+      %i[relationships conditions smart_management annotations]
     ]
   end
   helper_method :textual_group_list

--- a/app/controllers/container_replicator_controller.rb
+++ b/app/controllers/container_replicator_controller.rb
@@ -26,7 +26,7 @@ class ContainerReplicatorController < ApplicationController
   private
 
   def textual_group_list
-    [%i[properties container_labels container_selectors compliance], %i[relationships smart_management]]
+    [%i[properties container_labels container_selectors compliance], %i[relationships smart_management annotations]]
   end
   helper_method :textual_group_list
 

--- a/app/controllers/container_route_controller.rb
+++ b/app/controllers/container_route_controller.rb
@@ -20,7 +20,7 @@ class ContainerRouteController < ApplicationController
   private
 
   def textual_group_list
-    [%i[properties container_labels], %i[relationships smart_management]]
+    [%i[properties container_labels annotations], %i[relationships smart_management]]
   end
   helper_method :textual_group_list
 

--- a/app/controllers/container_service_controller.rb
+++ b/app/controllers/container_service_controller.rb
@@ -25,7 +25,7 @@ class ContainerServiceController < ApplicationController
   private
 
   def textual_group_list
-    [%i[properties port_configs container_labels container_selectors], %i[relationships smart_management]]
+    [%i[properties port_configs container_labels container_selectors], %i[relationships smart_management annotations]]
   end
   helper_method :textual_group_list
 

--- a/app/controllers/container_template_controller.rb
+++ b/app/controllers/container_template_controller.rb
@@ -20,7 +20,7 @@ class ContainerTemplateController < ApplicationController
   private
 
   def textual_group_list
-    [%i[properties parameters objects], %i[relationships container_labels smart_management]]
+    [%i[properties parameters objects], %i[relationships container_labels smart_management annotations]]
   end
   helper_method :textual_group_list
 

--- a/app/helpers/container_summary_helper.rb
+++ b/app/helpers/container_summary_helper.rb
@@ -73,12 +73,16 @@ module ContainerSummaryHelper
     TextualGroup.new(_("Labels"), textual_key_value_group(@record.labels.to_a))
   end
 
+  def textual_group_annotations
+    TextualGroup.new(_("Annotations"), textual_key_value_group(@record.annotations))
+  end
+
   def textual_group_miq_custom_attributes
     TextualGroup.new(_("Custom Attributes"), textual_miq_custom_attributes)
   end
 
   def textual_miq_custom_attributes
-    attrs = @record.custom_attributes
+    attrs = @record.miq_custom_attributes
     return nil if attrs.blank?
     attrs.sort_by(&:name).collect { |a| {:label => a.name.tr("_", " "), :value => a.value} }
   end


### PR DESCRIPTION
Add annotations on container summary pages that contain labels, remove custom attributes tab from container nodes summary page

Relevant PRs:
Providers-Kubernetes: https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/530
Providers-Openshift: https://github.com/ManageIQ/manageiq-providers-openshift/pull/262
Core ManageIQ: https://github.com/ManageIQ/manageiq/pull/23074

Old:
<img width="1409" alt="Screenshot 2024-06-27 at 7 41 03 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/68487937/795093d4-fb28-4579-895d-f888b967774e">

New:
<img width="1428" alt="Screenshot 2024-06-28 at 1 31 38 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/68487937/4c215b9f-c761-4763-b174-57298cacaf34">


Cross-Repo Tests:
https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/879 
All passing except for known failing test cases in core ManageIQ
