### PR TITLE
Use Rails 7 way to set yaml permitted classes

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -182,11 +182,7 @@ module OpsController::Settings::Common
       task_opts = {:action => "Save subscriptions for global region", :userid => session[:userid]}
       queue_opts = {:class_name => "MiqPglogical", :method_name => "save_global_region",
                     :args       => [subscriptions_to_save, subsciptions_to_remove]}
-      if ActiveRecord.respond_to?(:yaml_column_permitted_classes)
-        ActiveRecord.yaml_column_permitted_classes       = YamlPermittedClasses.app_yaml_permitted_classes | [subscriptions_to_save.first.class, subsciptions_to_remove.first.class]
-      else
-        ActiveRecord::Base.yaml_column_permitted_classes = YamlPermittedClasses.app_yaml_permitted_classes | [subscriptions_to_save.first.class, subsciptions_to_remove.first.class]
-      end
+      ActiveRecord.yaml_column_permitted_classes = YamlPermittedClasses.app_yaml_permitted_classes | [subscriptions_to_save.first.class, subsciptions_to_remove.first.class]
     when "remote"
       task_opts  = {:action => "Configure the database to be a replication remote region",
                     :userid => session[:userid]}


### PR DESCRIPTION
Drops the rails 6.1 compatibility from:
https://github.com/ManageIQ/manageiq-ui-classic/pull/9215

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
