### PR TITLE
Remove jquery from the audit exclusion list

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,10 +7,10 @@ nodeLinker: node-modules
 npmAuditExcludePackages:
 - angular
 # pending | high     | GHSA-4w4v-5hc9-xrr2 | angular >=1.3.0 <=1.8.3      | 1.8.3 brought in by manageiq-ui-classic@workspace:.
+# pending | moderate | GHSA-2qqx-w9hr-q5gx | angular <=1.8.3              | 1.8.3 brought in by manageiq-ui-classic@workspace:.
+# pending | moderate | GHSA-2vrf-hf26-jrp5 | angular <=1.8.3              | 1.8.3 brought in by manageiq-ui-classic@workspace:.
 # pending | moderate | GHSA-m2h2-264f-f486 | angular >=1.7.0              | 1.8.3 brought in by manageiq-ui-classic@workspace:.
 # pending | moderate | GHSA-prc3-vjfx-vhm9 | angular <=1.8.3              | 1.8.3 brought in by manageiq-ui-classic@workspace:.
-# pending | moderate | GHSA-2vrf-hf26-jrp5 | angular <=1.8.3              | 1.8.3 brought in by manageiq-ui-classic@workspace:.
-# pending | moderate | GHSA-2qqx-w9hr-q5gx | angular <=1.8.3              | 1.8.3 brought in by manageiq-ui-classic@workspace:.
 # pending | moderate | GHSA-qwqh-hm9m-p5hr | angular <=1.8.3              | 1.8.3 brought in by manageiq-ui-classic@workspace:.
 # pending | low      | GHSA-m9gf-397r-hwpg | angular >=1.3.0-rc.4 <=1.8.3 | 1.8.3 brought in by manageiq-ui-classic@workspace:.
 # pending | low      | GHSA-mqm9-c95h-x2p6 | angular <=1.8.3              | 1.8.3 brought in by manageiq-ui-classic@workspace:.
@@ -18,10 +18,5 @@ npmAuditExcludePackages:
 # pending | moderate | GHSA-9mvj-f7w8-pvh2 | bootstrap >=2.0.0 <=3.4.1 | 3.4.1 brought in by patternfly@npm:3.59.5
 - bootstrap-sass
 # pending | moderate | GHSA-9mvj-f7w8-pvh2 | bootstrap-sass >=2.0.0 <=3.4.3 | 3.4.3 brought in by patternfly@npm:3.59.5
-- jquery
-# pending | moderate | GHSA-rmxg-73gg-4p98 | jquery >=1.12.3 <3.0.0 | 2.2.4 brought in by manageiq-ui-classic@workspace:.
-# pending | moderate | GHSA-gxr4-xjj5-5px2 | jquery >=1.2.0 <3.5.0  | 2.2.4, 3.4.1 brought in by manageiq-ui-classic@workspace:., patternfly@npm:3.59.5
-# pending | moderate | GHSA-6c3j-c64m-qhgq | jquery >=1.1.4 <3.4.0  | 2.2.4 brought in by manageiq-ui-classic@workspace:.
-# pending | moderate | GHSA-jpcq-cgw6-v4j6 | jquery >=1.0.3 <3.5.0  | 2.2.4, 3.4.1 brought in by manageiq-ui-classic@workspace:., patternfly@npm:3.59.5
 
 yarnPath: .yarn/releases/yarn-4.5.3.cjs


### PR DESCRIPTION
No longer needed after the merge of #9322

@GilbertCherrie Please review.