### PR TITLE
Remove dead code

### DIFF
--- a/app/javascript/oldjs/services/miq_service.js
+++ b/app/javascript/oldjs/services/miq_service.js
@@ -27,10 +27,6 @@ ManageIQ.angular.app.service('miqService', ['$q', 'API', '$window', function($q,
     miqJqueryRequest(url, {beforeSend: true, data: serializeFields});
   };
 
-  this.restAjaxButton = function(url, button, dataType, data) {
-    miqRESTAjaxButton(url, button, dataType, data);
-  };
-
   this.jqueryRequest = function(url, options) {
     return miqJqueryRequest(url, options);
   };

--- a/app/javascript/oldjs/services/miq_service.js
+++ b/app/javascript/oldjs/services/miq_service.js
@@ -102,19 +102,6 @@ ManageIQ.angular.app.service('miqService', ['$q', 'API', '$window', function($q,
     $event.preventDefault();
   };
 
-  this.validateClicked = function($event, authType, formSubmit, angularForm, url) {
-    miqService.validateWithREST($event, authType, url, formSubmit)
-      .then(function success(data) {
-        if (data.level === 'error') {
-          angularForm.default_auth_status.$setViewValue(false);
-        } else {
-          angularForm.default_auth_status.$setViewValue(true);
-        }
-        miqService.miqFlash(data.level, data.message);
-        miqService.sparkleOff();
-      });
-  };
-
   this.disabledClick = function($event) {
     $event.preventDefault();
   };

--- a/app/javascript/oldjs/services/miq_service.js
+++ b/app/javascript/oldjs/services/miq_service.js
@@ -87,11 +87,6 @@ ManageIQ.angular.app.service('miqService', ['$q', 'API', '$window', function($q,
       .catch(options.handleFailure);
   };
 
-  this.validateWithAjax = function(url, model) {
-    miqSparkleOn();
-    miqAjaxButton(url, model || true);
-  };
-
   this.disabledClick = function($event) {
     $event.preventDefault();
   };

--- a/app/javascript/oldjs/services/miq_service.js
+++ b/app/javascript/oldjs/services/miq_service.js
@@ -92,16 +92,6 @@ ManageIQ.angular.app.service('miqService', ['$q', 'API', '$window', function($q,
     miqAjaxButton(url, model || true);
   };
 
-  this.validateWithREST = function($event, credType, url, formSubmit) {
-    angular.element('#button_name').val('validate');
-    angular.element('#cred_type').val(credType);
-    if (formSubmit) {
-      miqSparkleOn();
-      return $q.when(miqRESTAjaxButton(url, $event.target, 'json'));
-    }
-    $event.preventDefault();
-  };
-
   this.disabledClick = function($event) {
     $event.preventDefault();
   };

--- a/app/javascript/oldjs/services/miq_service.js
+++ b/app/javascript/oldjs/services/miq_service.js
@@ -69,12 +69,6 @@ ManageIQ.angular.app.service('miqService', ['$q', 'API', '$window', function($q,
     return form.$valid && form.$dirty;
   };
 
-  this.detectWithRest = function($event, url) {
-    angular.element('#button_name').val('detect');
-    miqSparkleOn();
-    return $q.when(miqRESTAjaxButton(url, $event.target, 'json'));
-  };
-
   this.networkProviders = function(options) {
     options = Object.assign(options || {}, {
       attributes: ['id', 'name'],

--- a/spec/javascripts/services/miq_service_spec.js
+++ b/spec/javascripts/services/miq_service_spec.js
@@ -154,20 +154,6 @@ describe('miqService', function() {
     });
   });
 
-  describe('#validateWithAjax', function() {
-    beforeEach(function() {
-      testService.validateWithAjax('/host/create/new?button=validate&type=default');
-    });
-
-    it('turns the spinner on via the miqService', function() {
-      expect(window.miqSparkleOn).toHaveBeenCalled();
-    });
-
-    it('delegates to miqService.miqAjaxButton', function() {
-      expect(window.miqAjaxButton).toHaveBeenCalledWith('/host/create/new?button=validate&type=default', true);
-    });
-  });
-
   describe('#disabledClick', function() {
     it('prevents a submit action', function() {
       var event = $.Event('click');

--- a/spec/javascripts/services/miq_service_spec.js
+++ b/spec/javascripts/services/miq_service_spec.js
@@ -154,20 +154,6 @@ describe('miqService', function() {
     });
   });
 
-  describe('#validateWithREST', function() {
-    beforeEach(function() {
-      testService.validateWithREST($.Event, "default", '/ems_cloud/create/new?button=validate&type=default', true);
-    });
-
-    it('turns the spinner on via the miqService', function() {
-      expect(window.miqSparkleOn).toHaveBeenCalled();
-    });
-
-    it('delegates to miqService.miqAjaxButton', function() {
-      expect(window.miqAjaxButton).toHaveBeenCalledWith('/ems_cloud/create/new?button=validate&type=default', true);
-    });
-  });
-
   describe('#validateWithAjax', function() {
     beforeEach(function() {
       testService.validateWithAjax('/host/create/new?button=validate&type=default');


### PR DESCRIPTION
Note, these are all callers of miqRESTAjaxButton which takes a dataType.  This function is related to [an issue with an upgrade of jquery from 2.2.4 to 3.7.1](https://github.com/ManageIQ/manageiq-ui-classic/pull/9410)

* validateWithAjax is unused as of 9268a856aaf606fff4399dba688415471910616d
* validateWithREST is unused as of 8efe154e0912337cefcc4b576f2124e77674c2b7
* validateClicked is unused as of 7fe831cb5f48a7039cf4d081856210d9949432b7
* restAjaxButton is unused as of 753534f7d11c6e11b4a4ec88ddec5f994dc192f4
* detectWithRest appears to not be used as of 775acdd8b4c047620c22cb04f7eeed8ab9401739