### PR TITLE
Fix request form automation fields

### DIFF
--- a/app/views/miq_request/_request_dialog_details.html.haml
+++ b/app/views/miq_request/_request_dialog_details.html.haml
@@ -28,13 +28,14 @@
       = h(field.values.detect { |k, _v| k == wf.value(field.name) }.try(:last) || wf.value(field.name))
 
     - when "DialogFieldDropDownList"
-      = h(field.value.blank? ? _("<None>") : field.value.to_s.gsub("\x1F", ", "))
+      - if field.value.instance_of?(Array)
+        = h(field.value.blank? ? _("<None>") : h(field.value.join(", ")))
+      - else
+        = h(field.value.blank? ? _("<None>") : h(field.value))
 
     - when 'DialogFieldTagControl'
-      - value = wf.value(field.name) || '' # it returns in format Clasification::id
-      - classifications = value.split(',').map do |c|
-        - classification = Classification.find_by(id: c.split('::').second)
-        - classification.description if classification
+      - value = wf.value(field.name) || ''
+      - classifications = Classification.where(:id => value).pluck(:description)
       - if classifications.empty?
         = h('')
       -else


### PR DESCRIPTION
As a follow up to this pr: https://github.com/ManageIQ/manageiq-automation_engine/pull/545 we need to fix the Services > Request summary page since the values are now coming in as an array instead of a string. This pr fixes the request page to show the values properly for single and multi select drop downs and tag control fields.

A catalog was ordered with these values:
<img width="857" alt="FormValues" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/02bbbb0e-606f-4173-ab5f-2e738deea4ff">

Before:
<img width="1155" alt="RequestBefore" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/8c5453d4-5f4f-49d3-a90e-1d44991f1ec6">

After:
<img width="1144" alt="RequestAfter" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/8d55395f-a3aa-4eeb-8616-b9fc023006a3">
