### PR TITLE
Explain why we have two script text converters

### DIFF
--- a/app/javascript/oldjs/jquery_overrides.js
+++ b/app/javascript/oldjs/jquery_overrides.js
@@ -24,6 +24,19 @@ jQuery.jsonPayload = function(text, fallback) {
 };
 
 $.ajaxSetup({
+  /* Define two script converters:
+
+  1) script - This is the original converter to evaluate scripts for successful responses.
+  2) miq_script - Define a duplicate but differently named script converter whose purpose is to
+  evaluate scripts for unsuccessful ajax responses.  jQuery 3.5.0 changed the behavior of the script
+  converter, replacing it with a no-op converter for scripts found in unsuccessful ajax responses.
+  Successful responses would continue to be evaluated as previously.
+  See: https://github.com/jquery/jquery/commit/da3dd85b63c4e3a6a768132c2a83a1a6eec24840
+
+  Due to this change starting in 3.5.0, we define a new type of script we can set as the dataType
+  so it's evaluated in the event of unsuccessful responses such as the SSO 401 unauthorized
+  issue we attempted to fix in #9410 and subsequently completed in #9426.
+  */
   accepts: {
     json: 'text/javascript, application/javascript, application/ecmascript, application/x-ecmascript',
   },


### PR DESCRIPTION
Define two script converters:

1) script - This is the original converter to evaluate scripts for successful responses.
2) miq_script - Define a duplicate but differently named script converter whose purpose is to evaluate scripts for unsuccessful ajax responses.  jQuery 3.5.0 changed the behavior of the script converter, replacing it with a no-op converter for scripts found in unsuccessful ajax responses. Successful responses would continue to be evaluated as previously. See: https://github.com/jquery/jquery/commit/da3dd85b63c4e3a6a768132c2a83a1a6eec24840
Due to this change starting in 3.5.0, we define a new type of script we can set as the dataType so it's evaluated in the event of unsuccessful responses such as the SSO 401 unauthorized issue we attempted to fix in #9410 and subsequently completed in #9426.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
