### PR TITLE
Wrap the uglifier compressor with harmony support

### DIFF
--- a/lib/manageiq/ui/classic/js_compressor.rb
+++ b/lib/manageiq/ui/classic/js_compressor.rb
@@ -1,0 +1,13 @@
+module ManageIQ
+  module UI
+    module Classic
+      class JsCompressor < Sprockets::UglifierCompressor
+        def initialize(options = {})
+          warn "\e[33m** Using #{self.class.name} with Uglifier.new(:harmony => true) from: #{__FILE__}:#{__LINE__}\e[0m"
+          options[:harmony] = true
+          super(options)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Allows es6 code that regular Uglifier doesn't support
* Avoids requiring Uglifier in all rails processes at application startup.
  * Uglifier requires a js runtime such as node
  * JS runtime can continue to be only available in development and for production pre-compilation

This is a better solution than https://github.com/ManageIQ/manageiq-ui-classic/pull/9244

Note, the original es6 workaround suggested by Uglifier is to use this harmony support: https://www.github.com/lautis/uglifier/issues/127

### Before this PR

```
joerafaniello@Joes-MBP manageiq % RAILS_ENV=production bin/rails c
UGLIFYING!!  # <--- loading uglifier and node :-(
** WARN: Rails is serving static assets in production mode
Loading production environment (Rails 7.0.8.4)
irb(main):001:0> exit
```

```
joerafaniello@Joes-MBP manageiq % RAILS_ENV=production bundle exec rake evm:compile_assets
UGLIFYING!!  # <--- loading uglifier and node, expected for this task
** WARN: Rails is serving static assets in production mode
I, [2024-08-08T13:09:55.131323 #95804]  INFO -- : Removed /Users/joerafaniello/Code/manageiq/public/assets
Webpacker is installed 🎉 🍰
Using /Users/joerafaniello/Code/manageiq-ui-classic/config/webpacker.yml file for setting up webpack paths
Removed webpack output path directory /Users/joerafaniello/Code/manageiq/public/packs
I, [2024-08-08T13:09:55.657908 #95804]  INFO -- : Writing /Users/joerafaniello/Code/manageiq/public/assets/actioncable-50da8baf37ad2ebc311be45df6420038f114341a0fc3a2a43e9b7979822dca32.js
I, [2024-08-08T13:09:55.658115 #95804]  INFO -- : Writing /Users/joerafaniello/Code/manageiq/public/assets/actioncable-50da8baf37ad2ebc311be45df6420038f114341a0fc3a2a43e9b7979822dca32.js.gz
```


### After (the new message is in yellow)
```
joerafaniello@Joes-MBP manageiq % RAILS_ENV=production bin/rails c
!!! No loading of uglifier / node
** WARN: Rails is serving static assets in production mode
Loading production environment (Rails 7.0.8.4)
irb(main):001:0> exit
```

```
joerafaniello@Joes-MBP manageiq % RAILS_ENV=production bundle exec rake evm:compile_assets
** WARN: Rails is serving static assets in production mode
I, [2024-08-08T13:07:33.871602 #95617]  INFO -- : Removed /Users/joerafaniello/Code/manageiq/public/assets
Webpacker is installed 🎉 🍰
Using /Users/joerafaniello/Code/manageiq-ui-classic/config/webpacker.yml file for setting up webpack paths
Removed webpack output path directory /Users/joerafaniello/Code/manageiq/public/packs
** Using ManageIQ::UI::Classic::JsCompressor with Uglifier.new(:harmony => true) from: /Users/joerafaniello/Code/manageiq-ui-classic/lib/manageiq/ui/classic/js_compressor.rb:6
UGLIFYING!! # <--- loading uglifier and node, expected for this task
I, [2024-08-08T13:07:34.361957 #95617]  INFO -- : Writing /Users/joerafaniello/Code/manageiq/public/assets/actioncable-50da8baf37ad2ebc311be45df6420038f114341a0fc3a2a43e9b7979822dca32.js
I, [2024-08-08T13:07:34.362130 #95617]  INFO -- : Writing /Users/joerafaniello/Code/manageiq/public/assets/actioncable-50da8baf37ad2ebc311be45df6420038f114341a0fc3a2a43e9b7979822dca32.js.gz
I, [2024-08-08T13:07:34.364246 #95617]  INFO -- : Writing /Users/joerafaniello/Code/manageiq/public/assets/actioncable.esm-fbb5dfe28663d4618729c2c72eb4afc9e78e988d25e37e87267a45c1b34b84df.js
I, [2024-08-08T13:07:34.364338 #95617]  INFO -- : Writing /Users/joerafaniello/Code/manageiq/public/assets/actioncable.esm-fbb5dfe28663d4618729c2c72eb4afc9e78e988d25e37e87267a45c1b34b84df.js.gz
I, [2024-08-08T13:07:34.365004 #95617]  INFO -- : Writing /Users/joerafaniello/Code/manageiq/public/assets/favicon-6ca95f7b93eeb006088db7dd238353e62eb9ad976446654600ad6d42e2d62ae2.ico
```

Here's how the new message looks... I'm open to suggestions:

![image](https://github.com/user-attachments/assets/39c9c07b-69db-4ebc-8706-414ff6b35b53)
