### PR TITLE
Fixes alert with event threshold

### DIFF
--- a/app/views/miq_alert/_alert_builtin_exp.html.haml
+++ b/app/views/miq_alert/_alert_builtin_exp.html.haml
@@ -12,7 +12,7 @@
         edit[:new][:expression][:options][:event_types]),
         :class => "selectpicker")
       :javascript
-        miqInitSelectPicker f();
+        miqInitSelectPicker();
         miqSelectPickerEvent('event_types', '#{url}', {beforeSend: true, complete: true})
   - when :time_threshold
     %label.control-label.col-md-2

--- a/spec/controllers/miq_alert_controller_spec.rb
+++ b/spec/controllers/miq_alert_controller_spec.rb
@@ -154,6 +154,44 @@ describe MiqAlertController do
       expect(assigns(:flash_array)).to be_nil
     end
 
+    it "forces Event to check to be present for eval_method - Event threshold" do
+      @miq_alert = FactoryBot.create(
+        :miq_alert,
+        :db         => "Host",
+        :options    => {:notifications => {:email => {:to => ["fred@test.com"]}}},
+        :expression => {:eval_method => 'event_threshold', :mode => "internal", :options => {:event_types => []}},
+        :severity   => 'info'
+      )
+
+      edit = {
+        :new => {
+          :expression => {:eval_method => 'event_threshold', :mode => "internal", :options => {:event_types => []}},
+        }
+      }
+      controller.instance_variable_set(:@edit, edit)
+      controller.send(:alert_valid_record?, @miq_alert)
+      expect(assigns(:flash_array).first[:message]).to(match("Event to Check is required"))
+    end
+
+    it "does not force Event to check to be present for eval_method - Event threshold" do
+      @miq_alert = FactoryBot.create(
+        :miq_alert,
+        :db         => "Host",
+        :options    => {:notifications => {:email => {:to => ["fred@test.com"]}}},
+        :expression => {:eval_method => 'event_threshold', :mode => "internal", :options => {:event_types => ["PowerOnVM_Task_Complete"]}},
+        :severity   => 'info'
+      )
+
+      edit = {
+        :new => {
+          :expression => {:eval_method => 'event_threshold', :mode => "internal", :options => {:event_types => ["PowerOnVM_Task_Complete"]}},
+        }
+      }
+      controller.instance_variable_set(:@edit, edit)
+      controller.send(:alert_valid_record?, @miq_alert)
+      expect(assigns(:flash_array)).to(be_nil)
+    end
+
     context 'not choosing Send an E-mail option while adding new Alert' do
       let(:alert) do
         FactoryBot.create(:miq_alert,


### PR DESCRIPTION
Fixes #9386 

When attempting to create an Alert via Control -> Alerts -> Add a new alert, and choosing Event Threshold as the "What to Evaluate", an error message appears as: `Event to Check is required` even when there is a value for the field.