### PR TITLE
Wait for task no longer 

### DIFF
--- a/app/controllers/application_controller/wait_for_task.rb
+++ b/app/controllers/application_controller/wait_for_task.rb
@@ -23,7 +23,7 @@ module ApplicationController::WaitForTask
     end
   end
 
-  def browser_refresh_task(task_id, should_flash = false)
+  def browser_refresh_task(task_id, should_flash: false)
     session[:async][:interval] += 250 if session[:async][:interval] < 5000 # Slowly move up to 5 second retries
     render :update do |page|
       page << javascript_prologue
@@ -61,7 +61,7 @@ module ApplicationController::WaitForTask
       session[:async][:params][:rx_action] = options[:rx_action]
     end
 
-    browser_refresh_task(task_id, !!options[:flash])
+    browser_refresh_task(task_id, :should_flash => !!options[:flash])
   end
   private :initiate_wait_for_task
 

--- a/app/controllers/application_controller/wait_for_task.rb
+++ b/app/controllers/application_controller/wait_for_task.rb
@@ -11,7 +11,6 @@ module ApplicationController::WaitForTask
     @edit = session[:edit]  # If in edit, need to preserve @edit object
     raise Forbidden, _('Invalid input for "wait_for_task".') unless params[:task_id]
 
-    @edit = session[:edit]  # If in edit, need to preserve @edit object
     session[:async] ||= {}
     session[:async][:interval] ||= 1000 # Default interval to 1 second
     session[:async][:params] ||= {}

--- a/spec/controllers/application_controller/buttons_spec.rb
+++ b/spec/controllers/application_controller/buttons_spec.rb
@@ -51,8 +51,9 @@ describe ApplicationController do
       end
 
       it "Vm button" do
+        task = MiqTask.create
         controller.params = {:id => vm.id, :button_id => button.id}
-        expect_any_instance_of(CustomButton).to receive(:invoke_async).with(vm, 'UI')
+        expect_any_instance_of(CustomButton).to receive(:invoke_async).with(vm, 'UI').and_return(task.id)
 
         controller.send(:custom_buttons)
         expect(assigns(:right_cell_text)).to include(vm.name)


### PR DESCRIPTION
## Overview

## Depends upon

- [x] https://github.com/ManageIQ/manageiq-ui-classic/pull/9358
- [ ] https://github.com/ManageIQ/guides/pull/560

## Issue

The `wait_for_task` mechanism relies upon the session.
Every http request changes the session. So when multiple requests come in, updates to the session can overwrite the changes done by another request.

Example:

Host's display of Cap&U was breaking because hits to notifications were overwriting the session variables. Note: VM's display of Cap&U was working fine because it did not have a hit to notifications (and therefore didn't have this race condition).

## Solution

Move `wait_for_task` parameters from the session to the url.

## Before

- `initiate_wait_for_task` sets `session[:async][:params]` with `action` and `params{}`
- `browser_refresh_task` puts shim into web page
- browser polls `wait_for_task` waiting for task to complete
- when task is complete, `session[:async][:params]` is used to complete action

## After

- `initiate_wait_for_task` gathers `async_params`
- `browser_refresh_task` puts shim into web page with `async_params`
- browser polls `wait_for_task` waiting for task to complete.
- when task is complete, url parameters (`async_params`) is used to complete action
