### PR TITLE
Fix generic object embedded table

### DIFF
--- a/app/controllers/generic_object_controller.rb
+++ b/app/controllers/generic_object_controller.rb
@@ -38,4 +38,5 @@ class GenericObjectController < ApplicationController
   end
 
   helper_method :textual_group_list
+  has_custom_buttons
 end

--- a/app/controllers/mixins/custom_buttons.rb
+++ b/app/controllers/mixins/custom_buttons.rb
@@ -22,9 +22,7 @@ module Mixins::CustomButtons
   def custom_toolbar_simple
     if @record && %w[show show_dashboard].include?(@lastaction) && %w[dashboard main].include?(@display)
       Mixins::CustomButtons::Result.new(:single)
-    elsif @lastaction == "show_list"
-      Mixins::CustomButtons::Result.new(:list)
-    elsif relationship_table_screen?
+    elsif @lastaction == "show_list" || relationship_table_screen?
       Mixins::CustomButtons::Result.new(:list)
     elsif @display == 'generic_objects'
       @lastaction == 'generic_object' ? Mixins::CustomButtons::Result.new(:single) : Mixins::CustomButtons::Result.new(:list)

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -16,10 +16,6 @@ class ServiceController < ApplicationController
     process_show_list(:dbname => :service, :gtl_dbname => :service)
   end
 
-  def show
-    super
-  end
-
   def button
     case params[:pressed]
     when 'service_tag'
@@ -36,7 +32,7 @@ class ServiceController < ApplicationController
       javascript_redirect(:action => 'service_reconfigure', :id => params[:id])
     when "custom_button"
       @display == 'generic_objects' ? generic_object_custom_buttons : custom_buttons
-    when 'generic_object_tag'
+    when "generic_object_tag"
       tag(GenericObject)
     else
       add_flash(_("Invalid button action"), :error)

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -18,8 +18,6 @@ class ServiceController < ApplicationController
 
   def show
     super
-    @options = {}
-    @view, @pages = get_view(Vm, :parent => @record, :parent_method => :all_vms, :all_pages => true)
   end
 
   def button
@@ -38,6 +36,8 @@ class ServiceController < ApplicationController
       javascript_redirect(:action => 'service_reconfigure', :id => params[:id])
     when "custom_button"
       @display == 'generic_objects' ? generic_object_custom_buttons : custom_buttons
+    when 'generic_object_tag'
+      tag(GenericObject)
     else
       add_flash(_("Invalid button action"), :error)
       render_flash
@@ -48,7 +48,7 @@ class ServiceController < ApplicationController
     display_options = {}
     ids = @lastaction == 'generic_object' ? @sb[:rec_id] : 'LIST'
     display_options[:display] = @display
-    display_options[:record_id] = parse_nodetype_and_id(x_node).last
+    display_options[:record_id] = @sb[:rec_id]
     display_options[:display_id] = params[:id] if @lastaction == 'generic_object'
     custom_buttons(ids, display_options)
   end
@@ -57,18 +57,16 @@ class ServiceController < ApplicationController
     _("My Services")
   end
 
+  def toolbar
+    return 'generic_object_center' if %w[generic_objects].include?(@display) # for nested generic objects list screen
+
+    %w[show_list].include?(@lastaction) ? 'services_center' : 'service_center'
+  end
+
   def set_display
     @display = params[:display]
     @display ||= default_display unless pagination_or_gtl_request?
     @display ||= 'generic_objects' if role_allows?(:feature => "generic_object_view") && @record.number_of(:generic_objects).positive?
-  end
-
-  def show_generic_object
-    if params[:generic_object_id]
-      show_single_generic_object
-    else
-      display_nested_list(@display)
-    end
   end
 
   def edit
@@ -101,27 +99,17 @@ class ServiceController < ApplicationController
     }
   end
 
