### PR TITLE
[Morphy] Fix cypress test assertion imports

### DIFF
--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -47,5 +47,4 @@ import './commands/search.js'
 import './commands/toolbar.js'
 
 // Assertions
-import './assertions/expect_explorer_title.js'
-import './assertions/expect_show_list_title.js'
+import './assertions/expect_title.js'


### PR DESCRIPTION
Fixed the assertion import on cypress tests

Before:
<img width="1791" alt="Screenshot 2024-07-30 at 12 29 07 PM" src="https://github.com/user-attachments/assets/aed6b416-2bab-419e-bcf3-3fd2103c26ec">

After:
<img width="893" alt="Screenshot 2024-07-30 at 12 29 36 PM" src="https://github.com/user-attachments/assets/5e5db532-48d5-4a51-bd28-c9cdf7108f3c">
