### PR TITLE
Define a custom script dataType converter, don't override the base one

### DIFF
--- a/app/javascript/oldjs/jquery_overrides.js
+++ b/app/javascript/oldjs/jquery_overrides.js
@@ -36,7 +36,7 @@ $.ajaxSetup({
         return jQuery.parseJSON(text);
       });
     }),
-    'text script': logError(function(text) {
+    'text miq_script': logError(function(text) {
       if (text.match(/^{/)) {
         return jQuery.jsonPayload(text, function(text) {
           return text;

--- a/app/javascript/oldjs/miq_application.js
+++ b/app/javascript/oldjs/miq_application.js
@@ -1123,8 +1123,8 @@ window.miqJqueryRequest = function(url, options) {
   };
 
   if (options.dataType === undefined) {
-    ajax_options.accepts = { script: `*/*;q=0.5, ${$.ajaxSettings.accepts.script}` };
-    ajax_options.dataType = 'script';
+    ajax_options.accepts = { miq_script: `*/*;q=0.5, ${$.ajaxSettings.accepts.script}` };
+    ajax_options.dataType = 'miq_script';
   }
 
   // copy selected options over


### PR DESCRIPTION
The jquery upgrade from 2.2.4 to 3.7.1 from 16cf008fda3145184b4709f5d39e8756a241b186 was causing the login page to spin after a 401 unauthorized with sso enabled for kerberos. This happened because our script converter wasn't being run with the newer jquery, therefore we weren't processing the response payload from the 401.  This response payload should ajax update the page with the error, stop the spinner, and show the login fields.

There were some changes in the 2.2.4 to 3.7.1 jquery upgrade  that seems to conflict with our converter, perhaps our converter was being overridden, or maybe we need to override it differently.  Either way, we can avoid this by defining our own converter.

This was recreated locally via:

```ruby
render :inline => Rails.root.join("public/proxy_pages/invalid_sso_credentials.js").read, :content_type => "text/javascript", :status => 401
```

in `kerberos_authenticate` in `dashboard_controller.rb` and running this in the js console:

```
await miqAjaxAuthSso('/dashboard/kerberos_authenticate?button=sso_login');
```

Here are the full set of changes for the upgrade:
https://github.com/jquery/jquery/compare/2.2.4...3.7.1

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
