### PR TITLE
Fix issue when using kerberos auth with Rails 7

### DIFF
--- a/app/controllers/application_controller/wait_for_task.rb
+++ b/app/controllers/application_controller/wait_for_task.rb
@@ -49,7 +49,7 @@ module ApplicationController::WaitForTask
     session[:async][:params] ||= {}
 
     # save the incoming parms + extra_params
-    session[:async][:params] = params.deep_dup.merge(options[:extra_params] || {})
+    session[:async][:params] = params.to_unsafe_h.merge(options[:extra_params] || {})
     session[:async][:params][:task_id] = task_id
 
     # override method to be called, when the task is done


### PR DESCRIPTION
kerberos auth requires a wait_for_task under the covers. When we create this task, we store a backup copy of the incoming request params within the session object, so we can restore it later after the task we are waiting for has completed, and that session object is `Marshal.dump`ed into memcached. In Rails 7, Rails changed the ActionController::Parameters object to include some more objects as context, such as the request, and the request internally has an IO object that cannot be dumped. Since we don't actually need the context and instead only need the parameters, we can use `to_unsafe_h` instead of `deep_dup`, to get a copy of those parameters in HashWithIndifferentAccess form. Later when [wait_for_task reconstructs the parameters](https://github.com/ManageIQ/manageiq-ui-classic/blob/c01c87edca30773d408a61de3f125ea62edbe751/app/controllers/application_controller/wait_for_task.rb#L22), they will be placed back into the request object, which will get them back into the ActionController::Parameters format.

@jrafanie Please review.