### PR TITLE
Update cypress env

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-        - '3.0'
+        - '3.1'
         node-version:
         - 18
         cypress-browser:
@@ -64,7 +64,7 @@ jobs:
     - name: Run tests
       run: bundle exec rake
     - name: Save artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: cypress-${{ matrix.cypress-browser }}


### PR DESCRIPTION
- The app now runs on Ruby 3.1 miniumum
- update-artifacts v3 no longer exists

@GilbertCherrie Please review

