### PR TITLE
Fix settings authentication form provider type ids

### DIFF
--- a/app/views/ops/_settings_authentication_tab.html.haml
+++ b/app/views/ops/_settings_authentication_tab.html.haml
@@ -92,7 +92,7 @@
           %label
             %input{:type              => 'radio',
                    :name              => 'provider_type',
-                   :id                => 'provider_type_none',
+                   :id                => 'provider_type',
                    :value             => 'none',
                    "data-miq_observe" => {:url => url}.to_json,
                    :checked           => @edit[:new][:authentication][:provider_type] == "none"}
@@ -101,7 +101,7 @@
           %label
             %input{:type              => 'radio',
                    :name              => 'provider_type',
-                   :id                => 'provider_type_saml',
+                   :id                => 'provider_type',
                    :value             => 'saml',
                    "data-miq_observe" => {:url => url}.to_json,
                    :checked           => @edit[:new][:authentication][:provider_type] == "saml"}
@@ -110,7 +110,7 @@
           %label
             %input{:type              => 'radio',
                    :name              => 'provider_type',
-                   :id                => 'provider_type_oidc',
+                   :id                => 'provider_type',
                    :value             => 'oidc',
                    "data-miq_observe" => {:url => url}.to_json,
                    :checked           => @edit[:new][:authentication][:provider_type] == "oidc"}


### PR DESCRIPTION
Fixed an issue with the Settings / Authentication Form where it isn't saving the correct values for the Provider type option or it won't let you save the form based on the provider type selected.

Before:
<img width="1023" alt="Screenshot 2025-04-11 at 2 15 36 PM" src="https://github.com/user-attachments/assets/7df6299f-8e3a-450c-95b2-98b98388cda4" />
<img width="1025" alt="Screenshot 2025-04-11 at 2 15 55 PM" src="https://github.com/user-attachments/assets/d6478894-6796-40fb-96f1-611138238708" />


After:
<img width="1026" alt="Screenshot 2025-04-11 at 2 14 17 PM" src="https://github.com/user-attachments/assets/658f1d6b-c99b-4891-8c89-1a3fe34fd81a" />
<img width="1025" alt="Screenshot 2025-04-11 at 2 17 58 PM" src="https://github.com/user-attachments/assets/56ec23e6-e9ac-403d-bea3-20e07cf89311" />
