### PR TITLE
Fix Key Value List Component Typing Bug

### DIFF
--- a/app/javascript/components/ansible-playbook-edit-catalog-form/helper.js
+++ b/app/javascript/components/ansible-playbook-edit-catalog-form/helper.js
@@ -182,7 +182,8 @@ export const KeyValueListComponent = (props) => {
       <label htmlFor={input.name} className="bx--label">{label}</label>
       <br />
       {input.value && input.value.map((pair, index) => (
-        <div key={pair.key} className="key-value-list-pair">
+        // eslint-disable-next-line react/no-array-index-key
+        <div key={index} className="key-value-list-pair">
           <TextInput
             id={`${input.name}.${index}.key`}
             labelText={keyLabel}

--- a/app/javascript/components/terraform-template-catalog-form/helper.js
+++ b/app/javascript/components/terraform-template-catalog-form/helper.js
@@ -183,7 +183,8 @@ export const KeyValueListComponent = (props) => {
       <label htmlFor={input.name} className="bx--label">{label}</label>
       <br />
       {input.value && input.value.map((pair, index) => (
-        <div key={pair.key} className="key-value-list-pair">
+        // eslint-disable-next-line react/no-array-index-key
+        <div key={index} className="key-value-list-pair">
           <TextInput
             id={`${input.name}.${index}.key`}
             labelText={keyLabel}


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/9300

This pr fixes a bug where the key value list component loses focus after each key press. This caused the user to have to reselect the variable field after every key they entered if they wanted to make a variable with a name longer than 1 character. 

Now you can continue to type in the variable field without the field losing focus.