### PR TITLE
Remove unused controller stub from spec

### DIFF
--- a/spec/controllers/mixins/generic_show_mixin_spec.rb
+++ b/spec/controllers/mixins/generic_show_mixin_spec.rb
@@ -1,8 +1,4 @@
 describe Mixins::GenericShowMixin do
-  class GenericShowMixinTestController < ActionController::Base
-    include Mixins::GenericShowMixin
-  end
-
   describe '#nested_list' do
     context 'displaying Service Templates thru Tenant textual summary' do
       let(:controller) { OpsController.new }


### PR DESCRIPTION
This was causing brakeman to fail, but it's not used.

@jrafanie Please review.