### PR TITLE
Dead code round 2

### DIFF
--- a/app/helpers/js_helper.rb
+++ b/app/helpers/js_helper.rb
@@ -56,10 +56,6 @@ module JsHelper
       .html_safe
   end
 
-  def javascript_update_element(element, content)
-    "$('##{element}').html('#{escape_javascript(content)}');"
-  end
-
   def js_build_calendar(options = {})
     skip_days = options[:skip_days].nil? ? 'undefined' : options[:skip_days].to_a.to_json
 

--- a/app/helpers/js_helper.rb
+++ b/app/helpers/js_helper.rb
@@ -22,10 +22,6 @@ module JsHelper
     "$('##{j_str(element)}').prepend('#{content_tag(:span, nil, :class => cls)}');".html_safe
   end
 
-  def javascript_highlight(element, status)
-    "miqHighlight('##{j_str(element)}', #{j_str(status)});".html_safe
-  end
-
   def javascript_disable_field(element)
     "$('##{j_str(element)}').prop('disabled', true);".html_safe
   end

--- a/app/helpers/js_helper.rb
+++ b/app/helpers/js_helper.rb
@@ -18,10 +18,6 @@ module JsHelper
     "$('##{j_str(element)}').focus();".html_safe
   end
 
-  def javascript_prepend_span(element, cls)
-    "$('##{j_str(element)}').prepend('#{content_tag(:span, nil, :class => cls)}');".html_safe
-  end
-
   def javascript_disable_field(element)
     "$('##{j_str(element)}').prop('disabled', true);".html_safe
   end

--- a/app/helpers/js_helper.rb
+++ b/app/helpers/js_helper.rb
@@ -42,10 +42,6 @@ module JsHelper
     "if (miqDomElementExists('#{j_str(element)}')) #{javascript_hide(element)}".html_safe
   end
 
-  def jquery_pulsate_element(element)
-    "$('##{element}').fadeIn().fadeOut().fadeIn().fadeOut().fadeIn().fadeOut().fadeIn().fadeOut().fadeIn().fadeOut().fadeIn();".html_safe
-  end
-
   def partial_replace(from, partial, locals)
     "$(\"##{h(from)}\").replaceWith(\"#{escape_javascript(render(:partial => partial, :locals => locals))}\");".html_safe
   end

