### PR TITLE
Drop include_concern in ResourcePool Helpers

### DIFF
--- a/app/helpers/resource_pool_cloud_helper.rb
+++ b/app/helpers/resource_pool_cloud_helper.rb
@@ -1,4 +1,4 @@
 module ResourcePoolCloudHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
   include ResourcePoolConfigHelper
 end

--- a/app/helpers/resource_pool_cloud_helper/textual_summary.rb
+++ b/app/helpers/resource_pool_cloud_helper/textual_summary.rb
@@ -2,7 +2,7 @@ module ResourcePoolCloudHelper::TextualSummary
   #
   # Groups
   #
-  
+
   def textual_ext_management_system
     textual_link(@record.ext_management_system)
   end

--- a/app/helpers/resource_pool_infra_helper.rb
+++ b/app/helpers/resource_pool_infra_helper.rb
@@ -1,4 +1,4 @@
 module ResourcePoolInfraHelper
-  include_concern 'TextualSummary'
+  include TextualSummary
   include ResourcePoolConfigHelper
 end

--- a/spec/config/routes.pending.yml
+++ b/spec/config/routes.pending.yml
@@ -1068,13 +1068,8 @@ ReportController:
 - x_history
 - x_show
 ResourcePoolCloudController:
-- adv_search_button
-- adv_search_clear
-- adv_search_load_choice
-- adv_search_name
-- adv_search_name_typed
-- adv_search_toggle
 - compare_cancel
+- compare_choose
 - compare_choose_base
 - compare_compress
 - compare_miq
@@ -1087,31 +1082,12 @@ ResourcePoolCloudController:
 - compare_to_csv
 - compare_to_pdf
 - compare_to_txt
-- download_data
-- download_summary_pdf
-- exp_button
-- exp_changed
-- exp_token_pressed
 - index
-- listnav_search_selected
-- protect
-- quick_search
-- report_data
-- save_default_search
-- search_clear
 - sections_field_changed
-- show
-- show_list
-- tagging_edit
 - tree_autoload
 ResourcePoolInfraController:
-- adv_search_button
-- adv_search_clear
-- adv_search_load_choice
-- adv_search_name
-- adv_search_name_typed
-- adv_search_toggle
 - compare_cancel
+- compare_choose
 - compare_choose_base
 - compare_compress
 - compare_miq
@@ -1124,24 +1100,11 @@ ResourcePoolInfraController:
 - compare_to_csv
 - compare_to_pdf
 - compare_to_txt
-- download_data
-- download_summary_pdf
-- exp_button
-- exp_changed
-- exp_token_pressed
 - index
-- listnav_search_selected
-- protect
-- quick_search
-- report_data
-- save_default_search
-- search_clear
 - sections_field_changed
-- show
-- show_list
-- tagging_edit
 - tree_autoload
 RestfulRedirectController:
+- compare_mode
 - index
 - report_data
 SecurityGroupController:

--- a/spec/config/routes.pending.yml
+++ b/spec/config/routes.pending.yml
@@ -1069,7 +1069,6 @@ ReportController:
 - x_show
 ResourcePoolCloudController:
 - compare_cancel
-- compare_choose
 - compare_choose_base
 - compare_compress
 - compare_miq
@@ -1087,7 +1086,6 @@ ResourcePoolCloudController:
 - tree_autoload
 ResourcePoolInfraController:
 - compare_cancel
-- compare_choose
 - compare_choose_base
 - compare_compress
 - compare_miq

--- a/spec/config/routes.pending.yml
+++ b/spec/config/routes.pending.yml
@@ -1102,7 +1102,6 @@ ResourcePoolInfraController:
 - sections_field_changed
 - tree_autoload
 RestfulRedirectController:
-- compare_mode
 - index
 - report_data
 SecurityGroupController:


### PR DESCRIPTION
Introduced by https://github.com/ManageIQ/manageiq-ui-classic/pull/8929
#9060 dropped include_conern
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
