### PR TITLE
Update yarn npm audit pending list (again)

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -15,13 +15,13 @@ npmAuditIgnoreAdvisories:
 - "1094513" # pending | moderate | GHSA-2qqx-w9hr-q5gx | angular <=1.8.3          | 1.5.11, 1.6.10, 1.8.3 brought in by angular-bootstrap-switch@npm:0.5.2, angular-patternfly@npm:3.26.0, manageiq-ui-classic@workspace:.
 - "1094514" # pending | moderate | GHSA-qwqh-hm9m-p5hr | angular <=1.8.3          | 1.5.11, 1.6.10, 1.8.3 brought in by angular-bootstrap-switch@npm:0.5.2, angular-patternfly@npm:3.26.0, manageiq-ui-classic@workspace:.
 - "1097291" # pending | high     | GHSA-4w4v-5hc9-xrr2 | angular >=1.3.0 <=1.8.3  | 1.5.11, 1.6.10, 1.8.3 brought in by angular-bootstrap-switch@npm:0.5.2, angular-patternfly@npm:3.26.0, manageiq-ui-classic@workspace:.
-- "1098345" # pending | moderate | GHSA-3mgp-fx93-9xv5 | bootstrap <3.4.0         | 3.3.7 brought in by patternfly@npm:3.31.2
-- "1098347" # pending | moderate | GHSA-ph58-4vrj-w6hr | bootstrap <3.4.0         | 3.3.7 brought in by patternfly@npm:3.31.2
-- "1098348" # pending | moderate | GHSA-7mvr-5x2g-wfc8 | bootstrap >=2.3.0 <3.4.0 | 3.3.7 brought in by patternfly@npm:3.31.2
-- "1098351" # pending | moderate | GHSA-4p24-vmcr-4gqj | bootstrap >=2.0.4 <3.4.0 | 3.3.7 brought in by patternfly@npm:3.31.2
 - "1098354" # pending | moderate | GHSA-9v3m-8fp8-mj99 | bootstrap >=3.0.0 <3.4.1 | 3.3.7 brought in by patternfly@npm:3.31.2
-- "1098357" # pending | moderate | GHSA-9mvj-f7w8-pvh2 | bootstrap >=2.0.0 <=3.4.1| 3.3.7, 3.4.1 brought in by patternfly@npm:3.31.2, patternfly@npm:3.59.5
-- "1098374" # pending | moderate | GHSA-3wqf-4x89-9g79 | bootstrap >=2.3.0 <3.4.0 | 3.3.7 brought in by patternfly@npm:3.31.2
+- "1098401" # pending | moderate | GHSA-9mvj-f7w8-pvh2 | bootstrap >=2.0.0 <=3.4.1| 3.3.7, 3.4.1 brought in by patternfly@npm:3.31.2, patternfly@npm:3.59.5
+- "1098405" # pending | moderate | GHSA-3mgp-fx93-9xv5 | bootstrap <3.4.0         | 3.3.7 brought in by patternfly@npm:3.31.2
+- "1098407" # pending | moderate | GHSA-ph58-4vrj-w6hr | bootstrap <3.4.0         | 3.3.7 brought in by patternfly@npm:3.31.2
+- "1098408" # pending | moderate | GHSA-3wqf-4x89-9g79 | bootstrap >=2.3.0 <3.4.0 | 3.3.7 brought in by patternfly@npm:3.31.2
+- "1098410" # pending | moderate | GHSA-7mvr-5x2g-wfc8 | bootstrap >=2.3.0 <3.4.0 | 3.3.7 brought in by patternfly@npm:3.31.2
+- "1098412" # pending | moderate | GHSA-4p24-vmcr-4gqj | bootstrap >=2.0.4 <3.4.0 | 3.3.7 brought in by patternfly@npm:3.31.2
 - "1086501" # pending | high     | GHSA-9r7h-6639-v5mw | bootstrap-select <1.13.6 | 1.12.2 brought in by patternfly@npm:3.59.5
 - "1098373" # pending | moderate | GHSA-7c82-mp33-r854 | bootstrap-select <1.13.6 | 1.12.2 brought in by patternfly@npm:3.59.5
 - "1094143" # pending | moderate | GHSA-rmxg-73gg-4p98 | jquery >=1.12.3 <3.0.0   | 2.2.4 brought in by manageiq-ui-classic@workspace:.


### PR DESCRIPTION
@jrafanie and/or @GilbertCherrie Please review.  Seems GitHub updated the advisory database again.  Moving forward I need to find a better way to manage this.  I've opened https://github.com/yarnpkg/berry/issues/6438 to start a conversation with upstream.