### PR TITLE
[Morphy] Update moment-timezone

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "moment": "~2.22.2",
     "moment-duration-format": "~2.2.2",
     "moment-strftime": "~0.5.0",
-    "moment-timezone": "~0.5.21",
+    "moment-timezone": "~0.5.37",
     "numeral": "~2.0.6",
     "patternfly": "~3.59.1",
     "patternfly-bootstrap-treeview": "~2.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10803,17 +10803,22 @@ moment-timezone@^0.4.0, moment-timezone@^0.4.1:
   dependencies:
     moment ">= 2.6.0"
 
-moment-timezone@~0.5.21:
-  version "0.5.34"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.34.tgz#a75938f7476b88f155d3504a9343f7519d9a405c"
-  integrity sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==
+moment-timezone@~0.5.37:
+  version "0.5.45"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.45.tgz#cb685acd56bac10e69d93c536366eb65aa6bcf5c"
+  integrity sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==
   dependencies:
-    moment ">= 2.9.0"
+    moment "^2.29.4"
 
-"moment@>= 2.6.0", "moment@>= 2.9.0", moment@^2.10, moment@^2.11.2, moment@^2.19.1, moment@^2.27.0:
+"moment@>= 2.6.0", moment@^2.10, moment@^2.11.2, moment@^2.19.1, moment@^2.27.0:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
+moment@^2.29.4:
+  version "2.30.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
+  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
 
 moment@~2.14.1:
   version "2.14.1"


### PR DESCRIPTION
Update moment-timezone to ~0.5.37.

No code changes required. Similar to this pr on the master branch: https://github.com/ManageIQ/manageiq-ui-classic/pull/8442