### PR TITLE
Transforms haml forms to react for Add and Edit feature of Automate Class

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -131,7 +131,6 @@ class MiqAeClassController < ApplicationController
       txt = rec.domain? ? _('Automate Domain') : _('Automate Namespace')
       @sb[:namespace_path] = rec.fqname
     end
-    @sb[:namespace_path]&.gsub!(%r{\/}, " / ")
     @right_cell_text = "#{txt} #{_("\"%s\"") % get_rec_name(rec)}" unless %w[root aei aem].include?(nodes[0])
   end
 

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -1884,11 +1884,12 @@ class MiqAeClassController < ApplicationController
       begin
         class_rec.save!
       rescue StandardError
+        errors = []
         class_rec.errors.each do |error|
-          add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error)
+          errors.push("#{error.attribute.to_s.capitalize} #{error.message}")
         end
         @changed = true
-        javascript_flash
+        render :json => {:error => errors, :status => 500}
       else
         edit_hash = {}
         edit_hash[:new] = {:name => params[:name],
@@ -1902,7 +1903,7 @@ class MiqAeClassController < ApplicationController
                               end
         AuditEvent.success(build_saved_audit(class_rec, edit_hash))
         @edit = session[:edit] = nil # clean out the saved info
-        replace_right_cell(:nodetype => x_node, :replace_trees => [:ae])
+        render :json => {:status => 200}
       end
     end
   end

--- a/app/javascript/components/miq-ae-class/class-form.schema.js
+++ b/app/javascript/components/miq-ae-class/class-form.schema.js
@@ -1,0 +1,36 @@
+import { componentTypes, validatorTypes } from '@@ddf';
+
+const createSchema = (fqname) => ({
+  fields: [
+    {
+      component: componentTypes.PLAIN_TEXT,
+      name: 'fqname',
+      label: `${__('Fully Qualified Name')}:\t ${fqname}`,
+    },
+    {
+      component: componentTypes.TEXT_FIELD,
+      id: 'name',
+      name: 'name',
+      label: __('Name'),
+      maxLength: 128,
+      validate: [{ type: validatorTypes.REQUIRED }],
+      isRequired: true,
+    },
+    {
+      component: componentTypes.TEXT_FIELD,
+      id: 'display_name',
+      name: 'display_name',
+      label: __('Display Name'),
+      maxLength: 128,
+    },
+    {
+      component: componentTypes.TEXT_FIELD,
+      id: 'description',
+      name: 'description',
+      label: __('Description'),
+      maxLength: 255,
+    },
+  ],
+});
+
+export default createSchema;

--- a/app/javascript/components/miq-ae-class/class-form.schema.js
+++ b/app/javascript/components/miq-ae-class/class-form.schema.js
@@ -3,9 +3,11 @@ import { componentTypes } from '@@ddf';
 const createSchema = (fqname) => ({
   fields: [
     {
-      component: componentTypes.PLAIN_TEXT,
+      component: componentTypes.TEXT_FIELD,
       name: 'fqname',
-      label: `${__('Fully Qualified Name')}:\t ${fqname}`,
+      label: 'Fully Qualified Name',
+      value: `${fqname}`,
+      disabled: true,
     },
     {
       component: componentTypes.TEXT_FIELD,

--- a/app/javascript/components/miq-ae-class/class-form.schema.js
+++ b/app/javascript/components/miq-ae-class/class-form.schema.js
@@ -1,4 +1,4 @@
-import { componentTypes, validatorTypes } from '@@ddf';
+import { componentTypes } from '@@ddf';
 
 const createSchema = (fqname) => ({
   fields: [
@@ -13,7 +13,7 @@ const createSchema = (fqname) => ({
       name: 'name',
       label: __('Name'),
       maxLength: 128,
-      validate: [{ type: validatorTypes.REQUIRED }],
+      validate: [{ type: 'customValidatorForNameField' }],
       isRequired: true,
     },
     {

--- a/app/javascript/components/miq-ae-class/index.jsx
+++ b/app/javascript/components/miq-ae-class/index.jsx
@@ -8,6 +8,7 @@ import miqRedirectBack from '../../helpers/miq-redirect-back';
 import miqFlash from '../../helpers/miq-flash';
 
 const MiqAeClass = ({ classRecord, fqname }) => {
+  const formattedFqname = fqname.replace(/\s+/g, '');
   const [data, setData] = useState({
     isLoading: true,
     initialValues: undefined,
@@ -24,7 +25,7 @@ const MiqAeClass = ({ classRecord, fqname }) => {
       });
     } else {
       const initialValues = {
-        fqname,
+        formattedFqname,
         name: classRecord && classRecord.name,
         display_name: classRecord && classRecord.display_name,
         description: classRecord && classRecord.description,
@@ -86,7 +87,7 @@ const MiqAeClass = ({ classRecord, fqname }) => {
     ? (
       <div className="dialog-provision-form">
         <MiqFormRenderer
-          schema={createSchema(fqname)}
+          schema={createSchema(formattedFqname)}
           initialValues={data.initialValues}
           validatorMapper={customValidatorMapper}
           onSubmit={onSubmit}

--- a/app/javascript/components/miq-ae-class/index.jsx
+++ b/app/javascript/components/miq-ae-class/index.jsx
@@ -1,0 +1,174 @@
+import React, { useState, useEffect } from 'react';
+import { FormSpy } from '@data-driven-forms/react-form-renderer';
+import { Button } from 'carbon-components-react';
+import MiqFormRenderer, { useFormApi } from '@@ddf';
+import PropTypes from 'prop-types';
+import createSchema from './class-form.schema';
+import miqRedirectBack from '../../helpers/miq-redirect-back';
+
+const MiqAeClass = ({ classRecord, fqname }) => {
+  const [data, setData] = useState({
+    isLoading: true,
+    initialValues: undefined,
+  });
+
+  const isEdit = !!(classRecord && classRecord.id);
+
+  useEffect(() => {
+    if (isEdit) {
+      http.get(`/miq_ae_class/edit_class_record/${classRecord.id}/`).then((recordValues) => {
+        if (recordValues) {
+          setData({ ...data, isLoading: false, initialValues: recordValues });
+        }
+      });
+    } else {
+      const initialValues = {
+        fqname,
+        name: classRecord && classRecord.name,
+        display_name: classRecord && classRecord.display_name,
+        description: classRecord && classRecord.description,
+      };
+      setData({ ...data, isLoading: false, initialValues });
+    }
+  }, [classRecord]);
+
+  const onSubmit = (values) => {
+    miqSparkleOn();
+
+    const params = {
+      action: isEdit ? 'edit' : 'create',
+      name: values.name,
+      display_name: values.display_name,
+      description: values.description,
+      old_data: data.initialValues,
+      button: classRecord.id ? 'save' : 'add',
+    };
+
+    const request = isEdit
+      ? http.post(`/miq_ae_class/class_update/${classRecord.id}`, params)
+      : http.post(`/miq_ae_class/class_update/`, params);
+
+    request
+      .then(() => {
+        const confirmation = isEdit ? __(`Class "${values.name}" was saved`) : __(`Class "${values.name}" was added`);
+        miqRedirectBack(sprintf(confirmation, values.name), 'success', '/miq_ae_class/explorer');
+      })
+      .catch(miqSparkleOff);
+  };
+
+  const onCancel = () => {
+    const confirmation = classRecord.id ? __(`Edit of Class "${classRecord.name}" cancelled by the user`)
+      : __(`Add of new Class was cancelled by the user`);
+    const message = sprintf(
+      confirmation
+    );
+    miqRedirectBack(message, 'warning', '/miq_ae_class/explorer');
+  };
+
+  return (!data.isLoading
+    ? (
+      <div className="dialog-provision-form">
+        <MiqFormRenderer
+          schema={createSchema(fqname)}
+          initialValues={data.initialValues}
+          onSubmit={onSubmit}
+          onCancel={onCancel}
+          canReset={!!classRecord.id}
+          validate={() => {}}
+          FormTemplate={(props) => <FormTemplate {...props} recId={classRecord.id} />}
+        />
+      </div>
+    ) : null
+  );
+};
+
+const FormTemplate = ({
+  formFields, recId,
+}) => {
+  const {
+    handleSubmit, onReset, onCancel, getState,
+  } = useFormApi();
+  const { valid, pristine } = getState();
+  const submitLabel = !!recId ? __('Save') : __('Add');
+  return (
+    <form onSubmit={handleSubmit}>
+      {formFields}
+      <FormSpy>
+        {() => (
+          <div className="custom-button-wrapper">
+            { !recId
+              ? (
+                <Button
+                  disabled={!valid}
+                  kind="primary"
+                  className="btnRight"
+                  type="submit"
+                  variant="contained"
+                >
+                  {submitLabel}
+                </Button>
+              ) : (
+                <Button
+                  disabled={!valid || pristine}
+                  kind="primary"
+                  className="btnRight"
+                  type="submit"
+                  variant="contained"
+                >
+                  {submitLabel}
+                </Button>
+              )}
+            {!!recId
+              ? (
+                <Button
+                  disabled={pristine}
+                  kind="secondary"
+                  className="btnRight"
+                  variant="contained"
+                  onClick={onReset}
+                  type="button"
+                >
+                  { __('Reset')}
+                </Button>
+              ) : null}
+
+            <Button variant="contained" type="button" onClick={onCancel} kind="secondary">
+              { __('Cancel')}
+            </Button>
+          </div>
+        )}
+      </FormSpy>
+    </form>
+  );
+};
+
+MiqAeClass.propTypes = {
+  classRecord: PropTypes.shape({
+    id: PropTypes.number,
+    name: PropTypes.string,
+    display_name: PropTypes.string,
+    description: PropTypes.string,
+  }),
+  fqname: PropTypes.string.isRequired,
+};
+
+MiqAeClass.defaultProps = {
+  classRecord: undefined,
+};
+
+FormTemplate.propTypes = {
+  formFields: PropTypes.arrayOf(
+    PropTypes.shape({ id: PropTypes.number }),
+    PropTypes.shape({ name: PropTypes.string }),
+    PropTypes.shape({ display_name: PropTypes.string }),
+    PropTypes.shape({ description: PropTypes.string }),
+  ),
+  recId: PropTypes.number,
+};
+
+FormTemplate.defaultProps = {
+  formFields: undefined,
+  recId: undefined,
+};
+
+export default MiqAeClass;

--- a/app/javascript/components/miq-ae-class/index.jsx
+++ b/app/javascript/components/miq-ae-class/index.jsx
@@ -52,8 +52,9 @@ const MiqAeClass = ({ classRecord, fqname }) => {
     request
       .then((response) => {
         if (response.status === 200) {
-          const confirmation = isEdit ? __(`Class "${values.name}" was saved`) : __(`Class "${values.name}" was added`);
-          miqRedirectBack(sprintf(confirmation, values.name), 'success', '/miq_ae_class/explorer');
+          const confirmation = isEdit ? __(`Class "%s" was saved`) : __(`Class "%s" was added`);
+          const message = sprintf(confirmation, values.name);
+          miqRedirectBack(message, 'success', '/miq_ae_class/explorer');
         } else {
           miqSparkleOff();
           miqFlash('error', response.error);
@@ -63,11 +64,9 @@ const MiqAeClass = ({ classRecord, fqname }) => {
   };
 
   const onCancel = () => {
-    const confirmation = classRecord.id ? __(`Edit of Class "${classRecord.name}" cancelled by the user`)
+    const confirmation = classRecord.id ? __(`Edit of Class "%s" cancelled by the user`)
       : __(`Add of new Class was cancelled by the user`);
-    const message = sprintf(
-      confirmation
-    );
+    const message = sprintf(confirmation, classRecord.name);
     miqRedirectBack(message, 'warning', '/miq_ae_class/explorer');
   };
 

--- a/app/javascript/packs/component-definitions-common.js
+++ b/app/javascript/packs/component-definitions-common.js
@@ -177,6 +177,7 @@ import WorkflowPayload from '../components/workflows/workflow_payload';
 import WorkflowRepositoryForm from '../components/workflow-repository-form';
 import XmlHolder from '../components/XmlHolder';
 import ZoneForm from '../components/zone-form';
+import MiqAeClass from '../components/miq-ae-class';
 
 /**
 * Add component definitions to this file.
@@ -363,3 +364,4 @@ ManageIQ.component.addReact('WorkflowPayload', WorkflowPayload);
 ManageIQ.component.addReact('WorkflowRepositoryForm', WorkflowRepositoryForm);
 ManageIQ.component.addReact('XmlHolder', XmlHolder);
 ManageIQ.component.addReact('ZoneForm', ZoneForm);
+ManageIQ.component.addReact('MiqAeClass', MiqAeClass);

--- a/app/javascript/spec/miq-ae-class-form/__snapshots__/miq-ae-class-form.spec.js.snap
+++ b/app/javascript/spec/miq-ae-class-form/__snapshots__/miq-ae-class-form.spec.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MiqAeClass Form Component should render add class form correctly 1`] = `""`;
+
+exports[`MiqAeClass Form Component should render edit class form correctly 1`] = `""`;

--- a/app/javascript/spec/miq-ae-class-form/miq-ae-class-form.spec.js
+++ b/app/javascript/spec/miq-ae-class-form/miq-ae-class-form.spec.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import fetchMock from 'fetch-mock';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import MiqAeClass from '../../components/miq-ae-class';
+
+describe('MiqAeClass Form Component', () => {
+  const classMockData = [
+    {
+      href: `/miq_ae_class/edit_class/2/`,
+      id: 2,
+      description: 'Configured System Provision',
+    },
+  ];
+
+  const MiqAeClassEditData = {
+    id: 40,
+    name: 'test',
+    display_name: 'test display name',
+    description: 'test description',
+  };
+
+  const fqName = 'Sample FQ Name';
+
+  afterEach(() => {
+    fetchMock.reset();
+    fetchMock.restore();
+  });
+
+  it('should render add class form correctly', async() => {
+    const wrapper = shallow(<MiqAeClass
+      classRecord={undefined}
+      fqname={fqName}
+    />);
+
+    fetchMock.get(`/miq_ae_class/new?&expand=resources/`, classMockData);
+
+    await new Promise((resolve) => {
+      setImmediate(() => {
+        wrapper.update();
+        expect(toJson(wrapper)).toMatchSnapshot();
+        resolve();
+      });
+    });
+  });
+
+  it('should render edit class form correctly', async() => {
+    const wrapper = shallow(<MiqAeClass
+      classRecord={MiqAeClassEditData}
+      fqname={fqName}
+    />);
+
+    fetchMock.get(`/miq_ae_class/edit_class_react/${MiqAeClassEditData.id}?&expand=resources/`, classMockData);
+    await new Promise((resolve) => {
+      setImmediate(() => {
+        wrapper.update();
+        expect(toJson(wrapper)).toMatchSnapshot();
+        resolve();
+      });
+    });
+  });
+});

--- a/app/views/miq_ae_class/_class_form.html.haml
+++ b/app/views/miq_ae_class/_class_form.html.haml
@@ -1,35 +1,6 @@
-- url = url_for_only_path(:action => 'form_field_changed', :id => (@ae_class.id || 'new'))
-- obs = {:interval => '.5', :url => url}.to_json
-%h3
-  = _('Properties')
-.form-horizontal
-  .form-group
-    %label.col-md-2.control-label
-      = _('Fully Qualified Name')
-    .col-md-8
-      = @sb[:namespace_path]
-  .form-group
-    %label.col-md-2.control-label
-      = _('Name')
-    .col-md-8
-      = text_field_tag("name", @edit[:new][:name],
-                        :maxlength         => ViewHelper::MAX_NAME_LEN,
-                        :class => "form-control",
-                        "data-miq_observe" => obs)
-      = javascript_tag(javascript_focus('name'))
-  .form-group
-    %label.col-md-2.control-label
-      = _('Display Name')
-    .col-md-8
-      = text_field_tag("display_name", @edit[:new][:display_name],
-                        :maxlength         => ViewHelper::MAX_NAME_LEN,
-                        :class => "form-control",
-                        "data-miq_observe" => obs)
-  .form-group
-    %label.col-md-2.control-label
-      = _('Description')
-    .col-md-8
-      = text_field_tag("description", @edit[:new][:description],
-                       :maxlength => ViewHelper::MAX_NAME_LEN,
-                       :class => "form-control",
-                       "data-miq_observe" => obs)
+- if @ae_class
+  - if @in_a_form
+    = react('MiqAeClass',
+      :classRecord => @ae_class,
+      :fqname => @sb[:namespace_path])
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1911,6 +1911,7 @@ Rails.application.routes.draw do
         ae_methods
         ae_method_operations
         show
+        edit_class_record
       ],
       :post => %w[
         add_update_method
@@ -1955,6 +1956,7 @@ Rails.application.routes.draw do
         x_button
         x_history
         x_show
+        class_update
       ] + adv_search_post +
         exp_post
     },

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -7,7 +7,7 @@ module.exports = defineConfig({
     baseUrl: 'http://localhost:3000',
     viewportHeight: 800,
     viewportWidth: 1800,
-    numTestsKeptInMemory: 5,
+    numTestsKeptInMemory: 0,
     videoCompression: false,
     // eslint-disable-next-line no-unused-vars
     setupNodeEvents(on, config) {

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -7,7 +7,7 @@ module.exports = defineConfig({
     baseUrl: 'http://localhost:3000',
     viewportHeight: 800,
     viewportWidth: 1800,
-    numTestsKeptInMemory: 0,
+    numTestsKeptInMemory: 5,
     videoCompression: false,
     // eslint-disable-next-line no-unused-vars
     setupNodeEvents(on, config) {

--- a/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/class.cy.js
+++ b/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/class.cy.js
@@ -1,6 +1,37 @@
 /* eslint-disable no-undef */
 
 describe('Automation > Embedded Automate > Explorer', () => {
+  before(() => {
+    // Create a Domain and Namespace before all the tests
+    cy.login();
+    cy.intercept('POST', '/ops/accordion_select?id=rbac_accord').as('accordion');
+    cy.menu('Automation', 'Embedded Automate', 'Explorer');
+    cy.get('#explorer_title_text');
+
+    // Creates a Domain
+    cy.get('[title="Datastore"]').click();
+    cy.get('[title="Configuration"]').click();
+    cy.get('[title="Add a New Domain"]').click();
+    cy.get('[name="name"]').type('TestDomain', {force: true});
+    cy.get('[name="description"]').type('This is a test domain');
+    cy.get('#enabled').check();
+    cy.get('[class="bx--btn bx--btn--primary"]').contains('Add').click();
+
+    // Check for the success message
+    cy.get('div.alert.alert-success.alert-dismissable').should('exist').and('contain', 'Automate Domain "TestDomain" was added').find('button.close').should('exist');
+
+    // Creates a Namespace
+    cy.get('[title="Datastore"]').click();
+    cy.get('[title="Automate Domain: TestDomain"]').click(); // Click on Domain
+    cy.get('[title="Configuration"]').click();
+    cy.get('[title="Add a New Namespace"]').click();
+    cy.get('[name="name"]').type('TestNameSpace', {force: true});
+    cy.get('[name="description"]').type('This is a test NameSpace');
+    cy.get('.bx--btn--primary').contains('Add').click();
+
+    cy.wait(1000); // Need this wait or else namespace doesn't get added properly
+  });
+
   beforeEach(() => {
     cy.login();
     cy.intercept('POST', '/ops/accordion_select?id=rbac_accord').as('accordion');
@@ -8,118 +39,243 @@ describe('Automation > Embedded Automate > Explorer', () => {
     cy.get('#explorer_title_text');
   });
 
-  afterEach(() => {
-    // Remove Domain after each tests
+  describe('Class Form', () => {
+    it('Cancel button works on the form', () => {
+      // Clicks the Cancel button on the create class form
+      cy.get('[title="Datastore"]').click();
+      cy.get('[title="Automate Domain: TestDomain"]').click();
+      cy.get('[title="Automate Namespace: TestNameSpace"]').click();
+      cy.get('[title="Configuration"]').click();
+      cy.get('[title="Add a New Class"]').click();
+      cy.get('[class="bx--btn bx--btn--secondary"]').contains('Cancel').click(); // clicks Cancel button
+
+      // Make sure that the cancel button redirects back to the namespace page
+      cy.get('[id="explorer_title_text"]').contains('Automate Namespace "TestNameSpace"');
+      cy.get('.flash_text_div > .alert').contains('Add of new Class was cancelled by the user');
+      cy.get('#ns_details_div > .alert').contains('The selected Namespace is empty');
+    });
+
+    it('Reset button works on the form', () => {
+      // Creates a Class
+      cy.get('[title="Datastore"]').click();
+      cy.get('[title="Automate Domain: TestDomain"]').click(); // clicks on Domain
+      cy.get('[title="Automate Namespace: TestNameSpace"]').click(); // clicks on Namespace
+      cy.get('[title="Configuration"]').click();
+      cy.get('[title="Add a New Class"]').click();
+      cy.get('[name="name"]').type('TestClass', {force: true});
+      cy.get('[name="display_name"]').type('Test Class 0');
+      cy.get('[name="description"').type('This is a test class description');
+      cy.get('.bx--btn--primary').contains('Add').click();
+
+      // Check for the success message
+      cy.get('#flash_msg_div .alert.alert-success').should('exist').and('be.visible').and('contain', 'Class "TestClass" was added');
+
+      // Navigate to the Properties tab of the class just created
+      cy.get('.clickable-row').contains('Test Class 0').click();
+      cy.get('#props_tab > a').click();
+
+      // Edits the class
+      cy.get('[title="Configuration"]').click();
+      cy.get('[title="Edit this Class"]').click();
+      cy.get('[name="name"]').type('Edit', {force: true});
+      cy.get('[name="display_name"]').clear().type('Edited Test Class');
+      cy.get('[name="description"').clear().type('Edited test class description');
+
+      // Click Reset Button
+      cy.get('.btnRight.bx--btn--secondary').contains('Reset').click();
+
+      // Verify that the form was reset
+      cy.get('.flash_text_div > .alert').contains('All changes have been reset');
+      cy.get('[name="name"]').should('have.value', 'TestClass');
+      cy.get('[name="display_name"]').should('have.value', 'Test Class 0');
+      cy.get('[name="description"]').should('have.value', 'This is a test class description');
+
+      // Click Cancel button
+      cy.get('[class="bx--btn bx--btn--secondary"]').contains('Cancel').click();
+
+      // Removes class
+      cy.get('[title="Configuration"]').click();
+      cy.get('[title="Remove this Class"]').click();
+
+      // Verify that the class was removed
+      cy.get('div.alert.alert-success.alert-dismissable').should('exist').and('contain', 'Automate Class "TestClass": Delete successful');
+      cy.get('#ns_details_div > .alert').contains('The selected Namespace is empty');
+    });
+
+    it('Form validation works', () => {
+      // Try to create a Class with an invalid name
+      cy.get('[title="Datastore"]').click();
+      cy.get('[title="Automate Domain: TestDomain"]').click(); // clicks on Domain
+      cy.get('[title="Automate Namespace: TestNameSpace"]').click(); // clicks on Namespace
+
+      cy.get('[title="Configuration"]').click();
+      cy.get('[title="Add a New Class"]').click();
+      cy.get('[name="name"]').type('Test Class', {force: true});
+      cy.get('[name="display_name"]').type('Test Class 0');
+      cy.get('[name="description"').type('This is a test class description');
+
+      // Verify that error message appears
+      cy.get('#name-error-msg').contains('Name may contain only alphanumeric and _ . - characters');
+      cy.get('.btnRight').should('be.disabled');
+
+      // Enter a valid name
+      cy.get('[name="name"]').clear({force: true}).type('TestClass');
+      cy.get('.btnRight').click();
+
+      cy.get('#flash_msg_div .alert.alert-success').should('exist').and('be.visible').and('contain', 'Class "TestClass" was added');
+
+      // Navigate to the Properties tab of the class just created
+      cy.get('.clickable-row').contains('Test Class 0').click();
+      cy.get('#props_tab > a').click();
+
+      // Verify that the class created correctly
+      cy.get(':nth-child(1) > .label_header').contains('Fully Qualified Name');
+      cy.get(':nth-child(1) > .content_value').contains('/ TestDomain / TestNameSpace / TestClass');
+      cy.get(':nth-child(2) > .label_header').contains('Name');
+      cy.get(':nth-child(2) > .content_value').contains('TestClass');
+      cy.get(':nth-child(3) > .label_header').contains('Display Name');
+      cy.get(':nth-child(3) > .content_value').contains('Test Class 0');
+      cy.get(':nth-child(4) > .label_header').contains('Description');
+      cy.get(':nth-child(4) > .content_value').contains('This is a test class description');
+      cy.get(':nth-child(5) > .label_header').contains('Instances');
+      cy.get(':nth-child(5) > .content_value').contains('0');
+
+      cy.get('.list-group-item').then((listItems) => {
+        const nums = [...Array(listItems.length).keys()];
+        nums.forEach((index) => {
+          if (listItems[index].innerText === 'TestNameSpace') {
+            cy.get(listItems[index]).click();
+          }
+        });
+      });
+
+      // Try to create a Class with the same name
+      cy.get('[title="Configuration"]').click();
+      cy.get('[title="Add a New Class"]').click();
+      cy.get('[name="name"]').type('TestClass', {force: true});
+      cy.get('[name="display_name"]').type('Test Class 1');
+      cy.get('[name="description"').type('This is a test class description');
+      cy.get('.btnRight').click();
+
+      // Verify that error message appears
+      cy.get('.alert').contains('Name has already been taken');
+
+      // Enter a new name
+      cy.get('[name="name"]').clear({force: true}).type('NewTestClass', {force: true});
+      cy.get('.btnRight').click();
+
+      // Check for the success message
+      cy.get('#flash_msg_div .alert.alert-success').should('exist').and('be.visible').and('contain', 'Class "NewTestClass" was added');
+
+      // Navigate to the Properties tab of the class just created
+      cy.get('.clickable-row').contains('Test Class 1').click();
+      cy.get('#props_tab > a').click();
+
+      // Verify that the class created correctly
+      cy.get(':nth-child(1) > .label_header').contains('Fully Qualified Name');
+      cy.get(':nth-child(1) > .content_value').contains('/ TestDomain / TestNameSpace / NewTestClass');
+      cy.get(':nth-child(2) > .label_header').contains('Name');
+      cy.get(':nth-child(2) > .content_value').contains('NewTestClass');
+      cy.get(':nth-child(3) > .label_header').contains('Display Name');
+      cy.get(':nth-child(3) > .content_value').contains('Test Class 1');
+      cy.get(':nth-child(4) > .label_header').contains('Description');
+      cy.get(':nth-child(4) > .content_value').contains('This is a test class description');
+      cy.get(':nth-child(5) > .label_header').contains('Instances');
+      cy.get(':nth-child(5) > .content_value').contains('0');
+
+      // Removes class
+      cy.get('[title="Configuration"]').click();
+      cy.get('[title="Remove this Class"]').click();
+
+      // Verify that the class was removed
+      cy.get('div.alert.alert-success.alert-dismissable').should('exist').and('contain', 'Automate Class "NewTestClass": Delete successful');
+
+      // Navigate to the Properties tab of the first class just created
+      cy.get('.clickable-row').contains('Test Class 0').click();
+
+      // Removes class
+      cy.get('[title="Configuration"]').click();
+      cy.get('[title="Remove this Class"]').click();
+
+      // Verify that the class was removed
+      cy.get('div.alert.alert-success.alert-dismissable').should('exist').and('contain', 'Automate Class "TestClass": Delete successful');
+      cy.get('#ns_details_div > .alert').contains('The selected Namespace is empty');
+    });
+
+    it('Creates and edits an automate class', () => {
+      // Creates a Class
+      cy.get('[title="Datastore"]').click({force: true});
+      cy.get('[title="Automate Domain: TestDomain"]').click({force: true}); // clicks on Domain
+      cy.get('[title="Automate Namespace: TestNameSpace"]').click({force: true}); // clicks on Namespace
+      cy.get('[title="Configuration"]').click({force: true});
+      cy.get('[title="Add a New Class"]').click({force: true});
+      cy.get('[name="name"]').type('TestClass', {force: true});
+      cy.get('[name="display_name"]').type('Test Class 0');
+      cy.get('[name="description"').type('This is a test class description');
+      cy.get('.bx--btn--primary').contains('Add').click();
+
+      // Check for the success message
+      cy.get('#flash_msg_div .alert.alert-success').should('exist').and('be.visible').and('contain', 'Class "TestClass" was added');
+
+      // Navigate to the Properties tab of the class just created
+      cy.get('.clickable-row').contains('Test Class 0').click();
+      cy.get('#props_tab > a').click();
+
+      // Verify that the class created correctly
+      cy.get(':nth-child(1) > .label_header').contains('Fully Qualified Name');
+      cy.get(':nth-child(1) > .content_value').contains('/ TestDomain / TestNameSpace / TestClass');
+      cy.get(':nth-child(2) > .label_header').contains('Name');
+      cy.get(':nth-child(2) > .content_value').contains('TestClass');
+      cy.get(':nth-child(3) > .label_header').contains('Display Name');
+      cy.get(':nth-child(3) > .content_value').contains('Test Class 0');
+      cy.get(':nth-child(4) > .label_header').contains('Description');
+      cy.get(':nth-child(4) > .content_value').contains('This is a test class description');
+      cy.get(':nth-child(5) > .label_header').contains('Instances');
+      cy.get(':nth-child(5) > .content_value').contains('0');
+
+      // Edits the class
+      cy.get('[title="Configuration"]').click({force: true});
+      cy.get('[title="Edit this Class"]').click({force: true});
+      cy.get('[name="name"]').type('Edit', {force: true});
+      cy.get('[name="display_name"]').clear().type('Edited Test Class', {force: true});
+      cy.get('[name="description"').clear().type('Edited test class description');
+      cy.get('[class="btnRight bx--btn bx--btn--primary"]').contains('Save').click({force: true});
+
+      // Navigate to the Properties tab of the class just edited
+      cy.get('#props_tab a').click();
+
+      // Verify that the class edited correctly
+      cy.get(':nth-child(1) > .label_header').contains('Fully Qualified Name');
+      cy.get(':nth-child(1) > .content_value').contains('/ TestDomain / TestNameSpace / TestClassEdit');
+      cy.get(':nth-child(2) > .label_header').contains('Name');
+      cy.get(':nth-child(2) > .content_value').contains('TestClassEdit');
+      cy.get(':nth-child(3) > .label_header').contains('Display Name');
+      cy.get(':nth-child(3) > .content_value').contains('Edited Test Class');
+      cy.get(':nth-child(4) > .label_header').contains('Description');
+      cy.get(':nth-child(4) > .content_value').contains('Edited test class description');
+      cy.get(':nth-child(5) > .label_header').contains('Instances');
+      cy.get(':nth-child(5) > .content_value').contains('0');
+
+      // Removes class
+      cy.get('[title="Configuration"]').click({force: true});
+      cy.get('[title="Remove this Class"]').click({force: true});
+
+      // Verify that the class was removed
+      cy.get('div.alert.alert-success.alert-dismissable')
+        .should('exist')
+        .and('contain', 'Automate Class "TestClassEdit": Delete successful');
+      cy.get('#ns_details_div > .alert').contains('The selected Namespace is empty');
+    });
+  });
+
+  after(() => {
+    // Remove the Domain after all the tests
+    cy.menu('Automation', 'Embedded Automate', 'Explorer');
     cy.get('[title="Datastore"]').click({force: true});
     cy.get('[title="Automate Domain: TestDomain"]').click({force: true});
     cy.get('[title="Configuration"]').click({force: true});
     cy.get('[title="Remove this Domain"]').click({force: true});
 
     cy.get('.bx--data-table-content tbody tr').should('not.contain', 'Automate Domain: TestDomain');
-  });
-
-  describe('Class Form', () => {
-    it('Creates and edits an automate class', () => {
-      // Creates a Domain
-      cy.get('[title="Datastore"]').click({force: true});
-      cy.get('[title="Configuration"]').click({force: true});
-      cy.get('[title="Add a New Domain"]').click({force: true});
-      cy.get('[name="name"]').type('TestDomain');
-      cy.get('[name="description"]').type('This is a test domain');
-      cy.get('#enabled').check();
-      cy.get('[class="bx--btn bx--btn--primary"]').contains('Add').click(); // submits Domain
-      // checks for the success message
-      cy.get('div.alert.alert-success.alert-dismissable')
-        .should('exist')
-        .and('contain', 'Automate Domain "TestDomain" was added')
-        .find('button.close').should('exist');
-
-      // Creates a Namespace
-      cy.get('[title="Datastore"]').click({force: true});
-      cy.get('[title="Automate Domain: TestDomain"]').click({force: true}); // clicks on Domain
-      cy.get('[title="Configuration"]').click({force: true});
-      cy.get('[title="Add a New Namespace"]').click({force: true});
-      cy.get('[name="name"]').type('TestNS');
-      cy.get('[name="description"]').type('This is a test NS');
-      cy.get('.bx--btn--primary').contains('Add').click(); // submits Namespace
-
-      // Creates a Class
-      cy.get('[title="Datastore"]').click({force: true});
-      cy.get('[title="Automate Domain: TestDomain"]').click({force: true}); // clicks on Domain
-      cy.get('[title="Automate Namespace: TestNS"]').click({force: true}); // clicks on Namespace
-      cy.get('[title="Configuration"]').click({force: true});
-      cy.get('[title="Add a New Class"]').click({force: true});
-      cy.get('[name="name"]').type('TestClass');
-      cy.get('[name="display_name"]').type('TC');
-      cy.get('[name="description"').type('This is a test class desc');
-      cy.get('.bx--btn--primary').contains('Add').click(); // submits class
-      // checks for the success message
-      cy.get('#flash_msg_div .alert.alert-success').should('exist')
-        .and('be.visible').and('contain', 'Class "TestClass" was added');
-
-      // Edits a class
-      cy.get('[title="Automate Class: TC (TestClass)"]').click({force: true}); // clicks on the class
-      cy.get('[title="Configuration"]').click({force: true});
-      cy.get('[title="Edit this Class"]').click({force: true});
-      cy.get('[name="display_name"]').clear({force: true});
-      cy.get('[name="display_name"]').type('Edited TC', {force: true});
-      cy.get('[name="description"').clear({force: true});
-      cy.get('[name="description"').type('Edited Test Class Description');
-      cy.get('[class="btnRight bx--btn bx--btn--primary"]').contains('Save').click({force: true});
-      // Checks if class data was updated
-      cy.get('#props_tab a').click(); // Navigate to the Properties tab
-      cy.get('div.label_header:contains("Name")').siblings('.content_value')
-        .should('contain', 'TestClass');
-      cy.get('div.label_header:contains("Display Name")').siblings('.content_value')
-        .should('contain', 'Edited TC');
-      cy.get('div.label_header:contains("Description")').siblings('.content_value')
-        .should('contain', 'Edited Test Class Description');
-
-      // Clicks the Cancel button during class creation
-      cy.get('[title="Datastore"]').click({force: true});
-      cy.get('[title="Automate Domain: TestDomain"]').click({force: true});
-      cy.get('[title="Automate Namespace: TestNS"]').click({force: true});
-      cy.get('[title="Configuration"]').click({force: true});
-      cy.get('[title="Add a New Class"]').click({force: true});
-      cy.get('[class="bx--btn bx--btn--secondary"]')
-        .contains('Cancel').click({force: true}); // clicks Cancel button
-      cy.get('[id="explorer_title_text"]').contains('Automate Namespace "TestNS"');
-
-      // Clicks the Cancel button during class update
-      cy.get('[title="Automate Class: Edited TC (TestClass)"]').click({force: true}); // clicks on the class
-      cy.get('[title="Configuration"]').click({force: true});
-      cy.get('[title="Edit this Class"]').click({force: true});
-      cy.get('[name="description"]').clear({force: true});
-      cy.get('[name="description"]').type('New description for class', {force: true});
-      cy.get('[class="bx--btn bx--btn--secondary"]').contains('Cancel').click({force: true});
-      // Checks if class data was updated
-      cy.get('#props_tab a').click(); // Navigate to the Properties tab
-      cy.get('div.label_header:contains("Description")').siblings('.content_value')
-        .should('not.contain', 'New description for class')
-        .should('contain', 'Edited Test Class Description');
-
-      // Clicks the Reset button during class update
-      cy.get('[title="Automate Class: Edited TC (TestClass)"]').click({force: true}); // clicks on the class
-      cy.get('[title="Configuration"]').click({force: true});
-      cy.get('[title="Edit this Class"]').click({force: true});
-      cy.get('[name="description"]').clear({force: true});
-      cy.get('[name="description"]').type('New description for class', {force: true});
-      cy.get('[class="btnRight bx--btn bx--btn--secondary"]').contains('Reset').click({force: true});
-      // Check for the flash message div
-      cy.get('#flash_msg_div .alert.alert-warning').should('exist')
-        .and('be.visible').and('contain', 'All changes have been reset');
-      // Checks if class data was updated
-      cy.get('[name="description"]').should('have.value', 'Edited Test Class Description');
-      cy.get('[class="bx--btn bx--btn--secondary"]').contains('Cancel').click({force: true});
-
-      // Removes class
-      cy.get('[title="Automate Class: Edited TC (TestClass)"]').click({force: true}); // clicks on the class
-      cy.get('[title="Configuration"]').click({force: true});
-      cy.get('[title="Remove this Class"]').click({force: true});
-      // checks for the success message
-      cy.get('div.alert.alert-success.alert-dismissable')
-        .should('exist')
-        .and('contain', 'Automate Class "TestClass": Delete successful');
-    });
   });
 });

--- a/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/class.cy.js
+++ b/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/class.cy.js
@@ -1,0 +1,125 @@
+/* eslint-disable no-undef */
+
+describe('Automation > Embedded Automate > Explorer', () => {
+  beforeEach(() => {
+    cy.login();
+    cy.intercept('POST', '/ops/accordion_select?id=rbac_accord').as('accordion');
+    cy.menu('Automation', 'Embedded Automate', 'Explorer');
+    cy.get('#explorer_title_text');
+  });
+
+  afterEach(() => {
+    // Remove Domain after each tests
+    cy.get('[title="Datastore"]').click({force: true});
+    cy.get('[title="Automate Domain: TestDomain"]').click({force: true});
+    cy.get('[title="Configuration"]').click({force: true});
+    cy.get('[title="Remove this Domain"]').click({force: true});
+
+    cy.get('.bx--data-table-content tbody tr').should('not.contain', 'Automate Domain: TestDomain');
+  });
+
+  describe('Class Form', () => {
+    it('Creates and edits an automate class', () => {
+      // Creates a Domain
+      cy.get('[title="Datastore"]').click({force: true});
+      cy.get('[title="Configuration"]').click({force: true});
+      cy.get('[title="Add a New Domain"]').click({force: true});
+      cy.get('[name="name"]').type('TestDomain');
+      cy.get('[name="description"]').type('This is a test domain');
+      cy.get('#enabled').check();
+      cy.get('[class="bx--btn bx--btn--primary"]').contains('Add').click(); // submits Domain
+      // checks for the success message
+      cy.get('div.alert.alert-success.alert-dismissable')
+        .should('exist')
+        .and('contain', 'Automate Domain "TestDomain" was added')
+        .find('button.close').should('exist');
+
+      // Creates a Namespace
+      cy.get('[title="Datastore"]').click({force: true});
+      cy.get('[title="Automate Domain: TestDomain"]').click({force: true}); // clicks on Domain
+      cy.get('[title="Configuration"]').click({force: true});
+      cy.get('[title="Add a New Namespace"]').click({force: true});
+      cy.get('[name="name"]').type('TestNS');
+      cy.get('[name="description"]').type('This is a test NS');
+      cy.get('.bx--btn--primary').contains('Add').click(); // submits Namespace
+
+      // Creates a Class
+      cy.get('[title="Datastore"]').click({force: true});
+      cy.get('[title="Automate Domain: TestDomain"]').click({force: true}); // clicks on Domain
+      cy.get('[title="Automate Namespace: TestNS"]').click({force: true}); // clicks on Namespace
+      cy.get('[title="Configuration"]').click({force: true});
+      cy.get('[title="Add a New Class"]').click({force: true});
+      cy.get('[name="name"]').type('TestClass');
+      cy.get('[name="display_name"]').type('TC');
+      cy.get('[name="description"').type('This is a test class desc');
+      cy.get('.bx--btn--primary').contains('Add').click(); // submits class
+      // checks for the success message
+      cy.get('#flash_msg_div .alert.alert-success').should('exist')
+        .and('be.visible').and('contain', 'Class "TestClass" was added');
+
+      // Edits a class
+      cy.get('[title="Automate Class: TC (TestClass)"]').click({force: true}); // clicks on the class
+      cy.get('[title="Configuration"]').click({force: true});
+      cy.get('[title="Edit this Class"]').click({force: true});
+      cy.get('[name="display_name"]').clear({force: true});
+      cy.get('[name="display_name"]').type('Edited TC', {force: true});
+      cy.get('[name="description"').clear({force: true});
+      cy.get('[name="description"').type('Edited Test Class Description');
+      cy.get('[class="btnRight bx--btn bx--btn--primary"]').contains('Save').click({force: true});
+      // Checks if class data was updated
+      cy.get('#props_tab a').click(); // Navigate to the Properties tab
+      cy.get('div.label_header:contains("Name")').siblings('.content_value')
+        .should('contain', 'TestClass');
+      cy.get('div.label_header:contains("Display Name")').siblings('.content_value')
+        .should('contain', 'Edited TC');
+      cy.get('div.label_header:contains("Description")').siblings('.content_value')
+        .should('contain', 'Edited Test Class Description');
+
+      // Clicks the Cancel button during class creation
+      cy.get('[title="Datastore"]').click({force: true});
+      cy.get('[title="Automate Domain: TestDomain"]').click({force: true});
+      cy.get('[title="Automate Namespace: TestNS"]').click({force: true});
+      cy.get('[title="Configuration"]').click({force: true});
+      cy.get('[title="Add a New Class"]').click({force: true});
+      cy.get('[class="bx--btn bx--btn--secondary"]')
+        .contains('Cancel').click({force: true}); // clicks Cancel button
+      cy.get('[id="explorer_title_text"]').contains('Automate Namespace "TestNS"');
+
+      // Clicks the Cancel button during class update
+      cy.get('[title="Automate Class: Edited TC (TestClass)"]').click({force: true}); // clicks on the class
+      cy.get('[title="Configuration"]').click({force: true});
+      cy.get('[title="Edit this Class"]').click({force: true});
+      cy.get('[name="description"]').clear({force: true});
+      cy.get('[name="description"]').type('New description for class', {force: true});
+      cy.get('[class="bx--btn bx--btn--secondary"]').contains('Cancel').click({force: true});
+      // Checks if class data was updated
+      cy.get('#props_tab a').click(); // Navigate to the Properties tab
+      cy.get('div.label_header:contains("Description")').siblings('.content_value')
+        .should('not.contain', 'New description for class')
+        .should('contain', 'Edited Test Class Description');
+
+      // Clicks the Reset button during class update
+      cy.get('[title="Automate Class: Edited TC (TestClass)"]').click({force: true}); // clicks on the class
+      cy.get('[title="Configuration"]').click({force: true});
+      cy.get('[title="Edit this Class"]').click({force: true});
+      cy.get('[name="description"]').clear({force: true});
+      cy.get('[name="description"]').type('New description for class', {force: true});
+      cy.get('[class="btnRight bx--btn bx--btn--secondary"]').contains('Reset').click({force: true});
+      // Check for the flash message div
+      cy.get('#flash_msg_div .alert.alert-warning').should('exist')
+        .and('be.visible').and('contain', 'All changes have been reset');
+      // Checks if class data was updated
+      cy.get('[name="description"]').should('have.value', 'Edited Test Class Description');
+      cy.get('[class="bx--btn bx--btn--secondary"]').contains('Cancel').click({force: true});
+
+      // Removes class
+      cy.get('[title="Automate Class: Edited TC (TestClass)"]').click({force: true}); // clicks on the class
+      cy.get('[title="Configuration"]').click({force: true});
+      cy.get('[title="Remove this Class"]').click({force: true});
+      // checks for the success message
+      cy.get('div.alert.alert-success.alert-dismissable')
+        .should('exist')
+        .and('contain', 'Automate Class "TestClass": Delete successful');
+    });
+  });
+});

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -24,7 +24,8 @@ describe MiqAeClassController do
       id = "aec-#{cls.id}"
       fq_name = cls.fqname
       controller.send(:set_right_cell_text, id, cls)
-      expect(assigns(:sb)[:namespace_path]).to eq(fq_name.gsub!(%r{\/}, " / "))
+      # expect(assigns(:sb)[:namespace_path]).to eq(fq_name.gsub!(%r{\/}, " / "))
+      expect(assigns(:sb)[:namespace_path]).to eq(fq_name)
 
       id = "root"
       fq_name = ""
@@ -291,7 +292,8 @@ describe MiqAeClassController do
                                          :active_tree => :ae_tree,
                                          :trees       => {:ae_tree => {:active_node => node}})
         controller.send(:get_node_info, node)
-        expect(assigns(:sb)[:namespace_path]).to eq(ns1.fqname.gsub!(%r{\/}, " / "))
+        # expect(assigns(:sb)[:namespace_path]).to eq(ns1.fqname.gsub!(%r{\/}, " / "))
+        expect(assigns(:sb)[:namespace_path]).to eq(ns1.fqname)
       end
     end
 

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -24,7 +24,6 @@ describe MiqAeClassController do
       id = "aec-#{cls.id}"
       fq_name = cls.fqname
       controller.send(:set_right_cell_text, id, cls)
-      # expect(assigns(:sb)[:namespace_path]).to eq(fq_name.gsub!(%r{\/}, " / "))
       expect(assigns(:sb)[:namespace_path]).to eq(fq_name)
 
       id = "root"
@@ -292,7 +291,6 @@ describe MiqAeClassController do
                                          :active_tree => :ae_tree,
                                          :trees       => {:ae_tree => {:active_node => node}})
         controller.send(:get_node_info, node)
-        # expect(assigns(:sb)[:namespace_path]).to eq(ns1.fqname.gsub!(%r{\/}, " / "))
         expect(assigns(:sb)[:namespace_path]).to eq(ns1.fqname)
       end
     end


### PR DESCRIPTION
Automation / Automate / Explorer / Datastore

Transforms haml forms to react for Add and Edit feature of Automate Class.

Before
<img width="1257" alt="Add Class - Old" src="https://github.com/user-attachments/assets/fe03752c-d40a-4364-a3ee-c53cae07d76e">

<img width="1254" alt="Edit Class - Old" src="https://github.com/user-attachments/assets/a976e0c7-7b13-4774-b2e2-e857f0a30dd1">


After

<img width="1240" alt="Add class - After" src="https://github.com/user-attachments/assets/9b8a3e68-9d7a-426a-b588-986ed03b7cb6">


<img width="1248" alt="Edit class - After" src="https://github.com/user-attachments/assets/1b7c1368-89c0-4058-a14d-39fc57eaf239">


<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
