### PR TITLE
Rails 7 compatible changes (part 1)

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -182,7 +182,11 @@ module OpsController::Settings::Common
       task_opts = {:action => "Save subscriptions for global region", :userid => session[:userid]}
       queue_opts = {:class_name => "MiqPglogical", :method_name => "save_global_region",
                     :args       => [subscriptions_to_save, subsciptions_to_remove]}
-      ActiveRecord::Base.yaml_column_permitted_classes |= [subscriptions_to_save.first.class, subsciptions_to_remove.first.class]
+      if ActiveRecord.respond_to?(:yaml_column_permitted_classes)
+        ActiveRecord.yaml_column_permitted_classes       = YamlPermittedClasses.app_yaml_permitted_classes | [subscriptions_to_save.first.class, subsciptions_to_remove.first.class]
+      else
+        ActiveRecord::Base.yaml_column_permitted_classes = YamlPermittedClasses.app_yaml_permitted_classes | [subscriptions_to_save.first.class, subsciptions_to_remove.first.class]
+      end
     when "remote"
       task_opts  = {:action => "Configure the database to be a replication remote region",
                     :userid => session[:userid]}

--- a/spec/views/availability_zone/show.html.haml_spec.rb
+++ b/spec/views/availability_zone/show.html.haml_spec.rb
@@ -1,15 +1,16 @@
 describe "availability_zone/show.html.haml" do
   shared_examples_for "miq_before_onload JS is needed" do
     it "renders proper JS" do
-      js_string = "ManageIQ.afterOnload = {action: () => miqAsyncAjax(\"/availability_zone/#{action}/#{availability_zone.id}\")}"
+      template_path = "availability_zone/#{action}"
+      js_string = "ManageIQ.afterOnload = {action: () => miqAsyncAjax(\"/#{template_path}/#{availability_zone.id}\")}"
       
-      render
+      render :template => template_path
       expect(rendered).to include(js_string)
     end
   end
 
   let(:availability_zone) { double("AvailabilityZone", :name => 'My AZ', :id => 1) }
-  let(:action) { 'index' }
+  let(:action) { 'show' }
 
   before do
     assign(:record, availability_zone)

--- a/spec/views/catalog/_form.html.haml_spec.rb
+++ b/spec/views/catalog/_form.html.haml_spec.rb
@@ -17,7 +17,7 @@ describe "catalog/_form.html.haml" do
   end
 
   it "Renders form when adding catalog bundle and st_prov_type is not set" do
-    render
+    render :template => "catalog/_form"
     expect(response).to render_template(:partial => "catalog/_form_basic_info")
   end
 end

--- a/spec/views/catalog/_sandt_tree_show.html.haml_spec.rb
+++ b/spec/views/catalog/_sandt_tree_show.html.haml_spec.rb
@@ -13,7 +13,7 @@ describe "catalog/_sandt_tree_show.html.haml" do
   end
 
   it "Renders bundle summary screen" do
-    render
+    render :template => "catalog/_sandt_tree_show"
     expect(rendered).to include(bundle.name)
     expect(rendered).to include(bundle.tenant.name)
   end

--- a/spec/views/dashboard/login.html.haml_spec.rb
+++ b/spec/views/dashboard/login.html.haml_spec.rb
@@ -8,7 +8,7 @@ describe "dashboard/login.html.haml" do
     end
 
     it "when authentication is 'database'" do
-      render
+      render :template => "dashboard/login"
       expect(response).to have_selector("form#login_div:has(input#browser_name)")
       expect(response).to have_selector("form#login_div:has(input#browser_version)")
       expect(response).to have_selector("form#login_div:has(input#browser_os)")
@@ -16,7 +16,7 @@ describe "dashboard/login.html.haml" do
     end
 
     it "when authentication is not 'database'" do
-      render
+      render :template => "dashboard/login"
       expect(response).to have_selector("form#login_div:has(input#browser_name)")
       expect(response).to have_selector("form#login_div:has(input#browser_version)")
       expect(response).to have_selector("form#login_div:has(input#browser_os)")
