### PR TITLE
Fix table pagination setting

### DIFF
--- a/app/javascript/components/gtl-view.jsx
+++ b/app/javascript/components/gtl-view.jsx
@@ -273,7 +273,7 @@ const setPaging = (settings, start, perPage) => ({
 const computePagination = (settings) => ({
   page: settings.current,
   perPage: settings.perpage,
-  perPageOptions: [10, 20, 50, 100, 200, 500, 1000],
+  perPageOptions: [5, 10, 20, 50, 100, 200, 500, 1000],
 });
 
 const GtlView = ({
@@ -292,6 +292,9 @@ const GtlView = ({
   noFlashDiv,
 }) => {
   // const { settings, data } = props;
+  if (pages && pages.perpage) {
+    initialState.settings.perpage = pages.perpage;
+  }
   const initState = {
     ...initialState,
     additionalOptions,
@@ -387,7 +390,7 @@ const GtlView = ({
     isExplorer,
     setPaging(settings, 0, perPage),
     records,
-    additionalOptions,
+    additionalOptions
   );
 
   /** Function execution when a page or perPage is changed in carbon pagination events. */
@@ -528,7 +531,9 @@ GtlView.propTypes = {
   records: PropTypes.arrayOf(PropTypes.any), // fixme
   hideSelect: PropTypes.bool,
   showUrl: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
-  pages: PropTypes.shape({}), // fixme
+  pages: PropTypes.shape({
+    list: PropTypes.number, reports: PropTypes.number, grid: PropTypes.number, tile: PropTypes.number,
+  }),
   isAscending: PropTypes.bool,
 };
 


### PR DESCRIPTION
Fixed issues with table pagination settings.

1. The 5 items per page option was missing on the table even though the settings page contains this as an option.
2. When selecting an option on the settings page for items per page it wasn't actually being applied to the tables in the UI.

Before:
The default items per page on the settings page was not actually being applied on the tables in the UI.
<img width="1413" alt="Screenshot 2025-01-13 at 11 53 57 AM" src="https://github.com/user-attachments/assets/32d4001d-482a-461a-8ef0-0c703e538c77" />

As seen here the table defaults to 20 items per page even though in the settings it was set to 10.
<img width="1416" alt="Screenshot 2025-01-13 at 11 55 44 AM" src="https://github.com/user-attachments/assets/e4bd9a1d-c49f-42ef-9246-6613a63f3fbb" />

Also, 5 items per page is not an option here even though it is on the settings page.
<img width="301" alt="Screenshot 2025-01-13 at 11 56 25 AM" src="https://github.com/user-attachments/assets/4d12e22a-4923-4f9b-a3fd-71299d779d30" />

After:
<img width="1420" alt="Screenshot 2025-01-13 at 11 59 55 AM" src="https://github.com/user-attachments/assets/2659469c-2852-4404-998f-4bc3b9759166" />
<img width="330" alt="Screenshot 2025-01-13 at 12 00 00 PM" src="https://github.com/user-attachments/assets/9e0d85b1-0c5e-4b36-9467-bf231fe94235" />

