### PR TITLE
Add bundler path

### DIFF
--- a/lib/tasks/manageiq/ui_tasks.rake
+++ b/lib/tasks/manageiq/ui_tasks.rake
@@ -66,6 +66,9 @@ namespace :webpack do
   end
 
   task :paths do
+    require "bundler"
+    require "bundler/cli"
+
     i18n_path = Bundler::CLI::Common.select_spec("gettext_i18n_rails_js").full_gem_path
 
     json = JSON.pretty_generate(


### PR DESCRIPTION
In ruby 3.1.*, it was not finding BUNDLER::CLI

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