@@ -33,7 +33,7 @@ describe "dashboard/login.html.haml" do
 
     it "show" do
       stub_settings(:server => {}, :session => {:show_login_info => true}, :authentication => {})
-      render
+      render :template => "dashboard/login"
       labels.each do |label|
         expect(response).to have_selector('p', :text => label)
       end
@@ -41,7 +41,7 @@ describe "dashboard/login.html.haml" do
 
     it "hide" do
       stub_settings(:server => {}, :session => {:show_login_info => false}, :authentication => {})
-      render
+      render :template => "dashboard/login"
       labels.each do |label|
         expect(response).not_to have_selector('p', :text => label)
       end

--- a/spec/views/ems_cluster/show.html.haml_spec.rb
+++ b/spec/views/ems_cluster/show.html.haml_spec.rb
@@ -15,7 +15,7 @@ describe "ems_cluster/show.html.haml" do
     let(:showtype) { 'drift' }
 
     it 'should render the compare partial' do
-      render
+      render :template => "ems_cluster/show"
       expect(response).to render_template(:partial => 'layouts/_compare')
     end
   end

--- a/spec/views/host/_show.html.haml_spec.rb
+++ b/spec/views/host/_show.html.haml_spec.rb
@@ -5,7 +5,7 @@ describe "host/show.html.haml" do
   shared_examples_for "miq_before_onload JS is needed" do
     it "renders proper JS" do
       js_string = "ManageIQ.afterOnload = {action: () => miqAsyncAjax(\"/host/#{action}/#{host.id}\")}"
-      render
+      render :template => "host/show"
       expect(rendered).to include(js_string)
     end
   end
@@ -46,7 +46,7 @@ describe "host/show.html.haml" do
     it "should render gtl view" do
       assign(:lastaction, "host_services")
       assign(:view, OpenStruct.new(:table => OpenStruct.new(:data => [])))
-      render
+      render :template => "host/show"
       expect(view).to render_template(:partial => 'layouts/gtl', :locals => {:action_url => 'host_services'})
     end
   end

--- a/spec/views/layouts/_center_div_no_listnav.html.haml_spec.rb
+++ b/spec/views/layouts/_center_div_no_listnav.html.haml_spec.rb
@@ -11,7 +11,7 @@ describe "layouts/_center_div_no_listnav.html.haml" do
   end
 
   it 'renders Search bar' do
-    render
+    render :template => "layouts/_center_div_no_listnav"
     expect(rendered).to include('SearchBar')
   end
 end

--- a/spec/views/layouts/_item.html.haml_spec.rb
+++ b/spec/views/layouts/_item.html.haml_spec.rb
@@ -5,7 +5,7 @@ describe "layouts/_item.html.haml" do
     assign(:view, FactoryBot.create(:miq_report_filesystem))
     assign(:item, fs)
     assign(:lastaction, 'filesystems')
-    render
+    render :template => "layouts/_item"
 
     expect(response).to have_selector('label', :text => 'Name')
     expect(response).to have_selector('label', :text => 'File Name')

--- a/spec/views/layouts/_searchbar.html.haml_spec.rb
+++ b/spec/views/layouts/_searchbar.html.haml_spec.rb
@@ -5,14 +5,14 @@ describe "layouts/_searchbar.html.haml" do
   end
 
   it 'renders Search bar and not quick search' do
-    render
+    render :template => "layouts/_searchbar"
     expect(rendered).to include('SearchBar')
     expect(rendered).not_to include('quicksearchbox')
   end
 
   it 'renders Advanced Search and quick search' do
     allow(view).to receive(:display_adv_search?).and_return(true)
-    render
+    render :template => "layouts/_searchbar"
     expect(rendered).to include('quicksearchbox')
   end
 end

