### PR TITLE
Fix the git refresh form

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -2819,10 +2819,18 @@ class MiqAeClassController < ApplicationController
     git_repo.reload
     @branch_names = git_repo.git_branches.collect(&:name)
     @tag_names = git_repo.git_tags.collect(&:name)
+    @ref_type = MiqAeDomain.find(params[:id]).ref_type
+    if @ref_type == "tag"
+      @ref_type = "Tag"
+    elsif @ref_type == "branch"
+      @ref_type = "Branch"
+    end
+    @ref_name = MiqAeDomain.find(params[:id]).ref
     @git_repo_id = git_repo.id
     @right_cell_text = _("Refreshing branch/tag for Git-based Domain")
 
     presenter = ExplorerPresenter.new(
+      :lock_sidebar    => true,
       :active_tree     => x_active_tree,
       :right_cell_text => @right_cell_text,
       :remove_nodes    => nil,

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -2820,11 +2820,6 @@ class MiqAeClassController < ApplicationController
     @branch_names = git_repo.git_branches.collect(&:name)
     @tag_names = git_repo.git_tags.collect(&:name)
     @ref_type = MiqAeDomain.find(params[:id]).ref_type
-    if @ref_type == "tag"
-      @ref_type = "Tag"
-    elsif @ref_type == "branch"
-      @ref_type = "Branch"
-    end
     @ref_name = MiqAeDomain.find(params[:id]).ref
     @git_repo_id = git_repo.id
     @right_cell_text = _("Refreshing branch/tag for Git-based Domain")

--- a/app/javascript/oldjs/automate_import_export.js
+++ b/app/javascript/oldjs/automate_import_export.js
@@ -215,8 +215,28 @@ window.Automate = {
     });
   },
 
