### PR TITLE
[Morphy] Update marked to ~4.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,6 +176,7 @@
     "@babel/traverse": "~7.26.7",
     "ip": "1.1.9",
     "lodash": "~4.17.21",
+    "marked": "~4.0.10",
     "minimist": "1.2.6",
     "moment": "^2.29.4",
     "moment-timezone": "~0.5.40",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10470,10 +10470,10 @@ marked-terminal@^3.2.0:
     node-emoji "^1.4.1"
     supports-hyperlinks "^1.0.1"
 
-marked@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
-  integrity sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==
+marked@^0.7.0, marked@~4.0.10:
+  version "4.0.19"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.19.tgz#d36198d1ac1255525153c351c68c75bc1d7aee46"
+  integrity sha512-rgQF/OxOiLcvgUAj1Q1tAf4Bgxn5h5JZTp04Fx4XUkVhs7B+7YA9JEWJhJpoO8eJt8MkZMwqLCNeNqj1bCREZQ==
 
 mathjs@^3.11.5:
   version "3.20.2"


### PR DESCRIPTION
Update marked package to ~4.0.10 using resolutions. The marked package is being pulled in from patternfly-react which we can't update or delete on the Morphy branch without major code changes, so instead we need to update the marked package directly using the resolutions.