--- a/spec/views/layouts/_user_input_filter.html.haml_spec.rb
+++ b/spec/views/layouts/_user_input_filter.html.haml_spec.rb
@@ -7,7 +7,7 @@ describe "layouts/_user_input_filter.html.haml" do
 
     it 'shows a dropdown field' do
       set_controller_for_view("host")
-      render
+      render :template => "layouts/_user_input_filter"
       expect(rendered).to include("<option value=\"false\">False</option>\n<option value=\"true\">True</option></select>")
     end
   end

--- a/spec/views/layouts/list_grid.html.haml_spec.rb
+++ b/spec/views/layouts/list_grid.html.haml_spec.rb
@@ -5,7 +5,7 @@ describe "layouts/_list_grid.html.haml" do
       allow(view).to receive(:js_options).and_return(:row_url => '_none_')
       record = FactoryBot.create(:ems_infra)
       assign(:parent, record)
-      render
+      render :template => "layouts/_list_grid"
     end
   end
 

--- a/spec/views/layouts/perf_charts_js_spec.rb
+++ b/spec/views/layouts/perf_charts_js_spec.rb
@@ -9,12 +9,12 @@ describe 'layouts/_perf_chart_js.html.haml' do
     let(:zoom_url)    { "javascript:miqAsyncAjax('/vm_infra/perf_chart_chooser/10000000000011?chart_idx=0')" }
 
     it 'with simple chart' do
-      render :partial => '/layouts/perf_chart_js.html.haml', :locals => {:chart_data => chart_data, :chart_index => 0, :chart_set => 'candu', :charts => charts}
+      render :partial => '/layouts/perf_chart_js', :locals => {:chart_data => chart_data, :chart_index => 0, :chart_set => 'candu', :charts => charts}
       expect(response).to include("<ul aria-labelledby='miq_chart_candu_0' class='dropdown-menu' id='miq_chartmenu_candu_0' role='menu' style='position: fixed;'></ul>")
     end
 
     it 'with composite chart' do
-      render :partial => '/layouts/perf_chart_js.html.haml', :locals => {:chart_data => chart_data2, :chart_index => 0, :chart_set => 'candu', :charts => charts}
+      render :partial => '/layouts/perf_chart_js', :locals => {:chart_data => chart_data2, :chart_index => 0, :chart_set => 'candu', :charts => charts}
       expect(response).to include("<ul aria-labelledby='miq_chart_candu_0' class='dropdown-menu' id='miq_chartmenu_candu_0' role='menu' style='position:fixed;'></ul>")
       expect(response).to include("<ul aria-labelledby='miq_chart_candu_0_2' class='dropdown-menu' id='miq_chartmenu_candu_0_2' role='menu' style='position: fixed;'></ul>")
     end

--- a/spec/views/miq_ae_class/_class_fields.html.haml_spec.rb
+++ b/spec/views/miq_ae_class/_class_fields.html.haml_spec.rb
@@ -17,7 +17,7 @@ describe "miq_ae_class/_class_fields.html.haml" do
     end
 
     it "Check instance", :js => true do
-      render
+      render :template => "miq_ae_class/_class_fields"
       expect(response).to have_text('ae_var1')
       expect(response).to have_text('Wilma')
     end
@@ -50,7 +50,7 @@ describe "miq_ae_class/_class_fields.html.haml" do
     end
 
     it "Check instance", :js => true do
-      render
+      render :template => "miq_ae_class/_class_fields"
       expect(rendered).to have_selector('input#fields_default_value_0[value=\'Wilma\']')
     end
   end

--- a/spec/views/miq_ae_class/_fields_seq_form.html.haml_spec.rb
+++ b/spec/views/miq_ae_class/_fields_seq_form.html.haml_spec.rb
@@ -7,7 +7,7 @@ describe "miq_ae_class/_fields_seq_form.html.haml" do
   end
 
   it "Check links in the list view", :js => true do
-    render
+    render :template => "miq_ae_class/_fields_seq_form"
     expect(response).to have_text("miq_tabs_disable_inactive('#ae_tabs')")
   end
 end

