### PR TITLE
[Morphy] Update semver regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
     "moment": "^2.29.4",
     "moment-timezone": "~0.5.40",
     "path-to-regexp": "~1.9.0",
+    "semver-regex": "~4.0.3",
     "tar": "~6.2.1",
     "tough-cookie": "~4.1.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14243,10 +14243,10 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-semver-regex@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-2.0.0.tgz#a93c2c5844539a770233379107b38c7b4ac9d338"
-  integrity sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
+semver-regex@^2.0.0, semver-regex@~4.0.3:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-4.0.5.tgz#fbfa36c7ba70461311f5debcb3928821eb4f9180"
+  integrity sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==
 
 "semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", "semver@^2.3.0 || 3.x || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"


### PR DESCRIPTION
Update semver-regex to ~4.0.3 using resolutions. Needed to use resolutions since this is being pulled in from patternfly-react which we can not update or remove on the Morphy branch.