-  # display a single generic object
-  #
-  def show_single_generic_object
-    return unless init_show_variables
-
-    @lastaction = 'generic_object'
-    @item = @record.generic_objects.find { |e| e[:id] == params[:generic_object_id].to_i }
-    drop_breadcrumb(:name => _("%{name} (All Generic Objects)") % {:name => @record.name}, :url => show_link(@record, :display => 'generic_objects'))
-    drop_breadcrumb(:name => @item.name, :url => show_link(@record, :display => 'generic_objects', :generic_object_id => params[:generic_object_id]))
-    @view = get_db_view(GenericObject)
-    @sb[:rec_id] = params[:generic_object_id]
-    @record = @item
-    show_item
-  end
-
   def self.display_methods
     %w[generic_objects custom_button_events]
   end
 
   def display_generic_objects
     nested_list(GenericObject)
+
+    if params[:generic_object_id]
+      generic_object_id = params[:generic_object_id]
+      redirect_to(:controller => 'generic_object', :action => "show", :id => generic_object_id)
+    end
   end
 
   def reconfigure_form_fields
@@ -287,5 +275,4 @@ class ServiceController < ApplicationController
   menu_section :svc
   feature_for_actions "service_view", *ADV_SEARCH_ACTIONS
   has_custom_buttons
-  toolbar :service, :services
 end

--- a/app/helpers/application_helper/toolbar/generic_object_center.rb
+++ b/app/helpers/application_helper/toolbar/generic_object_center.rb
@@ -10,7 +10,11 @@ class ApplicationHelper::Toolbar::GenericObjectCenter < ApplicationHelper::Toolb
           :generic_object_tag,
           'pficon pficon-edit fa-lg',
           N_('Edit Tags for this Generic Object Instance'),
-          N_('Edit Tags')),
+          N_('Edit Tags'),
+          :send_checked => true,
+          :enabled      => false,
+          :onwhen       => "1+"
+        ),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/mixins/custom_button_toolbar_mixin.rb
+++ b/app/helpers/application_helper/toolbar/mixins/custom_button_toolbar_mixin.rb
@@ -55,6 +55,8 @@ module ApplicationHelper::Toolbar::Mixins::CustomButtonToolbarMixin
     return false if @display.nil?
     display_class = @display.camelize.singularize
     return false unless custom_button_appliable_class?(display_class)
+    # Don't render custom buttons on nested generic object lists since it could contain generic objects with different definitions and custom buttons
+    return false if @display == 'generic_objects'
 
     show_action = @lastaction == "show"
     display_model = custom_button_class_model(display_class)

--- a/app/helpers/service_helper/textual_summary.rb
+++ b/app/helpers/service_helper/textual_summary.rb
@@ -285,7 +285,7 @@ module ServiceHelper::TextualSummary
     num = @record.number_of(:generic_objects)
     h = {:label => _("Instances"), :value => num}
     if role_allows?(:feature => "generic_object_view") && num.positive?
-      h.update(:link  => url_for_only_path(:action => 'show', :id => @record, :display => 'generic_objects', :type => 'tile'),
+      h.update(:link  => url_for_only_path(:action => 'show', :id => @record, :display => 'generic_objects'),
                :title => _('Show Generic Object Instances for this Service'))
     end
     h

--- a/app/views/service/show.html.haml
+++ b/app/views/service/show.html.haml
@@ -1,4 +1,4 @@
-- if @display == 'instances'
+- if @display == 'generic_objects'
   = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
 - elsif @ownershipitems
   = render :partial => "shared/views/ownership"


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/9255

Fixed generic object embedded table. Also, fixed the toolbar for the embedded generic object table page.

This pr also fixes an issue where custom buttons do not appear on the generic object show page.

Before:
<img width="1412" alt="Screenshot 2024-09-16 at 11 20 50 AM" src="https://github.com/user-attachments/assets/5a211b12-e6ee-49a2-8447-bc08f0a33217">
<img width="699" alt="Screenshot 2024-09-16 at 11 21 11 AM" src="https://github.com/user-attachments/assets/7bbb10da-97fe-49ab-8449-27c57f3ac25d">

After:
<img width="1416" alt="Screenshot 2024-09-16 at 11 18 33 AM" src="https://github.com/user-attachments/assets/fc862fad-04ff-4e68-ac55-41a83a708b4e">
<img width="892" alt="Screenshot 2024-09-16 at 11 19 10 AM" src="https://github.com/user-attachments/assets/1402c0de-dd9f-4843-b1d2-de2487fece0a">


