### PR TITLE
Handle customization for all provisions

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -38,7 +38,7 @@ module ApplicationController::MiqRequestMethods
 
       all_dialogs = @edit[:wf].get_all_dialogs rescue []
 
-      if @edit[:new] && @edit[:new][:addr_mode] && @edit[:new][:addr_mode][0] == "dhcp" && all_dialogs[:customize]
+      if @edit[:new] && @edit[:new][:addr_mode] && @edit[:new][:addr_mode][0] == "dhcp" && all_dialogs[:customize] && all_dialogs[:customize][:fields]
         all_dialogs[:customize][:fields][:hostname]&.[]=(:read_only, true)
         all_dialogs[:customize][:fields][:linux_host_name]&.[]=(:read_only, true)
         all_dialogs[:customize][:fields][:subnet_mask][:read_only] = true


### PR DESCRIPTION
Don't throw an error if `all_dialogs[:customize][:fields]` doesn't exist

```
FATAL -- production: Error caught: [NoMethodError] undefined method `[]=' for nil:NilClass
       manageiq-ui-classic/app/controllers/application_controller/miq_request_methods.rb:42:in `prov_field_changed'
```

Fixes ManageIQ/manageiq#23148
TBH/ I have not reproduced the error, so I am only patching the culprit of the error.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
