### PR TITLE
fix scss warning on division

### DIFF
--- a/app/stylesheet/quadicon.scss
+++ b/app/stylesheet/quadicon.scss
@@ -128,11 +128,11 @@ div.miq-quadicon {
       }
 
       .text.font-small {
-        font-size: $font-size * 3/3;
+        font-size: math.div($font-size * 3, 3);
       }
 
       .text.font-tiny {
-        font-size: $font-size * 2/3;
+        font-size: math.div($font-size * 2, 3);
       }
     }
   }


### PR DESCRIPTION
I don't know if we need the fractions, but this looked like the fix here.

Not sure exactly where to test this.

```
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($font-size * 2, 3) or calc($font-size * 2 / 3)

More info and automated migrator: https://sass-lang.com/d/slash-div

    ╷
135 │         font-size: $font-size * 2/3;
    │                    ^^^^^^^^^^^^^^^^
    ╵
    app/stylesheet/quadicon.scss 135:20  @import
    stdin 25:9                           root stylesheet
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
