### PR TITLE
Fix provider dashboard charts converted time bug

### DIFF
--- a/app/javascript/components/provider-dashboard-charts/helpers.js
+++ b/app/javascript/components/provider-dashboard-charts/helpers.js
@@ -9,7 +9,7 @@ export const getConvertedData = (data, units) => {
       columnsData.forEach((item, i) => {
         const obj = {};
         obj.group = units;
-        obj.date = moment(item).tz(ManageIQ.timezone || 'UTC').format('MM/DD/YYYY HH:mm:ss z')
+        obj.date = moment(item).tz(ManageIQ.timezone || 'UTC').format('MM/DD/YYYY HH:mm:ss');
         obj.value = rowsData[i];
         arr.push(obj);
       });


### PR DESCRIPTION
Fixes an issue with the provider dashboard charts where certain time zones for example "BST" were causing the chart components to throw errors. This seems like a bug with the Carbon charts however we can prevent this by simply omitting the `z` in our format function call. Including the `z` doesn't matter in this case because it only adds the time zone string to the formatted time value, however this formatted time string isn't displayed anywhere. This formatted string is passed into the Carbon charts for the chart data and being displayed as a data point, so we don't actually need to include the timezone in our formatted string. This prevents us from running into the error of the chart breaking. 

Before:
<img width="716" alt="BeforeChartBug" src="https://github.com/user-attachments/assets/56e1d2cc-b419-46fc-a82f-9b5abd1cc1dc" />

After:
<img width="695" alt="AfterChartBug" src="https://github.com/user-attachments/assets/06ced228-522f-4629-a538-039f995b8996" />

Also, as a side effect fix by removing the `z` it actually correctly converts the time. When using time data with hour 22:00 in UTC and a ManageIQ timezone value of GMT+3 it should correspond to converted time values of the next day at 03:00. However before it wasn't actually converting the time since you can see it was keeping it at the original day.

The following charts were rendered with this time data:

```                  
'2024-07-08T22:00:00.000Z',
'2024-07-09T22:00:00.000Z',
'2024-07-10T22:00:00.000Z',
'2024-07-11T22:00:00.000Z',
'2024-07-12T22:00:00.000Z',
```

Before:
The time is correctly converted as a string but the incorrect dates are shown on the chart.
<img width="461" alt="BeforeData" src="https://github.com/user-attachments/assets/7f1234ad-3d49-453b-a337-84f0c1a915fc" />
<img width="699" alt="BeforeChart" src="https://github.com/user-attachments/assets/8f27045e-a744-404c-9c0d-fa1a3713edab" />

After:
The time is correctly converted as a string and the correct dates are shown on the chart.
<img width="479" alt="AfterData" src="https://github.com/user-attachments/assets/49148459-1f51-4fc1-9739-23d88fbaff89" />
<img width="696" alt="AfterChart" src="https://github.com/user-attachments/assets/9bf20f1c-0494-4b8e-8ed2-dda5c6f7e642" />
