### PR TITLE
Use params[:name] over session[:async][:params][:name]

### DIFF
--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -66,8 +66,8 @@ class CloudNetworkController < ApplicationController
   end
 
   def create_finished
-    task_id = session[:async][:params][:task_id]
-    network_name = session[:async][:params][:name]
+    task_id = params[:task_id]
+    network_name = params[:name]
     task = MiqTask.find(task_id)
     if MiqTask.status_ok?(task.status)
       add_flash(_("Cloud Network \"%{name}\" created") % {:name => network_name })
@@ -164,8 +164,8 @@ class CloudNetworkController < ApplicationController
   end
 
   def update_finished
-    task_id = session[:async][:params][:task_id]
-    cloud_network_name = session[:async][:params][:name]
+    task_id = params[:task_id]
+    cloud_network_name = params[:name]
     task = MiqTask.find(task_id)
     if MiqTask.status_ok?(task.status)
       flash_and_redirect(_("Cloud Network \"%{name}\" updated") % {:name => cloud_network_name})

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -146,8 +146,8 @@ class CloudVolumeController < ApplicationController
   end
 
   def create_finished
-    task_id = session[:async][:params][:task_id]
-    volume_name = session[:async][:params][:name]
+    task_id = params[:task_id]
+    volume_name = params[:name]
     task = MiqTask.find(task_id)
     if MiqTask.status_ok?(task.status)
       add_flash(_("Cloud Volume \"%{name}\" created") % {
@@ -211,9 +211,9 @@ class CloudVolumeController < ApplicationController
   end
 
   def update_finished
-    task_id = session[:async][:params][:task_id]
-    volume_id = session[:async][:params][:id]
-    volume_name = session[:async][:params][:name]
+    task_id = params[:task_id]
+    volume_id = params[:id]
+    volume_name = params[:name]
     task = MiqTask.find(task_id)
     if MiqTask.status_ok?(task.status)
       add_flash(_("Cloud Volume \"%{name}\" updated") % {

--- a/app/controllers/floating_ip_controller.rb
+++ b/app/controllers/floating_ip_controller.rb
@@ -67,8 +67,8 @@ class FloatingIpController < ApplicationController
   end
 
   def create_finished
-    task_id = session[:async][:params][:task_id]
-    floating_ip_address = session[:async][:params][:address]
+    task_id = params[:task_id]
+    floating_ip_address = params[:address]
     task = MiqTask.find(task_id)
     if MiqTask.status_ok?(task.status)
       add_flash(_("Floating IP \"%{address}\" created") % { :address => floating_ip_address })

--- a/app/controllers/host_aggregate_controller.rb
+++ b/app/controllers/host_aggregate_controller.rb
@@ -161,9 +161,9 @@ class HostAggregateController < ApplicationController
   end
 
   def add_host_finished
-    task_id = session[:async][:params][:task_id]
-    host_aggregate_name = session[:async][:params][:name]
-    host_id = session[:async][:params][:host_id]
+    task_id = params[:task_id]
+    host_aggregate_name = params[:name]
+    host_id = params[:host_id]
 
     task = MiqTask.find(task_id)
     host = Host.find(host_id)
@@ -244,9 +244,9 @@ class HostAggregateController < ApplicationController
   end
 
   def remove_host_finished
-    task_id = session[:async][:params][:task_id]
-    host_aggregate_name = session[:async][:params][:name]
-    host_id = session[:async][:params][:host_id]
+    task_id = params[:task_id]
+    host_aggregate_name = params[:name]
+    host_id = params[:host_id]
 
     task = MiqTask.find(task_id)
     host = Host.find(host_id)

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -129,10 +129,10 @@ class NetworkRouterController < ApplicationController
   end
 
   def add_interface_finished
-    task_id = session[:async][:params][:task_id]
-    router_id = session[:async][:params][:id]
-    router_name = session[:async][:params][:name]
-    cloud_subnet_id = session[:async][:params][:cloud_subnet_id]
+    task_id = params[:task_id]
+    router_id = params[:id]
+    router_name = params[:name]
+    cloud_subnet_id = params[:cloud_subnet_id]
 
     task = MiqTask.find(task_id)
     cloud_subnet = CloudSubnet.find(cloud_subnet_id)
@@ -222,10 +222,10 @@ class NetworkRouterController < ApplicationController
   end
 
   def remove_interface_finished
-    task_id = session[:async][:params][:task_id]
-    router_id = session[:async][:params][:id]
-    router_name = session[:async][:params][:name]
-    cloud_subnet_id = session[:async][:params][:cloud_subnet_id]
+    task_id = params[:task_id]
+    router_id = params[:id]
+    router_name = params[:name]
+    cloud_subnet_id = params[:cloud_subnet_id]
 
     task = MiqTask.find(task_id)
     cloud_subnet = CloudSubnet.find(cloud_subnet_id)

--- a/app/controllers/security_group_controller.rb
+++ b/app/controllers/security_group_controller.rb
@@ -76,8 +76,8 @@ class SecurityGroupController < ApplicationController
   end
 
   def create_finished
-    task_id = session[:async][:params][:task_id]
-    security_group_name = session[:async][:params][:name]
+    task_id = params[:task_id]
+    security_group_name = params[:name]
     task = MiqTask.find(task_id)
     if MiqTask.status_ok?(task.status)
       flash_and_redirect(_("Security Group \"%{name}\" created") % {:name => security_group_name})
@@ -181,7 +181,7 @@ class SecurityGroupController < ApplicationController
   end
 
   def update_finished
-    security_group_id = session[:async][:params][:id]
+    security_group_id = params[:id]
 
     td = session[:security_group][:task]
     task = MiqTask.find(td[:id])

--- a/spec/controllers/cloud_network_controller_spec.rb
+++ b/spec/controllers/cloud_network_controller_spec.rb
@@ -197,11 +197,10 @@ describe CloudNetworkController do
   end
 
   describe '#update_finished' do
-    let(:miq_task) { double("MiqTask", :state => 'Finished', :status => 'ok', :message => 'some message') }
+    let(:miq_task) { MiqTask.create(:state => 'Finished', :status => 'ok', :message => 'some message') }
 
     before do
-      allow(MiqTask).to receive(:find).with(123).and_return(miq_task)
-      allow(controller).to receive(:session).and_return(:async => {:params => {:task_id => 123, :name => network.name}})
+      allow(controller).to receive(:params).and_return({:task_id => miq_task.id, :name => network.name})
     end
 
     it 'calls flash_and_redirect with appropriate arguments for succesful updating of a Cloud Network' do
@@ -210,7 +209,7 @@ describe CloudNetworkController do
     end
 
     context 'unsuccesful updating of a Cloud Network' do
-      let(:miq_task) { double("MiqTask", :state => 'Finished', :status => 'Error', :message => 'some message') }
+      let(:miq_task) { MiqTask.create(:state => 'Finished', :status => 'Error', :message => 'some message') }
 
       it 'calls flash_and_redirect with appropriate arguments' do
         expect(controller).to receive(:flash_and_redirect).with(_("Unable to update Cloud Network \"%{name}\": %{details}") % {

--- a/spec/controllers/host_aggregate_controller_spec.rb
+++ b/spec/controllers/host_aggregate_controller_spec.rb
@@ -44,12 +44,11 @@ describe HostAggregateController do
   end
 
   describe '#create_finished' do
-    let(:miq_task) { double("MiqTask", :state => 'Finished', :status => status, :message => 'some message') }
+    let(:miq_task) { MiqTask.create(:state => 'Finished', :status => status, :message => 'some message') }
     let(:status) { 'Error' }
 
     before do
-      allow(MiqTask).to receive(:find).with(123).and_return(miq_task)
-      allow(controller).to receive(:session).and_return(:async => {:params => {:task_id => 123, :name => aggregate.name}})
+      allow(controller).to receive(:params).and_return({:task_id => miq_task.id, :name => aggregate.name})
     end
   end
 
@@ -76,12 +75,11 @@ describe HostAggregateController do
   end
 
   describe '#update_finished' do
-    let(:miq_task) { double("MiqTask", :state => 'Finished', :status => status, :message => 'some message') }
+    let(:miq_task) { MiqTask.create(:state => 'Finished', :status => status, :message => 'some message') }
     let(:status) { 'Error' }
 
     before do
-      allow(MiqTask).to receive(:find).with(123).and_return(miq_task)
-      allow(controller).to receive(:session).and_return(:async => {:params => {:task_id => 123, :id => aggregate.id, :name => aggregate.name}})
+      allow(controller).to receive(:params).and_return({:task_id => miq_task.id, :id => aggregate.id, :name => aggregate.name})
     end
   end
 
@@ -184,12 +182,11 @@ describe HostAggregateController do
   end
 
   describe '#add_host_finished' do
-    let(:miq_task) { double("MiqTask", :state => 'Finished', :status => status, :message => 'some message') }
+    let(:miq_task) { MiqTask.create(:state => 'Finished', :status => status, :message => 'some message') }
     let(:status) { 'Error' }
 
     before do
-      allow(MiqTask).to receive(:find).with(123).and_return(miq_task)
-      allow(controller).to receive(:session).and_return(:async => {:params => {:task_id => 123, :id => aggregate.id, :name => aggregate.name, :host_id => host.id}})
+      allow(controller).to receive(:params).and_return({:task_id => miq_task.id, :id => aggregate.id, :name => aggregate.name, :host_id => host.id})
     end
 
     it 'calls flash_and_redirect with appropriate arguments' do
@@ -267,12 +264,11 @@ describe HostAggregateController do
   end
 
   describe '#remove_host_finished' do
-    let(:miq_task) { double("MiqTask", :state => 'Finished', :status => status, :message => 'some message') }
+    let(:miq_task) { MiqTask.create(:state => 'Finished', :status => status, :message => 'some message') }
     let(:status) { 'Error' }
 
     before do
-      allow(MiqTask).to receive(:find).with(123).and_return(miq_task)
-      allow(controller).to receive(:session).and_return(:async => {:params => {:task_id => 123, :id => aggregate.id, :name => aggregate.name, :host_id => host.id}})
+      allow(controller).to receive(:params).and_return({:task_id => miq_task.id, :id => aggregate.id, :name => aggregate.name, :host_id => host.id})
     end
 
     it 'calls flash_and_redirect with appropriate arguments' do

--- a/spec/controllers/security_group_controller_spec.rb
+++ b/spec/controllers/security_group_controller_spec.rb
@@ -406,12 +406,11 @@ describe SecurityGroupController do
 
   describe '#create_finished' do
     let(:group) { FactoryBot.create(:security_group) }
-    let(:miq_task) { double("MiqTask", :state => 'Finished', :status => status, :message => 'some message') }
+    let(:miq_task) { MiqTask.create(:state => 'Finished', :status => status, :message => 'some message') }
     let(:status) { 'Error' }
 
     before do
-      allow(MiqTask).to receive(:find).with(123).and_return(miq_task)
-      allow(controller).to receive(:session).and_return(:async => {:params => {:task_id => 123, :name => group.name}})
+      allow(controller).to receive(:params).and_return({:task_id => miq_task.id, :name => group.name})
     end
 
     it 'calls flash_and_redirect with appropriate arguments for unsuccesful creating of a Security Group' do


### PR DESCRIPTION
part of https://github.com/ManageIQ/manageiq-ui-classic/pull/9352

when use wait_for_task, all the parameters are stored in session[:async][:params] When the task is actually complete, the values are placed back into params.

(the next step is to no longer use session[:async], but that is for a future PR)

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
