### PR TITLE
Remove console log from jquery override

### DIFF
--- a/app/javascript/oldjs/jquery_overrides.js
+++ b/app/javascript/oldjs/jquery_overrides.js
@@ -59,7 +59,6 @@ $.ajaxSetup({
       return text;
     }),
     'text script': logError(function(text) {
-      console.log(text);
       if (text.match(/^{/)) {
         return jQuery.jsonPayload(text, function(text) {
           return text;


### PR DESCRIPTION
Remove console log from jquery override. This was accidentally added from this pr: https://github.com/ManageIQ/manageiq-ui-classic/pull/9426