--- a/app/javascript/oldjs/.eslintrc.json
+++ b/app/javascript/oldjs/.eslintrc.json
@@ -1,7 +1,6 @@
 {
   "globals": {
-    "GitImport": true, // local git_import.js
-    "miqHideSearchClearButton": true // local miq_application.js
+    "GitImport": true // local git_import.js
   },
   "rules": {
     "key-spacing": ["error", {

--- a/app/javascript/oldjs/miq_application.js
+++ b/app/javascript/oldjs/miq_application.js
@@ -207,19 +207,6 @@ window.miqGetBrowserInfo = function() {
   }
 };
 
-// Turn highlight on or off
-window.miqHighlight = function(elem, status) {
-  if ($(elem).length) {
-    return;
-  }
-
-  if (status) {
-    $(elem).addClass('active');
-  } else {
-    $(elem).removeClass('active');
-  }
-};
-
 // Turn on activity indicator
 window.miqSparkle = function(status) {
   if (status) {

--- a/app/javascript/oldjs/miq_application.js
+++ b/app/javascript/oldjs/miq_application.js
@@ -1485,16 +1485,6 @@ window.miqFormatNotification = function(text, bindings) {
   return str;
 };
 
-window.fontIconChar = _.memoize((klass) => {
-  const tmp = document.createElement('i');
-  tmp.className = `hidden ${klass}`;
-  document.body.appendChild(tmp);
-  const char = window.getComputedStyle(tmp, ':before').content.replace(/'|"/g, '');
-  const font = window.getComputedStyle(tmp, ':before').fontFamily;
-  tmp.remove();
-  return { font, char };
-});
-
 window.redirectLogin = function(msg) {
   if (ManageIQ.logoutInProgress) {
     return; // prevent double redirect after pressing the Logout button or when changing group

--- a/app/javascript/oldjs/miq_application.js
+++ b/app/javascript/oldjs/miq_application.js
@@ -918,13 +918,6 @@ window.miq_tabs_show_hide = function(tab_id, show) {
   $(tab_id).toggleClass('hidden', !show);
 };
 
-// Send explorer search by name via ajax
-window.miqSearchByName = function(button) {
-  if (button == null) {
-    miqJqueryRequest('x_search_by_name', { beforeSend: true, data: miqSerializeForm('searchbox') });
-  }
-};
-
 // Send transaction to server so automate tree selection box can be made active
 // and rest of the screen can be blocked
 window.miqShowAE_Tree = function(typ) {

--- a/app/javascript/oldjs/miq_application.js
+++ b/app/javascript/oldjs/miq_application.js
@@ -842,18 +842,6 @@ window.miqSendDateRequest = function(el) {
   return miqObserveRequest(urlstring, options);
 };
 
-// common function to pass ajax request to server
-window.miqAjaxRequest = function(itemId, path) {
-  if (miqCheckForChanges()) {
-    miqJqueryRequest(
-      miqPassFields(path, { id: itemId }),
-      { beforeSend: true, complete: true }
-    );
-    return true;
-  }
-  return false;
-};
-
 // Handle an element onclick to open href in a new window with optional confirmation
 window.miqClickAndPop = function(el) {
   const conmsg = el.getAttribute('data-miq_confirm');

--- a/app/javascript/oldjs/miq_application.js
+++ b/app/javascript/oldjs/miq_application.js
@@ -1493,11 +1493,3 @@ window.redirectLogin = function(msg) {
   add_flash(msg, 'warning');
   window.document.location.href = '/dashboard/login?timeout=true';
 };
-
-window.camelizeQuadicon = function(quad) {
-  return _.reduce(quad, (result, current, key) => {
-    const item = {};
-    item[_.camelCase(key)] = current;
-    return Object.assign(result, item);
-  }, {});
-};

--- a/app/javascript/oldjs/miq_application.js
+++ b/app/javascript/oldjs/miq_application.js
@@ -1309,29 +1309,6 @@ window.miqInitMainContent = function() {
   $('#main-content').css('height', `calc(100% - ${height}px)`);
 };
 
-window.miqHideSearchClearButton = function(explorer) {
-  // Hide the clear button if the search input is empty
-  $('.search-pf .has-clear .clear').each(function() {
-    if (!$(this).prev('.form-control').val()) {
-      $(this).hide();
-    }
-  });
-  // Show the clear button upon entering text in the search input
-  $('.search-pf .has-clear .form-control').keyup(function() {
-    const t = $(this);
-    t.nextAll('button.clear').toggle(Boolean(t.val()));
-  });
-  // Upon clicking the clear button, empty the entered text and hide the clear button
-  $('.search-pf .has-clear .clear').click(function() {
-    $(this).prev('.form-control').val('').focus();
-    $(this).hide();
-    // Clear Search text values as well
-    const url = `/${ManageIQ.controller}/search_clear` + `?in_explorer=${explorer}`;
-    ManageIQ.gridChecks = [];
-    miqJqueryRequest(url);
-  });
-};
-
 window.toggle_expansion = function(link) {
   link = $(link);
   link.find('i').toggleClass('fa-angle-right fa-angle-down');

--- a/app/javascript/oldjs/services/miq_service.js
+++ b/app/javascript/oldjs/services/miq_service.js
@@ -79,10 +79,6 @@ ManageIQ.angular.app.service('miqService', ['$q', 'API', '$window', function($q,
       .catch(options.handleFailure);
   };
 
-  this.disabledClick = function($event) {
-    $event.preventDefault();
-  };
-
   this.serializeModel = function(model) {
     var serializedObj = angular.copy(model);
 

--- a/app/javascript/oldjs/services/miq_service.js
+++ b/app/javascript/oldjs/services/miq_service.js
@@ -97,25 +97,6 @@ ManageIQ.angular.app.service('miqService', ['$q', 'API', '$window', function($q,
     return $q.reject(e);
   };
 
-  this.getCloudNetworksByEms = function(callback) {
-    return function(id) {
-      if (!id) {
-        callback([]);
-        return;
-      }
-      miqService.sparkleOn();
-
-      API.get('/api/cloud_networks?expand=resources&attributes=name,ems_ref&filter[]=external_facing=true&filter[]=ems_id=' + id)
-        .then(getCloudNetworksByEmsData)
-        .catch(miqService.handleFailure);
-    };
-
-    function getCloudNetworksByEmsData(data) {
-      callback(data);
-      miqService.sparkleOff();
-    }
-  };
-
   this.getProviderTenants = function(callback) {
     return function(id) {
       if (!id) {

--- a/app/javascript/oldjs/services/miq_service.js
+++ b/app/javascript/oldjs/services/miq_service.js
@@ -79,30 +79,6 @@ ManageIQ.angular.app.service('miqService', ['$q', 'API', '$window', function($q,
       .catch(options.handleFailure);
   };
 
-  this.serializeModel = function(model) {
-    var serializedObj = angular.copy(model);
-
-    for (var k in serializedObj) {
-      if (serializedObj.hasOwnProperty(k) && !serializedObj[k]) {
-        delete serializedObj[k];
-      }
-    }
-
-    return serializedObj;
-  };
-
-  this.serializeModelWithIgnoredFields = function(model, ignoredFields) {
-    var serializedObj = angular.copy(model);
-
-    for (var k in serializedObj) {
-      if ((ignoredFields.indexOf(k) >= 0) || (serializedObj.hasOwnProperty(k) && !serializedObj[k])) {
-        delete serializedObj[k];
-      }
-    }
-
-    return serializedObj;
-  };
-
   this.handleFailure = function(e) {
     miqSparkleOff();
 

--- a/app/javascript/oldjs/services/miq_service.js
+++ b/app/javascript/oldjs/services/miq_service.js
@@ -23,10 +23,6 @@ ManageIQ.angular.app.service('miqService', ['$q', 'API', '$window', function($q,
     miqAjaxButton(url, serializeFields, options);
   };
 
-  this.miqAsyncAjaxButton = function(url, serializeFields) {
-    miqJqueryRequest(url, {beforeSend: true, data: serializeFields});
-  };
-
   this.jqueryRequest = function(url, options) {
     return miqJqueryRequest(url, options);
   };

--- a/app/javascript/oldjs/services/miq_service.js
+++ b/app/javascript/oldjs/services/miq_service.js
@@ -23,10 +23,6 @@ ManageIQ.angular.app.service('miqService', ['$q', 'API', '$window', function($q,
     miqAjaxButton(url, serializeFields, options);
   };
 
-  this.jqueryRequest = function(url, options) {
-    return miqJqueryRequest(url, options);
-  };
-
   this.refreshSelectpicker = function() {
     $('select').selectpicker('refresh');
   };

--- a/app/javascript/oldjs/services/miq_service.js
+++ b/app/javascript/oldjs/services/miq_service.js
@@ -97,25 +97,6 @@ ManageIQ.angular.app.service('miqService', ['$q', 'API', '$window', function($q,
     return $q.reject(e);
   };
 
-  this.getProviderTenants = function(callback) {
-    return function(id) {
-      if (!id) {
-        callback([]);
-        return;
-      }
-      miqService.sparkleOn();
-
-      API.get('/api/providers/' + id + '/cloud_tenants?expand=resources&attributes=id,name')
-        .then(getCloudTenantsByEms)
-        .catch(miqService.handleFailure);
-    };
-
-    function getCloudTenantsByEms(data) {
-      callback(data);
-      miqService.sparkleOff();
-    }
-  };
-
   this.redirectBack = function(message, flashType, redirectUrl) {
     miqFlashLater({message: message, level: flashType});
 

--- a/spec/helpers/js_helper_spec.rb
+++ b/spec/helpers/js_helper_spec.rb
@@ -21,13 +21,6 @@ describe JsHelper do
     end
   end
 
-  context '#javascript_highlight' do
-    it 'returns js to to add or remove the active class on the element' do
-      expect(javascript_highlight('foo', true)).to eq("miqHighlight('\#foo', true);")
-      expect(javascript_highlight('foo', false)).to eq("miqHighlight('\#foo', false);")
-    end
-  end
-
   context '#javascript_disable_field' do
     it 'returns js to disable the provided element' do
       expect(javascript_disable_field('foo')).to eq("$('#foo').prop('disabled', true);")

--- a/spec/javascripts/services/miq_service_spec.js
+++ b/spec/javascripts/services/miq_service_spec.js
@@ -153,12 +153,4 @@ describe('miqService', function() {
       });
     });
   });
-
-  describe('#disabledClick', function() {
-    it('prevents a submit action', function() {
-      var event = $.Event('click');
-      testService.disabledClick(event);
-      expect(event.isDefaultPrevented()).toBeTruthy();
-    });
-  });
 });

--- a/spec/javascripts/services/miq_service_spec.js
+++ b/spec/javascripts/services/miq_service_spec.js
@@ -128,29 +128,6 @@ describe('miqService', function() {
           expect(testService.saveable(scheduleForm)).toBe(false);
         });
       });
-
-      describe('when the passed in model contains few attributes with null vaues', function() {
-        beforeEach(function() {
-          model = {
-          depot_name:   'my_nfs_depot',
-          uri:          'nfs://nfs_location',
-          uri_prefix:   'nfs',
-          log_userid:   null,
-          log_password: null,
-          log_protocol: 'NFS'
-          };
-        });
-
-        it('it returns an object with null attributes excluded', function() {
-          returnedObj = {
-            depot_name:   'my_nfs_depot',
-            uri:          'nfs://nfs_location',
-            uri_prefix:   'nfs',
-            log_protocol: 'NFS'
-          };
-          expect(testService.serializeModel(model)).toEqual(returnedObj);
-        });
-      });
     });
   });
 });


### PR DESCRIPTION
Follow up to #9411...

I went through each function/method, checked if it was called, and verified the last usage was a commit (usually a conversion) that mistakenly didn't remove the dead code, and removed it.

* getProviderTenants is unused as of 1f458eaf4234e1ef7feccff8571a4ba230ba347b
* getCloudNetworksByEms is unused as of e4db01a7fbcf737b01ff84b118bf17368f0addd6
* serializeModel is unused as of 3c0aab7b0fd87a56cf8aee6d57e6e582ba7ba856
* disabledClick is unused as of 6d09bfb6844e75550c2acc3d61ebf2f75b96c4a4
* jqueryRequest is unused as of 807cab9b655067cb735c9c1722432f912c9b244d
* miqAsyncAjaxButton is unused as of 07c32fe7627a1e5df5512ec7ad550c0b84f9a671
* javascript_update_element is unused as of 68c7a5a154ee09523f2eccd4022f07d515d01070
* jquery_pulsate_element is unused as of 2161555c93c24de71332de2ab4e1fcb96d11720d
* javascript_prepend_span is unused as of 0d5bec47b723c893ddf041c37024f8f52628f9bd
* camelizeQuadicon is unused as of cb5aad2e32f072b513c02de7eb94e8c993f650c6
* fontIconChar is unused as of 57dee8f8a97e763e643e1686c7eaf546a02709ee
* miqHideSearchClearButton is unused as of 450960c8e2e23ddd5fb8ce46e3259a765005ba60
* miqSearchByName unused as of 450960c8e2e23ddd5fb8ce46e3259a765005ba60
* miqAjaxRequest unused as of 5a1ed5d2400fa33e38e0d9905122c78130b9a7da
* javascript_highlight unused as of 7d85b054b14fae7ade34776c3ea4fed3ffa6334e