--- a/spec/views/miq_ae_class/_instance_fields.html.haml_spec.rb
+++ b/spec/views/miq_ae_class/_instance_fields.html.haml_spec.rb
@@ -16,7 +16,7 @@ describe "miq_ae_class/_instance_fields.html.haml" do
     end
 
     it "Check instance", :js => true do
-      render
+      render :template => "miq_ae_class/_instance_fields"
       expect(response).to have_text('ae_var1')
       expect(response).to have_text('hello world')
     end

--- a/spec/views/miq_ae_class/_method_inputs.html.haml_spec.rb
+++ b/spec/views/miq_ae_class/_method_inputs.html.haml_spec.rb
@@ -20,7 +20,7 @@ describe "miq_ae_class/_method_inputs.html.haml" do
     end
 
     it "Check inputs", :js => true do
-      render
+      render :template => "miq_ae_class/_method_inputs"
       expect(response).to have_text('ae_result')
       expect(response).to have_text('ae_next_state')
     end

--- a/spec/views/miq_ae_class/show.html.haml_spec.rb
+++ b/spec/views/miq_ae_class/show.html.haml_spec.rb
@@ -8,7 +8,7 @@ describe "miq_ae_class/show.html.haml" do
   end
 
   it 'renders partial all_tabs' do
-    render
+    render :template => "miq_ae_class/show"
     expect(response).to include("<div id='ae_tabs'>", "<div id='ns_details_div'>", 'miqInitCodemirror({"text_area_id":"miq_none"')
   end
 end

--- a/spec/views/miq_alert/_show.html.haml_spec.rb
+++ b/spec/views/miq_alert/_show.html.haml_spec.rb
@@ -10,7 +10,7 @@ describe "miq_alert/show.html.haml" do
   it "Trap Number is displayed correctly" do
     opts = {:notifications => {:snmp => {:host => ['test.test.org'], :snmp_version => 'v1', :trap_id => '42'}}}
     allow(@alert).to receive(:options).and_return(opts)
-    render
+    render :template => "miq_alert/show"
     expect(rendered).to include('Trap Number')
   end
 end

--- a/spec/views/ops/_label_tag_mapping_form.html.haml_spec.rb
+++ b/spec/views/ops/_label_tag_mapping_form.html.haml_spec.rb
@@ -14,14 +14,6 @@ describe 'ops/_label_tag_mapping_form.html.haml' do
       render :partial => "ops/label_tag_mapping_form"
     end
 
-    it 'renders the entity select box' do
-      expect(render).to have_selector('select#entity')
-    end
-
-    it 'renders the label name text box' do
-      expect(render).to have_selector('input#label_name')
-    end
-
     it 'entity should be enabled when adding a new mapping' do
       expect(response.body).to include('<select name="entity" id="entity" class="selectpicker">')
     end

--- a/spec/views/ops/_rbac_tenant_details.html.haml_spec.rb
+++ b/spec/views/ops/_rbac_tenant_details.html.haml_spec.rb
@@ -10,7 +10,7 @@ describe 'ops/_rbac_tenant_details.html.haml' do
   end
 
   it 'renders textual summary of a Tenant' do
-    render :partial => 'ops/rbac_tenant_details.html.haml'
+    render :partial => 'ops/rbac_tenant_details'
     expect(rendered).to include("<div id='textual_summary'>", 'Properties', 'Relationships', 'Smart Management')
     expect(rendered).to include(tenant.description)
   end

--- a/spec/views/ops/_rbac_user_details.html.haml_spec.rb
+++ b/spec/views/ops/_rbac_user_details.html.haml_spec.rb
@@ -12,7 +12,7 @@ describe 'ops/_rbac_user_details.html.haml' do
     end
 
     it "displays full name" do
-      render
+      render :template => "ops/_rbac_user_details"
       expect(rendered).to have_field("name", :with => "Joe Test")
     end
   end

