### PR TITLE
Exclude bootstrap-sass from yarn audit

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -16,6 +16,8 @@ npmAuditExcludePackages:
 # pending | low      | GHSA-mqm9-c95h-x2p6 | angular <=1.8.3              | 1.8.3 brought in by manageiq-ui-classic@workspace:.
 - bootstrap
 # pending | moderate | GHSA-9mvj-f7w8-pvh2 | bootstrap >=2.0.0 <=3.4.1 | 3.4.1 brought in by patternfly@npm:3.59.5
+- bootstrap-sass
+# pending | moderate | GHSA-9mvj-f7w8-pvh2 | bootstrap-sass >=2.0.0 <=3.4.3 | 3.4.3 brought in by patternfly@npm:3.59.5
 - jquery
 # pending | moderate | GHSA-rmxg-73gg-4p98 | jquery >=1.12.3 <3.0.0 | 2.2.4 brought in by manageiq-ui-classic@workspace:.
 # pending | moderate | GHSA-gxr4-xjj5-5px2 | jquery >=1.2.0 <3.5.0  | 2.2.4, 3.4.1 brought in by manageiq-ui-classic@workspace:., patternfly@npm:3.59.5


### PR DESCRIPTION
This package is being brought in by patternfly, and we are already at the latest version. We need to upgrade patternfly or replace it completely to be off of this package.

This is related to CVE-2024-6484, however I'm not sure why this changed all of a sudden.

@jrafanie Please review. cc @GilbertCherrie 