### PR TITLE
Rails 7.1 / Rails 7.0 compatible changes

### DIFF
--- a/app/helpers/security_group_helper/textual_summary.rb
+++ b/app/helpers/security_group_helper/textual_summary.rb
@@ -102,7 +102,7 @@ module SecurityGroupHelper::TextualSummary
     elsif rule.port == rule.end_port
       rule.port.to_s
     else
-      rule.port_range.to_s(:dash)
+      rule.port_range.to_fs(:dash)
     end
   end
 end

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -168,8 +168,8 @@ describe EmsCloudController do
       expect(ems).to receive(:sync_users_queue)
       post :sync_users, :params => {:id => ems.id, :sync => "", :admin_role => 1, :member_role => 2}
       expect(session[:flash_msgs]).to match [a_hash_including(:message => "Sync users queued.", :level => :success)]
-      expect(response.body).to include("redirected")
-      expect(response.body).to include("ems_cloud/#{ems.id}")
+      expect(response.status).to eq(302)
+      assert_redirected_to(controller.ems_cloud_path(ems.id))
     end
 
     it "returns error if admin role is not selected" do

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -206,8 +206,8 @@ describe EmsInfraController do
       post :scaling, :params => { :id => @ems.id, :scale => "", :orchestration_stack_id => @orchestration_stack.id,
                                   @orchestration_stack_parameter_compute.name => 2 }
       expect(controller.send(:flash_errors?)).to be_falsey
-      expect(response.body).to include("redirected")
-      expect(response.body).to include("ems_infra")
+      expect(response.status).to eq(302)
+      assert_redirected_to(controller.ems_infra_path(@ems.id))
       expect(session[:flash_msgs]).to match [a_hash_including(:message => "Scaling compute-1::count from 1 to 2 ", :level => :success)]
     end
 
@@ -266,8 +266,8 @@ describe EmsInfraController do
       post :scaledown, :params => {:id => @ems.id, :scaledown => "",
                                    :orchestration_stack_id => @orchestration_stack.id, :host_ids => [@host2.id]}
       expect(controller.send(:flash_errors?)).to be_falsey
-      expect(response.body).to include("redirected")
-      expect(response.body).to include("ems_infra")
+      expect(response.status).to eq(302)
+      assert_redirected_to(controller.ems_infra_path(@ems.id))
       expect(session[:flash_msgs]).to match [a_hash_including(:message => " Scaling down to 1 compute nodes", :level => :success)]
     end
 
@@ -299,8 +299,8 @@ describe EmsInfraController do
         .to receive(:register_and_configure_nodes).and_return("SUCCESS")
       post :register_nodes, :params => {:id => @ems.id, :nodes_json => @nodes_example, :register => 1}
       expect(controller.send(:flash_errors?)).to be_falsey
-      expect(response.body).to include("redirected")
-      expect(response.body).to include("ems_infra")
+      expect(response.status).to eq(302)
+      assert_redirected_to(%r(#{controller.ems_infra_path(@ems.id)}))
     end
 
     it "when failure expected, workflow service not reachable" do


### PR DESCRIPTION
### Fix rails 7.1 removal, use to_fs(:dash) instead of Range#to_s(:dash)

Rails 7.0 was reporting this warning:

DEPRECATION WARNING: Range#to_s(:dash) is deprecated. Please use Range#to_fs(:dash) instead. (called from port_range_helper at /home/runner/work/manageiq-ui-classic/manageiq-ui-classic/app/helpers/security_group_helper/textual_summary.rb:105)

### Assert redirect in a rails 7.1 friendly way

In rails 7.1, the response.body in the redirect is an empty string.