### PR TITLE
Use npmAuditExcludePackages instead of npmAuditIgnoreAdvisories

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,36 +4,41 @@ enableGlobalCache: true
 
 nodeLinker: node-modules
 
-npmAuditIgnoreAdvisories:
-- "1085687" # pending | moderate | GHSA-28hp-fgcr-2r4h | angular <1.6.0           | 1.5.11 brought in by angular-patternfly@npm:3.26.0
-- "1087446" # pending | moderate | GHSA-5cp4-xmrw-59wf | angular <1.8.0           | 1.5.11, 1.6.10 brought in by angular-patternfly@npm:3.26.0, manageiq-ui-classic@workspace:.
-- "1089079" # pending | high     | GHSA-89mq-4x47-5v83 | angular <1.7.9           | 1.5.11, 1.6.10 brought in by angular-patternfly@npm:3.26.0, manageiq-ui-classic@workspace:.
-- "1089210" # pending | moderate | GHSA-m2h2-264f-f486 | angular >=1.7.0          | 1.8.3 brought in by angular-bootstrap-switch@npm:0.5.2
-- "1093555" # pending | moderate | GHSA-mhp6-pxh8-r675 | angular <1.8.0           | 1.5.11, 1.6.10 brought in by angular-patternfly@npm:3.26.0, manageiq-ui-classic@workspace:.
-- "1093574" # pending | moderate | GHSA-prc3-vjfx-vhm9 | angular <=1.8.3          | 1.5.11, 1.6.10, 1.8.3 brought in by angular-bootstrap-switch@npm:0.5.2, angular-patternfly@npm:3.26.0, manageiq-ui-classic@workspace:.
-- "1094512" # pending | moderate | GHSA-2vrf-hf26-jrp5 | angular <=1.8.3          | 1.5.11, 1.6.10, 1.8.3 brought in by angular-bootstrap-switch@npm:0.5.2, angular-patternfly@npm:3.26.0, manageiq-ui-classic@workspace:.
-- "1094513" # pending | moderate | GHSA-2qqx-w9hr-q5gx | angular <=1.8.3          | 1.5.11, 1.6.10, 1.8.3 brought in by angular-bootstrap-switch@npm:0.5.2, angular-patternfly@npm:3.26.0, manageiq-ui-classic@workspace:.
-- "1094514" # pending | moderate | GHSA-qwqh-hm9m-p5hr | angular <=1.8.3          | 1.5.11, 1.6.10, 1.8.3 brought in by angular-bootstrap-switch@npm:0.5.2, angular-patternfly@npm:3.26.0, manageiq-ui-classic@workspace:.
-- "1097291" # pending | high     | GHSA-4w4v-5hc9-xrr2 | angular >=1.3.0 <=1.8.3  | 1.5.11, 1.6.10, 1.8.3 brought in by angular-bootstrap-switch@npm:0.5.2, angular-patternfly@npm:3.26.0, manageiq-ui-classic@workspace:.
-- "1098345" # pending | moderate | GHSA-3mgp-fx93-9xv5 | bootstrap <3.4.0         | 3.3.7 brought in by patternfly@npm:3.31.2
-- "1098347" # pending | moderate | GHSA-ph58-4vrj-w6hr | bootstrap <3.4.0         | 3.3.7 brought in by patternfly@npm:3.31.2
-- "1098348" # pending | moderate | GHSA-7mvr-5x2g-wfc8 | bootstrap >=2.3.0 <3.4.0 | 3.3.7 brought in by patternfly@npm:3.31.2
-- "1098351" # pending | moderate | GHSA-4p24-vmcr-4gqj | bootstrap >=2.0.4 <3.4.0 | 3.3.7 brought in by patternfly@npm:3.31.2
-- "1098354" # pending | moderate | GHSA-9v3m-8fp8-mj99 | bootstrap >=3.0.0 <3.4.1 | 3.3.7 brought in by patternfly@npm:3.31.2
-- "1098357" # pending | moderate | GHSA-9mvj-f7w8-pvh2 | bootstrap >=2.0.0 <=3.4.1| 3.3.7, 3.4.1 brought in by patternfly@npm:3.31.2, patternfly@npm:3.59.5
-- "1098374" # pending | moderate | GHSA-3wqf-4x89-9g79 | bootstrap >=2.3.0 <3.4.0 | 3.3.7 brought in by patternfly@npm:3.31.2
-- "1086501" # pending | high     | GHSA-9r7h-6639-v5mw | bootstrap-select <1.13.6 | 1.12.2 brought in by patternfly@npm:3.59.5
-- "1098373" # pending | moderate | GHSA-7c82-mp33-r854 | bootstrap-select <1.13.6 | 1.12.2 brought in by patternfly@npm:3.59.5
-- "1094143" # pending | moderate | GHSA-rmxg-73gg-4p98 | jquery >=1.12.3 <3.0.0   | 2.2.4 brought in by manageiq-ui-classic@workspace:.
-- "1094185" # pending | moderate | GHSA-gxr4-xjj5-5px2 | jquery >=1.2.0 <3.5.0    | 2.2.4, 3.2.1, 3.4.1 brought in by manageiq-ui-classic@workspace:., patternfly@npm:3.31.2, patternfly@npm:3.59.5
-- "1097145" # pending | moderate | GHSA-6c3j-c64m-qhgq | jquery >=1.1.4 <3.4.0    | 2.2.4, 3.2.1 brought in by manageiq-ui-classic@workspace:., patternfly@npm:3.31.2
-- "1097311" # pending | moderate | GHSA-jpcq-cgw6-v4j6 | jquery >=1.0.3 <3.5.0    | 2.2.4, 3.2.1, 3.4.1 brought in by manageiq-ui-classic@workspace:., patternfly@npm:3.31.2, patternfly@npm:3.59.5
-- "1085674" # pending | moderate | GHSA-x5rq-j2xg-h7qm | lodash <4.17.11          | 3.10.1 brought in by angular-patternfly@npm:3.26.0
-- "1094499" # pending | high     | GHSA-4xc9-xhrj-v574 | lodash <4.17.11          | 3.10.1 brought in by angular-patternfly@npm:3.26.0
-- "1094500" # pending | moderate | GHSA-29mw-wpgm-hmr9 | lodash <4.17.21          | 3.10.1 brought in by angular-patternfly@npm:3.26.0
-- "1096305" # pending | high     | GHSA-p6mc-m468-83gw | lodash >=3.7.0 <4.17.19  | 3.10.1 brought in by angular-patternfly@npm:3.26.0
-- "1096996" # pending | high     | GHSA-35jh-r3h4-6jhm | lodash <4.17.21          | 3.10.1 brought in by angular-patternfly@npm:3.26.0
-- "1097130" # pending | moderate | GHSA-fvqr-27wr-82fm | lodash <4.17.5           | 3.10.1 brought in by angular-patternfly@npm:3.26.0
-- "1097140" # pending | critical | GHSA-jf85-cpcp-j695 | lodash <4.17.12          | 3.10.1 brought in by angular-patternfly@npm:3.26.0
+npmAuditExcludePackages:
+- angular
+# pending | moderate | GHSA-28hp-fgcr-2r4h | angular <1.6.0          | 1.5.11 brought in by angular-patternfly@npm:3.26.0
+# pending | moderate | GHSA-5cp4-xmrw-59wf | angular <1.8.0          | 1.5.11, 1.6.10 brought in by angular-patternfly@npm:3.26.0, manageiq-ui-classic@workspace:.
+# pending | high     | GHSA-89mq-4x47-5v83 | angular <1.7.9          | 1.5.11, 1.6.10 brought in by angular-patternfly@npm:3.26.0, manageiq-ui-classic@workspace:.
+# pending | moderate | GHSA-m2h2-264f-f486 | angular >=1.7.0         | 1.8.3 brought in by angular-bootstrap-switch@npm:0.5.2
+# pending | moderate | GHSA-mhp6-pxh8-r675 | angular <1.8.0          | 1.5.11, 1.6.10 brought in by angular-patternfly@npm:3.26.0, manageiq-ui-classic@workspace:.
+# pending | moderate | GHSA-prc3-vjfx-vhm9 | angular <=1.8.3         | 1.5.11, 1.6.10, 1.8.3 brought in by angular-bootstrap-switch@npm:0.5.2, angular-patternfly@npm:3.26.0, manageiq-ui-classic@workspace:.
+# pending | moderate | GHSA-2vrf-hf26-jrp5 | angular <=1.8.3         | 1.5.11, 1.6.10, 1.8.3 brought in by angular-bootstrap-switch@npm:0.5.2, angular-patternfly@npm:3.26.0, manageiq-ui-classic@workspace:.
+# pending | moderate | GHSA-2qqx-w9hr-q5gx | angular <=1.8.3         | 1.5.11, 1.6.10, 1.8.3 brought in by angular-bootstrap-switch@npm:0.5.2, angular-patternfly@npm:3.26.0, manageiq-ui-classic@workspace:.
+# pending | moderate | GHSA-qwqh-hm9m-p5hr | angular <=1.8.3         | 1.5.11, 1.6.10, 1.8.3 brought in by angular-bootstrap-switch@npm:0.5.2, angular-patternfly@npm:3.26.0, manageiq-ui-classic@workspace:.
+# pending | high     | GHSA-4w4v-5hc9-xrr2 | angular >=1.3.0 <=1.8.3 | 1.5.11, 1.6.10, 1.8.3 brought in by angular-bootstrap-switch@npm:0.5.2, angular-patternfly@npm:3.26.0, manageiq-ui-classic@workspace:.
+- bootstrap
+# pending | moderate | GHSA-9v3m-8fp8-mj99 | bootstrap >=3.0.0 <3.4.1  | 3.3.7 brought in by patternfly@npm:3.31.2
+# pending | moderate | GHSA-9mvj-f7w8-pvh2 | bootstrap >=2.0.0 <=3.4.1 | 3.3.7, 3.4.1 brought in by patternfly@npm:3.31.2, patternfly@npm:3.59.5
+# pending | moderate | GHSA-3mgp-fx93-9xv5 | bootstrap <3.4.0          | 3.3.7 brought in by patternfly@npm:3.31.2
+# pending | moderate | GHSA-ph58-4vrj-w6hr | bootstrap <3.4.0          | 3.3.7 brought in by patternfly@npm:3.31.2
+# pending | moderate | GHSA-3wqf-4x89-9g79 | bootstrap >=2.3.0 <3.4.0  | 3.3.7 brought in by patternfly@npm:3.31.2
+# pending | moderate | GHSA-7mvr-5x2g-wfc8 | bootstrap >=2.3.0 <3.4.0  | 3.3.7 brought in by patternfly@npm:3.31.2
+# pending | moderate | GHSA-4p24-vmcr-4gqj | bootstrap >=2.0.4 <3.4.0  | 3.3.7 brought in by patternfly@npm:3.31.2
+- bootstrap-select
+# pending | high     | GHSA-9r7h-6639-v5mw | bootstrap-select <1.13.6 | 1.12.2 brought in by patternfly@npm:3.59.5
+# pending | moderate | GHSA-7c82-mp33-r854 | bootstrap-select <1.13.6 | 1.12.2 brought in by patternfly@npm:3.59.5
+- jquery
+# pending | moderate | GHSA-rmxg-73gg-4p98 | jquery >=1.12.3 <3.0.0 | 2.2.4 brought in by manageiq-ui-classic@workspace:.
+# pending | moderate | GHSA-gxr4-xjj5-5px2 | jquery >=1.2.0 <3.5.0  | 2.2.4, 3.2.1, 3.4.1 brought in by manageiq-ui-classic@workspace:., patternfly@npm:3.31.2, patternfly@npm:3.59.5
+# pending | moderate | GHSA-6c3j-c64m-qhgq | jquery >=1.1.4 <3.4.0  | 2.2.4, 3.2.1 brought in by manageiq-ui-classic@workspace:., patternfly@npm:3.31.2
+# pending | moderate | GHSA-jpcq-cgw6-v4j6 | jquery >=1.0.3 <3.5.0  | 2.2.4, 3.2.1, 3.4.1 brought in by manageiq-ui-classic@workspace:., patternfly@npm:3.31.2, patternfly@npm:3.59.5
+- lodash
+# pending | moderate | GHSA-x5rq-j2xg-h7qm | lodash <4.17.11         | 3.10.1 brought in by angular-patternfly@npm:3.26.0
+# pending | high     | GHSA-4xc9-xhrj-v574 | lodash <4.17.11         | 3.10.1 brought in by angular-patternfly@npm:3.26.0
+# pending | moderate | GHSA-29mw-wpgm-hmr9 | lodash <4.17.21         | 3.10.1 brought in by angular-patternfly@npm:3.26.0
+# pending | high     | GHSA-p6mc-m468-83gw | lodash >=3.7.0 <4.17.19 | 3.10.1 brought in by angular-patternfly@npm:3.26.0
+# pending | high     | GHSA-35jh-r3h4-6jhm | lodash <4.17.21         | 3.10.1 brought in by angular-patternfly@npm:3.26.0
+# pending | moderate | GHSA-fvqr-27wr-82fm | lodash <4.17.5          | 3.10.1 brought in by angular-patternfly@npm:3.26.0
+# pending | critical | GHSA-jf85-cpcp-j695 | lodash <4.17.12         | 3.10.1 brought in by angular-patternfly@npm:3.26.0
 
 yarnPath: .yarn/releases/yarn-4.3.1.cjs


### PR DESCRIPTION
Alternative to #9240

Ideally we could use npmAuditIgnoreAdvisories to be aware when new advisories come in, but it turns out the IDs are not stable in that as changes are made to a GHSA, it creates a new ID (See https://github.com/yarnpkg/berry/issues/6438). This churn is difficult to work with. Instead this commit switches to package based, which, while not as granular, is more stable.

@jrafanie Please review.  Note that I have a rake task to generate this list (and the old list), but I want to put that in a separate PR.

cc @GilbertCherrie 