### PR TITLE
Add option to create new dialog for terraform template in service catalog item

### DIFF
--- a/app/javascript/components/terraform-template-catalog-form/terraform-template-catalog-form.schema.js
+++ b/app/javascript/components/terraform-template-catalog-form/terraform-template-catalog-form.schema.js
@@ -207,11 +207,22 @@ const provisionTabSchema = (
         valueLabel: __('Default value'),
       },
       {
+        component: componentTypes.RADIO,
+        id: 'config_info.provision.dialog_type',
+        name: 'config_info.provision.dialog_type',
+        label: __('Dialog'),
+        options: [{ value: 'useExisting', label: __('Use Existing') }, { value: 'createNew', label: __('Create New') }],
+      },      
+      {
         component: componentTypes.SELECT,
         id: 'config_info.provision.dialog_id',
         name: 'config_info.provision.dialog_id',
         label: __('Existing Dialog'),
         options: transformGeneralOptions(dialogs),
+        condition: {
+          when: 'config_info.provision.dialog_type',
+          is: 'useExisting',
+        },
         includeEmpty: true,
         isRequired: true,
         validate: [{ type: validatorTypes.REQUIRED }],


### PR DESCRIPTION
Depends on:
- [x] https://github.com/ManageIQ/manageiq-providers-embedded_terraform/pull/75
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

This PR, make changes for Terraform Template, in New Service Catalog Item page.

* Before this PR changes,  in Provision tab, the user could not create new dialog for terraform template, they could only select existing service dialogs.

   <img width="582" alt="Before-Service-Catalog-item-Provision-tab" src="https://github.com/user-attachments/assets/ba048b28-ae29-4b8f-9c1c-5f3e7e31664d">
   
* After the changes in PR, in Provision tab, the user can now either choose to use existing service dialog or create new dialog for the terraform template.
     
   <img width="581" alt="After-Service-Catalog-Item-Provision-tab" src="https://github.com/user-attachments/assets/c5d6ee36-414f-4cea-ae5e-6d4ba8e8bed7">

   
* If the user chooses to create new dialog, providing new dialog name, then saves the Service Catalog item, new dialog is created in background.
   
   <img width="591" alt="New-Service-Catalog-Item-with-new-dialog" src="https://github.com/user-attachments/assets/20ca7e0a-593a-4946-b051-4a23415ac045">


* The newly dialog created, will have section added for `Terraform Template Variables`,  this section will have textboxes for each 'input' variables from terraform template.  The newly created dialog can be edited by the user according to needs.
   In current Hello World example, the terraform template has single input variable called 'name', so you see one textbox component with label 'name'.
    
   <img width="611" alt="new-dialog-edit" src="https://github.com/user-attachments/assets/7b82b2d7-de14-4642-805a-c9034b51e231">
   
* When the same  Service catalog item is ordered ..
         
   <img width="720" alt="Order-Service-Catalog-Item-with-TF-var-section" src="https://github.com/user-attachments/assets/8f1396ce-f515-41e5-83ae-87762057db4c">

   



   




<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
