### PR TITLE
Fix Settings Tag Category Edit Page

### DIFF
--- a/app/controllers/ops_controller/settings/tags.rb
+++ b/app/controllers/ops_controller/settings/tags.rb
@@ -69,7 +69,12 @@ module OpsController::Settings::Tags
     category = Classification.find(params[:id])
     add_flash(_("Category \"%{name}\" was saved") % {:name => category.name})
     get_node_info(x_node)
-    replace_right_cell(:nodetype => "root")
+    render :update do |page|
+      page << javascript_prologue
+      page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+      page << "miqScrollTop();" if @flash_array.present?
+      page.replace_html('my_company_categories', :partial => 'settings_my_company_categories_tab')
+    end
   end
 
   def category_form


### PR DESCRIPTION
Fix the Settings Tag Category edit page save button. Before clicking save will not return back to the list screen and throws error `#settings_my_company_categories does not exist in the DOM` in the console.

Before:
<img width="1626" alt="Screenshot 2025-05-15 at 10 30 24 AM" src="https://github.com/user-attachments/assets/2a0b919b-9963-46e8-b99b-15cbf29bd775" />

After:
<img width="1612" alt="Screenshot 2025-05-15 at 10 33 37 AM" src="https://github.com/user-attachments/assets/a506a7ba-2037-406e-9dc8-cc64a96e36b3" />

