### PR TITLE
Fix a typo in the fork name

### DIFF
--- a/.github/workflows/locale_po_to_json.yaml
+++ b/.github/workflows/locale_po_to_json.yaml
@@ -50,7 +50,7 @@ jobs:
         committer: ManageIQ Bot <bot@manageiq.org>
         delete-branch: true
         labels: internationalization
-        push-to-fork: ManageIQ/manageiq-ui-classic
+        push-to-fork: miq-bot/manageiq-ui-classic
         title: Update UI json translation files
         body: Update UI json translation files
         token: ${{ secrets.PR_TOKEN }}


### PR DESCRIPTION
We're creating a PR using the fork of the bot, not the main repository.

Fixes an issue in the one area in PR #9263 that I couldn't test: creating the PR as the bot.  🤣 

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
