### PR TITLE
Fix inline method automplete issue

### DIFF
--- a/app/views/miq_ae_class/_method_inputs.html.haml
+++ b/app/views/miq_ae_class/_method_inputs.html.haml
@@ -80,5 +80,5 @@
             %tr
               %td= record_name(record)
               %td= record.datatype.blank? ? 'string' : record.datatype
-              %td
+              %td{:autocomplete => "off"}
                 = record.datatype == 'password' ? '********' : record.default_value


### PR DESCRIPTION
Turn autocomplete off on the inline method input parameters form.