### PR TITLE
Making tags more readable

### DIFF
--- a/app/javascript/components/miq-structured-list/miq-structured-list-body/value-tags/miq-structured-list-text.jsx
+++ b/app/javascript/components/miq-structured-list/miq-structured-list-body/value-tags/miq-structured-list-text.jsx
@@ -4,8 +4,12 @@ import classNames from 'classnames';
 
 /** Component to print the text value inside a cell. */
 const MiqStructuredListText = ({ value }) => {
-  const text = (value === null || value === undefined ? '' : String(value));
-
+  let text;
+  if (Array.isArray(value)) {
+    text = value.join('\n');
+  } else {
+    text = (value === null || value === undefined ? '' : String(value));
+  }
   return (
     <div className={classNames(text ? 'expand' : '', 'wrap_text')}>
       {text}

--- a/app/javascript/spec/textual_summary/tests/__snapshots__/tag_group.test.js.snap
+++ b/app/javascript/spec/textual_summary/tests/__snapshots__/tag_group.test.js.snap
@@ -782,7 +782,8 @@ exports[`TagGroup renders just fine 1`] = `
                                                               <div
                                                                 className="expand wrap_text"
                                                               >
-                                                                Policy,2
+                                                                Policy
+2
                                                               </div>
                                                             </MiqStructuredListText>
                                                           </div>
@@ -1173,7 +1174,9 @@ exports[`TagGroup renders just fine 1`] = `
                                                               <div
                                                                 className="expand wrap_text"
                                                               >
-                                                                Policy,2,3
+                                                                Policy
+2
+3
                                                               </div>
                                                             </MiqStructuredListText>
                                                           </div>

--- a/app/javascript/spec/textual_summary/tests/tag_group.test.js
+++ b/app/javascript/spec/textual_summary/tests/tag_group.test.js
@@ -36,7 +36,7 @@ describe('TagGroup', () => {
     };
 
     const wrapper = mount(<TagGroup items={tagData.items} title={tagData.title} />);
-    expect(wrapper.html()).toContain('<div class="expand wrap_text">Policy,2</div>');
+    expect(wrapper.html()).toContain('<div class="expand wrap_text">Policy\n2</div>');
     expect(wrapper.containsMatchingElement(<i className="fa fa-tag" />)).toEqual(true);
   });
 });

--- a/app/stylesheet/miq-structured-list.scss
+++ b/app/stylesheet/miq-structured-list.scss
@@ -158,6 +158,7 @@
   .wrap_text {
     width: 100%;
     word-break: break-all;
+    white-space: pre-line;
   }
 
   &.bordered-list {


### PR DESCRIPTION
Old: 
<img width="700" alt="Screenshot 2024-12-10 at 3 45 04 PM" src="https://github.com/user-attachments/assets/8c9e39bb-99e7-4ec6-ba0b-22696c07de62">

New: 
<img width="695" alt="Screenshot 2024-12-10 at 3 44 28 PM" src="https://github.com/user-attachments/assets/83c1069f-d9e3-4d49-b743-dc70e2cdba0b">

