### PR TITLE
Fix the VM Infra button checking EmsCloud providers

### DIFF
--- a/app/helpers/application_helper/button/vm_miq_request_new.rb
+++ b/app/helpers/application_helper/button/vm_miq_request_new.rb
@@ -8,6 +8,6 @@ class ApplicationHelper::Button::VmMiqRequestNew < ApplicationHelper::Button::Bu
 
   def provisioning_supported?
     # TODO: EmsCloud.supporting(:provisioning).any?
-    EmsCloud.all.any? { |ems| ems.supports?(:provisioning) }
+    EmsInfra.all.any? { |ems| ems.supports?(:provisioning) }
   end
 end

--- a/spec/helpers/application_helper/buttons/vm_miq_request_new_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_miq_request_new_spec.rb
@@ -1,0 +1,22 @@
+describe ApplicationHelper::Button::VmMiqRequestNew do
+  let(:view_context) { setup_view_context_with_sandbox({}) }
+  let(:button)       { described_class.new(view_context, {}, {}, {}) }
+
+  describe '#disabled?' do
+    context "with no ext_management_systems" do
+      it_behaves_like "a disabled button", "No Infrastructure Provider that supports VM provisioning added"
+    end
+
+    context "with a cloud ext_management_system" do
+      let!(:ems) { FactoryBot.create(:ems_cloud) }
+
+      it_behaves_like "a disabled button", "No Infrastructure Provider that supports VM provisioning added"
+    end
+
+    context "with an infrastructure ext_management_system" do
+      let!(:ems) { FactoryBot.create(:ems_infra) }
+
+      it_behaves_like "an enabled button"
+    end
+  end
+end


### PR DESCRIPTION
Found by https://github.com/orgs/ManageIQ/discussions/23147#discussioncomment-10351757

This looks like it was just copied&pasted from [app/helpers/application_helper/button/instance_miq_request_new.rb](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/helpers/application_helper/button/instance_miq_request_new.rb) without updating the EmsCloud => EmsInfra
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