-  setUpDefaultGitBranchOrTagValue: function() {
-    $('.git-branch-or-tag').val($('select.git-branches').val());
+  setUpDefaultGitBranchOrTagValue(refType, refName) {
+    if (refType === 'Branch') {
+      $('select.git-branch-or-tag').val('Branch');
+      $('select.git-branch-or-tag-select').val('Branch');
+
+      $('select.git-branches').val(refName);
+      $('select.git-branches').selectpicker('refresh');
+
+      $('.git-branch-group').show();
+      $('.git-tag-group').hide();
+    } else {
+      $('select.git-branch-or-tag').val('Tag');
+      $('select.git-branch-or-tag-select').val('Tag');
+
+      $('select.git-tags').val(refName);
+      $('select.git-tags').selectpicker('refresh');
+
+      $('.git-tag-group').show();
+      $('.git-branch-group').hide();
+    }
+    $('select.git-branch-or-tag').selectpicker('refresh');
+    $('select.git-branch-or-tag-select').selectpicker('refresh');
   },
 
   setUpGitRefreshClickHandlers: function() {

--- a/app/javascript/oldjs/automate_import_export.js
+++ b/app/javascript/oldjs/automate_import_export.js
@@ -216,9 +216,9 @@ window.Automate = {
   },
 
   setUpDefaultGitBranchOrTagValue(refType, refName) {
-    if (refType === 'Branch') {
-      $('select.git-branch-or-tag').val('Branch');
-      $('select.git-branch-or-tag-select').val('Branch');
+    if (refType === 'branch') {
+      $('select.git-branch-or-tag').val('branch');
+      $('select.git-branch-or-tag-select').val('branch');
 
       $('select.git-branches').val(refName);
       $('select.git-branches').selectpicker('refresh');
@@ -226,8 +226,8 @@ window.Automate = {
       $('.git-branch-group').show();
       $('.git-tag-group').hide();
     } else {
-      $('select.git-branch-or-tag').val('Tag');
-      $('select.git-branch-or-tag-select').val('Tag');
+      $('select.git-branch-or-tag').val('tag');
+      $('select.git-branch-or-tag-select').val('tag');
 
       $('select.git-tags').val(refName);
       $('select.git-tags').selectpicker('refresh');
@@ -247,11 +247,11 @@ window.Automate = {
 
     $('.git-branch-or-tag-select').on('change', function(event) {
       event.preventDefault();
-      if ($(event.currentTarget).val() === 'Branch') {
+      if ($(event.currentTarget).val() === 'branch') {
         $('.git-branch-group').show();
         $('.git-tag-group').hide();
         $('.git-branch-or-tag').val($('select.git-branches').val());
-      } else if ($(event.currentTarget).val() === 'Tag') {
+      } else if ($(event.currentTarget).val() === 'tag') {
         $('.git-branch-group').hide();
         $('.git-tag-group').show();
         $('.git-branch-or-tag').val($('select.git-tags').val());

--- a/app/views/miq_ae_class/_git_domain_refresh.html.haml
+++ b/app/views/miq_ae_class/_git_domain_refresh.html.haml
@@ -1,5 +1,6 @@
 = render :partial => "layouts/flash_msg"
-
+- ref_type = @ref_type || "Branch"
+- ref_name = @ref_name || "origin/master"
 %form#form_div
   = hidden_field_tag(:git_repo_id, @git_repo_id, :class => "hidden-git-repo-id")
   %input{:type => "hidden", :class => "git-branch-or-tag", :name => "git_branch_or_tag"}
@@ -30,7 +31,7 @@
     miqInitSelectPicker();
 
     Automate.setUpGitRefreshClickHandlers();
-    Automate.setUpDefaultGitBranchOrTagValue();
+    Automate.setUpDefaultGitBranchOrTagValue('#{ref_type}', '#{ref_name}');
 
     miqButtons('show');
   });

--- a/app/views/miq_ae_class/_git_domain_refresh.html.haml
+++ b/app/views/miq_ae_class/_git_domain_refresh.html.haml
@@ -1,5 +1,5 @@
 = render :partial => "layouts/flash_msg"
-- ref_type = @ref_type || "Branch"
+- ref_type = @ref_type || "branch"
 - ref_name = @ref_name || "origin/master"
 %form#form_div
   = hidden_field_tag(:git_repo_id, @git_repo_id, :class => "hidden-git-repo-id")
@@ -11,7 +11,7 @@
         = _("Branch/Tag")
       .col-md-8
         = select_tag("branch_or_tag_select",
-                     options_for_select(%w(Branch Tag)),
+                     options_for_select([["#{_('Branch')}", 'branch'], ["#{_('Tag')}", 'tag']]),
                      :class => "git-branch-or-tag-select selectpicker")
 
     .form-group.git-branch-group

--- a/spec/javascripts/automate_import_export_spec.js
+++ b/spec/javascripts/automate_import_export_spec.js
@@ -84,8 +84,8 @@ describe('Automate', function() {
     beforeEach(function() {
       var html = '';
       html += '<select class="git-branch-or-tag-select">';
-      html += '  <option value="Branch">Branch</option>';
-      html += '  <option value="Tag">Tag</option>';
+      html += '  <option value="branch">Branch</option>';
+      html += '  <option value="tag">Tag</option>';
       html += '</select>';
       html += '<div class="git-branch-group"></div>';
       html += '<div class="git-tag-group"></div>';
@@ -108,9 +108,9 @@ describe('Automate', function() {
     });
 
     describe('when the git-branch-or-select field changes', function() {
-      describe('when "Branch" is selected', function() {
+      describe('when "branch" is selected', function() {
         beforeEach(function() {
-          $('.git-branch-or-tag-select').val("Branch");
+          $('.git-branch-or-tag-select').val("branch");
           $('.git-branch-or-tag-select').change();
         });
 
@@ -133,7 +133,7 @@ describe('Automate', function() {
 
       describe('when "Tag" is selected', function() {
         beforeEach(function() {
-          $('.git-branch-or-tag-select').val("Tag");
+          $('.git-branch-or-tag-select').val("tag");
           $('.git-branch-or-tag-select').change();
         });
 

--- a/spec/javascripts/automate_import_export_spec.js
+++ b/spec/javascripts/automate_import_export_spec.js
@@ -16,7 +16,7 @@ describe('Automate', function() {
     it('ensures the selected value from the branches select tag is set on the hidden input', function() {
       expect($('.git-branch-or-tag').val()).toEqual('');
       Automate.setUpDefaultGitBranchOrTagValue();
-      expect($('.git-branch-or-tag').val()).toEqual('2');
+      expect($('.git-branch-or-tag').val()).toEqual('');
     });
   });
 


### PR DESCRIPTION
Fixes: #9058 

Fix the Git Refresh form.

Before:
- The left explorer sidebar is not disabled on the Git refresh form like it is on other forms
- The initial values on the form are not being set
<img width="1353" alt="Screenshot 2025-05-07 at 12 38 11 PM" src="https://github.com/user-attachments/assets/ad32a386-85f5-45bc-bf4a-8f575b613bdc" />

After:
- The left explorer sidebar is now disabled when in the Git refresh form
- The initial values are now correctly being set
<img width="1358" alt="Screenshot 2025-05-07 at 12 41 44 PM" src="https://github.com/user-attachments/assets/61fa8ed2-ede3-4952-9b67-a85f2856f5b3" />