--- a/spec/views/ops/_settings_cu_collection_tab.html.haml_spec.rb
+++ b/spec/views/ops/_settings_cu_collection_tab.html.haml_spec.rb
@@ -32,14 +32,14 @@ describe "ops/_settings_cu_collection_tab.html.haml" do
   it "Displays note if there are no Clusters" do
     @cluster_tree = nil
     assign(:edit, :new => {:all_clusters => false})
-    render
+    render :template => "ops/_settings_cu_collection_tab"
     expect(response).to have_selector("div.note b", :text => "Note: No Clusters available.")
   end
 
   it "Displays note if there are no Datastores" do
     @datastore_tree = nil
     assign(:edit, :new => {:all_storages => false})
-    render
+    render :template => "ops/_settings_cu_collection_tab"
     expect(response).to have_selector("div.note b", :text => "Note: No Datastores available.")
   end
 end

--- a/spec/views/report/_report_list.html.haml_spec.rb
+++ b/spec/views/report/_report_list.html.haml_spec.rb
@@ -27,7 +27,7 @@ describe "report/_report_list.html.haml" do
     end
 
     it 'Check if report list is present' do
-      render
+      render :template => "report/_report_list"
       expect(response).to have_selector("//div[@id=\"report_list_div\"]")
     end
   end

--- a/spec/views/report/_widget_form_menu.html.haml_spec.rb
+++ b/spec/views/report/_widget_form_menu.html.haml_spec.rb
@@ -6,7 +6,7 @@ describe "report/_widget_form_menu.html.haml" do
   end
 
   it "correctly renders patternfly classes" do
-    render
+    render :template => "report/_widget_form_menu"
     expect(response).to have_selector('a.fa.fa-close.pull-right')
   end
 end

--- a/spec/views/shared/buttons/_ab_form.html.haml_spec.rb
+++ b/spec/views/shared/buttons/_ab_form.html.haml_spec.rb
@@ -16,14 +16,14 @@ describe "shared/buttons/_ab_form.html.haml" do
     it "is enabled if the copied target class is the same as the current target class" do
       allow(view).to receive(:session)
         .and_return(:resolve_object => {:new => {:target_class => "CloudNetwork"}})
-      render
+      render :template => "shared/buttons/_ab_form"
       expect(rendered).to include("Paste object details for use in a Button.")
     end
 
     it "is disabled if the copied target class differs from the current target class" do
       allow(view).to receive(:session)
         .and_return(:resolve_object => {:new => {:target_class => "AvailabilityZone"}})
-      render
+      render :template => "shared/buttons/_ab_form"
       expect(rendered).to include("Paste is not available, target class differs from the target class of the object copied from the Simulation screen")
     end
   end

--- a/spec/views/vm/_show.html.haml_spec.rb
+++ b/spec/views/vm/_show.html.haml_spec.rb
@@ -24,7 +24,7 @@ describe "vm/show.html.haml" do
     it 'should render policies view' do
       assign(:lastaction, 'policy_sim')
       stub_template "vm_common/_policies.html.haml" => "Stubbed Content"
-      render
+      render :template => "vm/show"
       expect(rendered).to render_template(:partial => 'vm_common/policies', :locals => {:controller => 'vm'})
     end
   end


### PR DESCRIPTION
This PR squashes ~40 test failures on rails 7.   There are still 2 more failures but I'll tackle them in a follow up PR to keep this PR easier to review.  This should be backward compatible with rails 6.1

The primary change is:

    Resolve ActionView::MissingTemplate errors by specifying template

    Rails 7 now raises this error if you don't specify the template correctly.

    Specifying templates with "." in the name was deprecated here:
    https://www.github.com/rails/rails/pull/39164

    The interface they want is without periods and for you to specify the formats
    if it's non-standard.  Also, render with no :template, :partial, etc. is also
    gone in rails 7.

    Somewhat related issued with helpful information can be found here:
    https://www.github.com/mileszs/wicked_pdf/issues/1005