### PR TITLE
Fix textual summary duplication bug

### DIFF
--- a/app/javascript/react/textual_summary_wrapper.jsx
+++ b/app/javascript/react/textual_summary_wrapper.jsx
@@ -6,7 +6,6 @@ import textualSummaryGenericClick from './textual_summary_click';
 export default (props) => {
   const onClick = props.onClick || textualSummaryGenericClick;
   const component = <TextualSummary onClick={onClick} {...props} />;
-
   if (props.options && Object.keys(props.options).length > 0) {
     document.addEventListener('DOMContentLoaded', () => {
       ReactDOM.render(component, document.body.appendChild(document.createElement('div')));

--- a/app/javascript/react/textual_summary_wrapper.jsx
+++ b/app/javascript/react/textual_summary_wrapper.jsx
@@ -6,7 +6,8 @@ import textualSummaryGenericClick from './textual_summary_click';
 export default (props) => {
   const onClick = props.onClick || textualSummaryGenericClick;
   const component = <TextualSummary onClick={onClick} {...props} />;
-  if (props.options) {
+
+  if (props.options && Object.keys(props.options).length > 0) {
     document.addEventListener('DOMContentLoaded', () => {
       ReactDOM.render(component, document.body.appendChild(document.createElement('div')));
     });


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/9218

There is an issue where the textual summary page is being duplicated. This is due to the code:

```
  if (props.options) {
    document.addEventListener('DOMContentLoaded', () => {
      ReactDOM.render(component, document.body.appendChild(document.createElement('div')));
    });
  }
```

This code is used to generate the print summary screen.
![Screenshot 2024-07-24 at 12 25 14 PM](https://github.com/user-attachments/assets/69fae0cb-8251-463b-8a12-92a5a29e6ee2)

The issue is that currently `if (props.options)` is `true` but props.options is an empty object. So instead of just checking if the object exists we can also check if it contains any data by looking at the length of the `keys` array. This prevents the textual summary from being duplicated.

Before:
In the page elements we see an extra div being rendered at the bottom between the error-modal component and toast-wrapper div.
<img width="1333" alt="Screenshot 2024-07-24 at 12 28 23 PM" src="https://github.com/user-attachments/assets/3f3e9a21-0f5c-4863-a888-03ebbc47f146">

After:
This div is no longer being rendered in the page elements.
<img width="1343" alt="Screenshot 2024-07-24 at 12 29 22 PM" src="https://github.com/user-attachments/assets/800c4b7f-7e34-4532-b2c8-cb2a8742df56">

Also, the print summary screen is left unchanged by this pr.
![Screenshot 2024-07-24 at 12 32 15 PM](https://github.com/user-attachments/assets/4398160c-4203-4764-9a9c-49f5049f03d0)

