### PR TITLE
Pin cheerio package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,6 +186,7 @@
     "ansi-regex": "~5.0.1",
     "@babel/traverse": "~7.26.7",
     "bootstrap-select": "~1.13.18",
+    "cheerio": "1.0.0-rc.12",
     "cross-spawn": "~7.0.5",
     "decode-uri-component": "^0.2.2",
     "express": "^4.18.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4840,7 +4840,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cheerio@npm:^1.0.0-rc.3":
+"cheerio@npm:1.0.0-rc.12":
   version: 1.0.0-rc.12
   resolution: "cheerio@npm:1.0.0-rc.12"
   dependencies:


### PR DESCRIPTION
Pin the cheerio package version to 1.0.0-rc.12. This is because when the yarn.lock file is being updated it pulls in the latest version of cheerio which is 1.0.0, which causes our github actions specs to fail. After this pr is merged it should allow us to properly update the yarn.lock with the latest dependencies using this pr: #9276