### PR TITLE
Show Terraform Template stack stdout

### DIFF
--- a/app/helpers/application_helper/toolbar/service_center.rb
+++ b/app/helpers/application_helper/toolbar/service_center.rb
@@ -88,4 +88,14 @@ class ApplicationHelper::Toolbar::ServiceCenter < ApplicationHelper::Toolbar::Ba
                    ]
                  ),
                ])
+  button_group('service_refresh', [
+                button(
+                  :service_view,
+                  'fa fa-refresh fa-lg',
+                  N_('Refresh this page'),
+                  N_('Refresh'),
+                  # needs the function because reload can't be called with different this
+                  :data => { 'function' => 'function() { window.location.reload(); }' }
+                )
+              ])
 end

--- a/app/views/service/_svcs_show.html.haml
+++ b/app/views/service/_svcs_show.html.haml
@@ -3,6 +3,10 @@
     %ul.nav.nav-tabs{'role' => 'tablist'}
       = miq_tab_header("details") do
         = _("Details")
+      - if @record.type == "ServiceTerraformTemplate"   
+        - stack = @record.try(:stack, "Provision")
+        = miq_tab_header("output") do
+          = _("Output")
       - if @record.type == "ServiceAnsiblePlaybook"
         - provision_job = @record.try(:job, "Provision")
         - retirement_job = @record.try(:job, "Retirement")
@@ -29,6 +33,12 @@
               = _('VMs')
             - if @view
               = render :partial => "layouts/gtl", :locals => {:view => @view, :no_flash_div => true}
+      
+      - if @record.type == "ServiceTerraformTemplate"
+        = miq_tab_content("output", 'default', :class => 'cm-tab') do
+          - if stack
+            = react('ServiceDetailStdout', { :taskid => stack.raw_stdout_via_worker(User.current_user&.userid, 'html')});
+
       - if @record.type == "ServiceAnsibleTower" || @record.type == "ServiceAwx"
         = miq_tab_content("tower_job", 'default', :class => 'cm-tab') do
           = render :partial => "layouts/textual_groups_tabs", :locals => {:textual_group_list => textual_tower_job_group_list, :tab_id => "tower_job"}


### PR DESCRIPTION
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

This PR is dependant on https://github.com/ManageIQ/manageiq-providers-embedded_terraform/pull/78

With this change, separate tab added to show standard output from the terraform cli run job.

* Before the changes,  there was no standard output shown.
<img width="749" alt="Before-Changes(Show-Service)" src="https://github.com/user-attachments/assets/06d315f2-a10e-4adc-a275-5606ea4a108d">

---

* After the changes,  there are two tabs, one for details, other for standard output from the terraform cli run job.
<img width="797" alt="After-Changes(Show-Service)" src="https://github.com/user-attachments/assets/2a6c8e12-508c-4967-a6ef-372091930700">

* Output tab with terraform CLI standard output
<img width="630" alt="After-Change-Stdout(Show-Service)" src="https://github.com/user-attachments/assets/25cb6657-bd91-4df9-9277-e7638d2b9e30">

---
Additional changes

* Also added is a 'Refresh' button to refresh the page data
<img width="718" alt="After-Change-Stdout-Refresh(Service-View)" src="https://github.com/user-attachments/assets/2c81a24d-a063-49fa-a103-2b173befd8ac">



<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
