### PR TITLE
Fix `ConfigurationJobController` using AnsibleTower

### DIFF
--- a/app/controllers/configuration_job_controller.rb
+++ b/app/controllers/configuration_job_controller.rb
@@ -10,7 +10,7 @@ class ConfigurationJobController < ApplicationController
   include Mixins::BreadcrumbsMixin
 
   def self.model
-    ManageIQ::Providers::AnsibleTower::AutomationManager::Job
+    ManageIQ::Providers::ExternalAutomationManager::OrchestrationStack
   end
 
   def self.table_name
@@ -36,7 +36,7 @@ class ConfigurationJobController < ApplicationController
     when "configuration_job_delete"
       configuration_job_delete
     when "configuration_job_tag"
-      tag(ManageIQ::Providers::AnsibleTower::AutomationManager::Job)
+      tag(self.class.model)
     when "configuration_job_reload"
       # TODO: this line is not needed when feature name "configuration_job_reload" will exist
       assert_privileges("configuration_job_control")
@@ -72,7 +72,6 @@ class ConfigurationJobController < ApplicationController
     {
       :breadcrumbs => [
         {:title => _("Automation")},
-        {:title => _("Ansible Tower")},
         {:title => _("Jobs"), :url => controller_url},
       ],
     }

--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -31,7 +31,7 @@ class OrchestrationStackController < ApplicationController
 
   def show_list
     process_show_list(
-      :named_scope => [[:without_type, 'ManageIQ::Providers::AnsibleTower::AutomationManager::Job']]
+      :named_scope => [[:without_type, 'ManageIQ::Providers::ExternalAutomationManager::OrchestrationStack']]
     )
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -424,7 +424,8 @@ module ApplicationHelper
         "ManageIQ::Providers::CloudManager::CloudDatabase",
         "ManageIQ::Providers::ConfigurationManager",
         "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem",
-        "ManageIQ::Providers::AnsibleTower::AutomationManager::Job", "ConfigurationScript"
+        "ManageIQ::Providers::ExternalAutomationManager::OrchestrationStack",
+        "ConfigurationScript"
       controller = request.parameters[:controller]
     when "ContainerVolume"
       controller = "persistent_volume"

--- a/app/views/layouts/_tag_edit_items.html.haml
+++ b/app/views/layouts/_tag_edit_items.html.haml
@@ -3,8 +3,8 @@
   %h3
     - t = {:amount => @tagitems.length, :object => ui_lookup(:model => @edit[:tagging]), :objects => ui_lookup(:models => @edit[:tagging])}
     - case @edit[:tagging]
-      - when "ManageIQ::Providers::AnsibleTower::AutomationManager::Job"
-        = n_("%{amount} Ansible Tower Job Being Tagged", "%{amount} Ansible Tower Jobs Being Tagged", @tagitems.length) % t
+      - when "ManageIQ::Providers::ExternalAutomationManager::OrchestrationStack"
+        = n_("%{amount} Automation Job Being Tagged", "%{amount} Automation Jobs Being Tagged", @tagitems.length) % t
       - when "ManageIQ::Providers::AnsibleTower::AutomationManager"
         = n_("%{amount} Automation Manager (Ansible Tower) Being Tagged", "%{amount} Automation Managers (Ansible Tower) Being Tagged", @tagitems.length) % t
       - when "AvailabilityZone"

--- a/product/views/ManageIQ_Providers_ExternalAutomationManager_OrchestrationStack.yaml
+++ b/product/views/ManageIQ_Providers_ExternalAutomationManager_OrchestrationStack.yaml
@@ -9,13 +9,13 @@
 #
 
 # Report title
-title: Ansible Tower Jobs
+title: Automation Jobs
 
 # Menu name
-name: Ansible Tower Job
+name: Automation Job
 
 # Main DB table report is based on
-db: ManageIQ::Providers::AnsibleTower::AutomationManager::Job
+db: ManageIQ::Providers::ExternalAutomationManager::OrchestrationStack
 
 # Columns to fetch from the main table
 cols:

--- a/spec/controllers/configuration_job_controller_spec.rb
+++ b/spec/controllers/configuration_job_controller_spec.rb
@@ -9,7 +9,7 @@ describe ConfigurationJobController do
 
   describe '#show' do
     context "instances" do
-      let(:record) { FactoryBot.create(:ansible_tower_job) }
+      let(:record) { FactoryBot.create(:awx_job) }
 
       before do
         session[:settings] = {
@@ -39,7 +39,7 @@ describe ConfigurationJobController do
     let!(:user) { stub_user(:features => :all) }
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      @cj = FactoryBot.create(:ansible_tower_job, :name => "testJob")
+      @cj = FactoryBot.create(:awx_job, :name => "testJob")
       allow(@cj).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
       classification = FactoryBot.create(:classification, :name => "department", :description => "Department")
       @tag1 = FactoryBot.create(:classification_tag,
@@ -49,10 +49,10 @@ describe ConfigurationJobController do
                                  :name   => "tag2",
                                  :parent => classification)
       allow(Classification).to receive(:find_assigned_entries).with(@cj).and_return([@tag1, @tag2])
-      session[:tag_db] = "ManageIQ::Providers::AnsibleTower::AutomationManager::Job"
+      session[:tag_db] = "ManageIQ::Providers::Awx::AutomationManager::Job"
       edit = {
-        :key        => "ManageIQ::Providers::AnsibleTower::AutomationManager::Job_edit_tags__#{@cj.id}",
-        :tagging    => "ManageIQ::Providers::AnsibleTower::AutomationManager::Job",
+        :key        => "ManageIQ::Providers::Awx::AutomationManager::Job_edit_tags__#{@cj.id}",
+        :tagging    => "ManageIQ::Providers::Awx::AutomationManager::Job",
         :object_ids => [@cj.id],
         :current    => {:assignments => []},
         :new        => {:assignments => [@tag1.id, @tag2.id]}
@@ -84,5 +84,5 @@ describe ConfigurationJobController do
     end
   end
 
-  include_examples '#download_summary_pdf', :ansible_tower_job
+  include_examples '#download_summary_pdf', :awx_job
 end


### PR DESCRIPTION
The `configuration_job_controller` should show all `ExternalAutomationManager` `OrchestrationStacks` not just `AnsibleTower` ones.

![image](https://github.com/user-attachments/assets/3b008282-fccc-476f-b028-6bd2cdc2fa71)
![image](https://github.com/user-attachments/assets/dcc52847-ef2b-4645-8844-795f5d5d8e69)


<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
