### PR TITLE
[Morphy] Update decode-uri-component package

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
   "resolutions": {
     "ansi-regex": "~5.0.1", 
     "@babel/traverse": "~7.26.7",
+    "decode-uri-component": "~0.2.1",
     "ip": "1.1.9",
     "lodash": "~4.17.21",
     "marked": "~4.0.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5674,10 +5674,10 @@ decimal.js@9.0.1:
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-9.0.1.tgz#1cc8b228177da7ab6498c1cc06eb130a290e6e1e"
   integrity sha512-2h0iKbJwnImBk4TGk7CG1xadoA0g3LDPlQhQzbZ221zvG0p2YVUedbKIPsOZXKZGx6YmZMJKYOalpCMxSdDqTQ==
 
-decode-uri-component@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
-  integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+decode-uri-component@^0.2.0, decode-uri-component@~0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
+  integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
 
 decompress-response@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
Update decode-uri-component to ~0.2.1 using resolutions. Need to use resolutions to update this because this is being pulled in from patternfly-react which we can not update or remove on the Morphy branch.