### PR TITLE
Fixes 500 error occurred during refreshing of a provider instance

### DIFF
--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -84,6 +84,8 @@ module ApplicationController::Explorer
 
     # Process model actions that are currently implemented
     if X_BUTTON_ALLOWED_ACTIONS[action] == :s1
+      # resetting action that was stored during other operations
+      @sb[:action] = nil if @sb
       send(method)
     elsif X_BUTTON_ALLOWED_ACTIONS[action] == :s2
       # don't need to set params[:id] and do find_checked_items for methods

--- a/spec/controllers/vm_cloud_controller_spec.rb
+++ b/spec/controllers/vm_cloud_controller_spec.rb
@@ -110,6 +110,27 @@ describe VmCloudController do
       expect(response).to render_template(:partial => 'vm_common/_resize')
     end
 
+    it 'can open instance refresh tab' do
+      post :explorer
+      expect(response.status).to eq(200)
+      allow(controller).to receive(:x_node).and_return("v-#{vm_openstack.id}")
+
+      post :x_button, :params => {:pressed => 'instance_refresh', :id => vm_openstack.id}
+      expect(response.status).to eq(200)
+    end
+
+    it 'can do instance refresh after its reconfigure' do
+      post :explorer
+      expect(response.status).to eq(200)
+      allow(controller).to receive(:x_node).and_return("v-#{vm_openstack.id}")
+
+      post :x_button, :params => {:pressed => 'instance_resize', :id => vm_openstack.id}
+      expect(response.status).to eq(200)
+
+      post :x_button, :params => {:pressed => 'instance_refresh', :id => vm_openstack.id}
+      expect(response.status).to eq(200)
+    end
+
     it 'can open instance live migrate tab' do
       post :explorer
       expect(response.status).to eq(200)


### PR DESCRIPTION
Issue- An internal server error occurs during refresh('Refresh Relationships and Power States') of a provider instance. The error occurs only in cases when refresh is done 'after' a reconfigure ('Reconfigure selected instance') operation on the provider instance.

Observation- This was happening because it was rendering the _resize partial due to a pre-existing value in the @sb[:action].

Steps to reproduce the behavior:
1. Choose instance from AWS provider
2. Configuration -> Reconfigure selected Instance
3. Recheck on the same item from step 1
4. Configure -> Refresh Relationships and Power States

Before the fix - 

<img width="1508" alt="instance refresh - before" src="https://github.com/user-attachments/assets/267e3baf-e2f1-45f0-971b-d9e86c589046" />

After the fix - 
<img width="1506" alt="instance refresh - after" src="https://github.com/user-attachments/assets/8a420445-9e5b-4674-94e7-097aec105ea5" />


@miq-bot add-label bug
@miq-bot add-reviewer @GilbertCherrie
