### PR TITLE
Fix Chrome autofilling password when editing a schema

### DIFF
--- a/app/views/miq_ae_class/_class_fields.html.haml
+++ b/app/views/miq_ae_class/_class_fields.html.haml
@@ -61,6 +61,7 @@
                       = password_field_tag("fields_password_value_#{i}", '',
                         :placeholder       => placeholder_if_present(default_value),
                         :style             => field['datatype'] == "password" ? "" : "display:none",
+                        :autocomplete      => "new-password",
                         "data-miq_observe" => obs)
                     - else
                       = text_field_tag("fields_#{fname}_#{i}", field[fname],


### PR DESCRIPTION
Adds autocomplete attribute to prevent password datatype default values from using password manager values

@miq-bot add-label bug
@miq-bot add-reviewer @GilbertCherrie 