### PR TITLE
Use uglifier harmony mode to handle es6 syntax with rails 7

### DIFF
--- a/lib/manageiq/ui/classic/engine.rb
+++ b/lib/manageiq/ui/classic/engine.rb
@@ -37,7 +37,10 @@ module ManageIQ
         config.assets.paths << root.join('vendor', 'assets', 'stylesheets').to_s
 
         if Rails.env.production? || Rails.env.test?
-          config.assets.js_compressor = :uglifier
+          # Workaround rails 7 + es6 syntax in some js causing uglifier errors by running harmony mode
+          # See: https://www.github.com/lautis/uglifier/issues/127
+          require 'uglifier'
+          config.assets.js_compressor = Uglifier.new(:harmony => true)
         end
 
         def self.vmdb_plugin?


### PR DESCRIPTION
We were getting the following error in production mode:

```
RAILS_ENV=production bundle exec rake evm:compile_assets
...
rake aborted!
Uglifier::Error: Unexpected token: punc ((). To use ES6 syntax, harmony mode must be enabled with Uglifier.new(:harmony => true).
```

Note, this change makes all rails processes in production and test load uglifier even if they'll never use it.  This is because we're eager loading it, instead of delay loading it via a symbol.

It sounds like we can possibly resolve this by figuring out which es6 syntax it doesn't like

See https://www.github.com/lautis/uglifier/issues/127

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
