### PR TITLE
Remove unused miqsanitize angular code

### DIFF
--- a/app/javascript/oldjs/components/index.js
+++ b/app/javascript/oldjs/components/index.js
@@ -1,4 +1,3 @@
 require('./ae_resolve_options/ae-resolve-options.js');
 require('./index.js');
 require('./miq-button.js');
-require('./sanitize.js');

--- a/app/javascript/oldjs/components/sanitize.js
+++ b/app/javascript/oldjs/components/sanitize.js
@@ -1,7 +1,0 @@
-angular.module('ManageIQ')
-  .component('miqSanitize', {
-    bindings: {
-      value: '@',
-    },
-    template: '<span ng-bind-html="$ctrl.value"></span>',
-  });


### PR DESCRIPTION
Remove unused miqsanitize angular code. This is code that was added in this pr: https://github.com/ManageIQ/manageiq-ui-classic/pull/275 for the service catalog page but is no longer being used there.