### PR TITLE
Drop j_str helper method

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -195,8 +195,8 @@ class ApplicationController < ActionController::Base
           page << "
             sendDataWithRx({
               serverError: {
-                data: '#{j_str message}',
-                url: '#{j_str request.url}',
+                data: '#{j message}',
+                url: '#{j request.url}',
               },
               source: 'server',
             });

--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -140,8 +140,8 @@ module ApplicationController::MiqRequestMethods
       @edit = session[:edit]
       render :update do |page|
         page << javascript_prologue
-        page << "$('#row_#{j_str(@edit[:src_vm_id])}').removeClass('selected');" if @edit[:src_vm_id]
-        page << "$('#row_#{j_str(params[:sel_id])}').addClass('selected');"
+        page << "$('#row_#{j(@edit[:src_vm_id])}').removeClass('selected');" if @edit[:src_vm_id]
+        page << "$('#row_#{j(params[:sel_id])}').addClass('selected');"
         session[:changed] = true
         page << javascript_for_miq_button_visibility(session[:changed])
         @edit[:src_vm_id] = params[:sel_id].to_i

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -777,7 +777,7 @@ module OpsController::OpsRbac
         page.replace("customer_tags_div", :partial => "ops/rbac_group/customer_tags") if params[:use_filter_expression].present?
 
         # Only update description field value if ldap group user field was selected
-        page << "$('#description').val('#{j_str(@edit[:new][:ldap_groups_user])}');" if params[:ldap_groups_user]
+        page << "$('#description').val('#{j(@edit[:new][:ldap_groups_user])}');" if params[:ldap_groups_user]
 
         # don't do anything to lookup box when checkboxes on the right side are checked
         page << set_element_visible('group_lookup', @edit[:new][:lookup]) unless params[:check]

--- a/app/controllers/ops_controller/settings/analysis_profiles.rb
+++ b/app/controllers/ops_controller/settings/analysis_profiles.rb
@@ -71,8 +71,8 @@ module OpsController::Settings::AnalysisProfiles
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         page << "miqScrollTop();" if @flash_array.present?
         page.replace_html("ap_form_div", :partial => "ap_form", :locals => {:entry => session[:edit_filename], :edit => true})
-        page << javascript_focus("entry_#{j_str(params[:field])}")
-        page << "$('#entry_#{j_str(params[:field])}').select();"
+        page << javascript_focus("entry_#{j(params[:field])}")
+        page << "$('#entry_#{j(params[:field])}').select();"
       end
     elsif params[:edit_entry] == "edit_registry"
       session[:reg_data] = {}
@@ -83,8 +83,8 @@ module OpsController::Settings::AnalysisProfiles
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         page << "miqScrollTop();" if @flash_array.present?
         page.replace("ap_form_div", :partial => "ap_form", :locals => {:entry => session[:reg_data], :edit => true})
-        page << javascript_focus("entry_#{j_str(params[:field])}")
-        page << "$('#entry_#{j_str(params[:field])}').select();"
+        page << javascript_focus("entry_#{j(params[:field])}")
+        page << "$('#entry_#{j(params[:field])}').select();"
       end
     elsif params[:edit_entry] == "edit_nteventlog"
       session[:nteventlog_data] = {}
@@ -104,8 +104,8 @@ module OpsController::Settings::AnalysisProfiles
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         page << "miqScrollTop();" if @flash_array.present?
         page.replace("ap_form_div", :partial => "ap_form", :locals => {:entry => session[:nteventlog_data], :edit => true})
-        page << javascript_focus("entry_#{j_str(params[:field])}")
-        page << "$('#entry_#{j_str(params[:field])}').select();"
+        page << javascript_focus("entry_#{j(params[:field])}")
+        page << "$('#entry_#{j(params[:field])}').select();"
       end
     else
       session[:edit_filename] = ""

--- a/app/controllers/ops_controller/settings/tags.rb
+++ b/app/controllers/ops_controller/settings/tags.rb
@@ -151,8 +151,8 @@ module OpsController::Settings::Tags
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         page << "miqScrollTop();" if @flash_array.present?
         page.replace("classification_entries_div", :partial => "classification_entries", :locals => {:entry => entry, :edit => true})
-        page << javascript_focus("entry_#{j_str(params[:field])}")
-        page << "$('#entry_#{j_str(params[:field])}').select();"
+        page << javascript_focus("entry_#{j(params[:field])}")
+        page << "$('#entry_#{j(params[:field])}').select();"
       end
       session[:entry] = entry
     end

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -76,7 +76,7 @@ module VmCommon
       javascript_flash(:spinner_off => true)
     else
       options
-      "$(\"##{h(@refresh_div)}\").replaceWith(\"#{escape_javascript(render(:partial => "vm_common/#{@refresh_partial}"))}\");".html_safe
+      "$(\"##{h(@refresh_div)}\").replaceWith(\"#{j(render(:partial => "vm_common/#{@refresh_partial}"))}\");".html_safe
     end
   end
 

--- a/app/helpers/js_helper.rb
+++ b/app/helpers/js_helper.rb
@@ -9,47 +9,40 @@ module JsHelper
     'miqSparkleOff();'
   end
 
-  # safe variant of j/escape_javascript that calls .to_s to work with non-string values
-  def j_str(value)
-    j(value.to_s)
-  end
-
   def javascript_focus(element)
-    "$('##{j_str(element)}').focus();".html_safe
+    "$('##{j(element)}').focus();".html_safe
   end
 
   def javascript_disable_field(element)
-    "$('##{j_str(element)}').prop('disabled', true);".html_safe
+    "$('##{j(element)}').prop('disabled', true);".html_safe
   end
 
   def javascript_enable_field(element)
-    "$('##{j_str(element)}').prop('disabled', false);".html_safe
+    "$('##{j(element)}').prop('disabled', false);".html_safe
   end
 
   def javascript_show(element)
-    "$('##{j_str(element)}').show();".html_safe
+    "$('##{j(element)}').show();".html_safe
   end
 
   def javascript_hide(element)
-    "$('##{j_str(element)}').hide();".html_safe
+    "$('##{j(element)}').hide();".html_safe
   end
 
   def javascript_show_if_exists(element)
-    "if (miqDomElementExists('#{j_str(element)}')) #{javascript_show(element)}".html_safe
+    "if (miqDomElementExists('#{j(element)}')) #{javascript_show(element)}".html_safe
   end
 
   def javascript_hide_if_exists(element)
-    "if (miqDomElementExists('#{j_str(element)}')) #{javascript_hide(element)}".html_safe
+    "if (miqDomElementExists('#{j(element)}')) #{javascript_hide(element)}".html_safe
   end
 
   def javascript_checked(element)
-    "if ($('##{j_str(element)}').prop('type') == 'checkbox') {$('##{j_str(element)}').prop('checked', true);}"
-      .html_safe
+    "if ($('##{j(element)}').prop('type') == 'checkbox') {$('##{j(element)}').prop('checked', true);}".html_safe
   end
 
   def javascript_unchecked(element)
-    "if ($('##{j_str(element)}').prop('type') == 'checkbox') {$('##{j_str(element)}').prop('checked', false);}"
-      .html_safe
+    "if ($('##{j(element)}').prop('type') == 'checkbox') {$('##{j(element)}').prop('checked', false);}".html_safe
   end
 
   def js_build_calendar(options = {})
@@ -60,7 +53,7 @@ module JsHelper
       ManageIQ.calendar.calDateTo = #{js_format_date(options[:date_to])};
       ManageIQ.calendar.calSkipDays = #{skip_days};
       miqBuildCalendar();
-EOD
+    EOD
   end
 
   # JSONP request access prevention

--- a/app/views/configuration/_ui_3.html.haml
+++ b/app/views/configuration/_ui_3.html.haml
@@ -7,12 +7,12 @@
       = _('Filters')
     = _('(Checked default filters will be visible.)')
     %br{:style => "line-height: 2.5em"}
-    .btn.btn-default{:id => "squash_button", :onclick => "miqSquashToggle('#{j_str(@df_tree.name.to_s)}')", :title => _('Expand All')}
+    .btn.btn-default{:id => "squash_button", :onclick => "miqSquashToggle('#{j(@df_tree.name.to_s)}')", :title => _('Expand All')}
       %i{:class => "fa fa-plus-square-o fa-lg"}
     - tree_id = "#{@df_tree.name}box"
     %br{:style => "line-height: 2.5em"}
     :javascript
-      miqTreeResetState('#{j_str @df_tree.name}');
+      miqTreeResetState('#{j @df_tree.name}');
     %div{:id => "#{tree_id}", :style => "color:#000; height:100%"}
       = render(:partial => 'shared/tree', :locals => {:tree => @df_tree, :name => @df_tree.name})
 

--- a/app/views/dashboard/oidc_login.html.haml
+++ b/app/views/dashboard/oidc_login.html.haml
@@ -8,7 +8,7 @@
     - if validation_url
       :javascript
         miqFlashClearSaved();
-        window.location = '#{j_str validation_url}';
+        window.location = '#{j validation_url}';
     - else
       :javascript
         miqFlashClearSaved();

--- a/app/views/dashboard/saml_login.html.haml
+++ b/app/views/dashboard/saml_login.html.haml
@@ -8,7 +8,7 @@
     - if validation_url
       :javascript
         miqFlashClearSaved();
-        window.location = '#{j_str validation_url}';
+        window.location = '#{j validation_url}';
     - else
       :javascript
         miqFlashClearSaved();

--- a/app/views/layouts/_protect.html.haml
+++ b/app/views/layouts/_protect.html.haml
@@ -5,7 +5,7 @@
     = render :partial => 'layouts/info_msg', :locals => {:message => _("No Policy Profiles available.")}
   - else
     :javascript
-      miqTreeResetState('#{j_str @protect_tree.name}');
+      miqTreeResetState('#{j @protect_tree.name}');
     = render(:partial => 'shared/tree', :locals => {:tree => @protect_tree, :name => @protect_tree.name})
   %br
   - if @politems.length > 1

--- a/app/views/layouts/_textual_groups_generic.html.haml
+++ b/app/views/layouts/_textual_groups_generic.html.haml
@@ -2,6 +2,6 @@
 - if respond_to?(:textual_summary_flash_list)
   - process_flash_messages(textual_summary_flash_list).each do |flash|
     :javascript
-      add_flash("#{j_str(flash[:message])}", "#{j_str(flash[:level])}")
+      add_flash("#{j(flash[:message])}", "#{j(flash[:level])}")
 #textual_summary
   = react('TextualSummaryWrapper', {:options => @options, :summary => process_textual_info(textual_group_list, @record)})

--- a/app/views/layouts/listnav/_compare_sections.html.haml
+++ b/app/views/layouts/listnav/_compare_sections.html.haml
@@ -3,7 +3,7 @@
 .panel-group{:style => style}
   = miq_accordion_panel(@lastaction == "drift" ? _("Drift Sections") : _("Comparison Sections"), true, "sections") do
     :javascript
-      miqTreeResetState('#{j_str @sections_tree.name}');
+      miqTreeResetState('#{j @sections_tree.name}');
     = render(:partial => 'shared/tree', :locals => {:tree => @sections_tree, :name => @sections_tree.name})
   .spacer
   %table{:width => "100%"}

--- a/app/views/miq_policy_rsop/_rsop_results.html.haml
+++ b/app/views/miq_policy_rsop/_rsop_results.html.haml
@@ -41,7 +41,7 @@
             = _("red italics")
         = _("do not change the outcome of the scope or expression")
       %br{:style => "line-height: 2.5em"}
-      .btn.btn-default{:id => "squash_button", :onclick => "miqSquashToggle('#{j_str(@rsop_tree.name.to_s)}')", :title => _('Collapse All')}
+      .btn.btn-default{:id => "squash_button", :onclick => "miqSquashToggle('#{j(@rsop_tree.name.to_s)}')", :title => _('Collapse All')}
         %i{:class => "fa fa-minus-square-o fa-lg"}
       %br{:style => "line-height: 2.5em"}
       = render(:partial => 'shared/tree', :locals => {:tree => @rsop_tree, :name => @rsop_tree.name})

--- a/app/views/ops/_settings_cu_collection_tab.html.haml
+++ b/app/views/ops/_settings_cu_collection_tab.html.haml
@@ -30,7 +30,7 @@
                   %b= _("Enable Collection by Cluster")
                   %br/
                   :javascript
-                    miqTreeResetState('#{j_str @cluster_tree.name}');
+                    miqTreeResetState('#{j @cluster_tree.name}');
                   = render(:partial => 'shared/tree', :locals => {:tree => @cluster_tree, :name => @cluster_tree.name})
                   %br/
                   .note= _("VM data will be collected for VMs under selected Hosts only. Data is collected for a Cluster and all of its Hosts when at least one Host is selected.")
@@ -59,7 +59,7 @@
                   %b= _("Enable Collection by Datastore")
                   %br/
                   :javascript
-                    miqTreeResetState('#{j_str @datastore_tree.name}');
+                    miqTreeResetState('#{j @datastore_tree.name}');
                   = render(:partial => 'shared/tree', :locals => {:tree => @datastore_tree, :name => @datastore_tree.name})
             - else
               .note

--- a/app/views/ops/_smartproxy_affinity.html.haml
+++ b/app/views/ops/_smartproxy_affinity.html.haml
@@ -7,5 +7,5 @@
       = _("No Servers with the SmartProxy role are in Zone: \"%{zone_description}\"") % {:zone_description => @selected_zone.description}
 - else
   :javascript
-    miqTreeResetState('#{j_str @smartproxy_affinity_tree.name}');
+    miqTreeResetState('#{j @smartproxy_affinity_tree.name}');
   = render(:partial => 'shared/tree', :locals => {:tree => @smartproxy_affinity_tree, :name => @smartproxy_affinity_tree.name})

--- a/app/views/shared/_file_chooser.html.haml
+++ b/app/views/shared/_file_chooser.html.haml
@@ -7,4 +7,4 @@
 - placeholder = _("No file chosen")
 - button_text = _("Choose file")
 :javascript
-  $(":file").filestyle({icon: false, placeholder: "#{j_str placeholder}", buttonText: "#{j_str button_text}"});
+  $(":file").filestyle({icon: false, placeholder: "#{j placeholder}", buttonText: "#{j button_text}"});

--- a/app/views/shared/dialogs/_dialog_user.html.haml
+++ b/app/views/shared/dialogs/_dialog_user.html.haml
@@ -26,7 +26,7 @@
   ManageIQ.angular.app.value('dialogId', '#{dialog_id}');
   ManageIQ.angular.app.value('finishSubmitEndpoint', '#{finish_submit_endpoint}');
   ManageIQ.angular.app.value('apiSubmitEndpoint', '#{api_submit_endpoint}');
-  ManageIQ.angular.app.value('apiAction', '#{j_str(api_action)}');
+  ManageIQ.angular.app.value('apiAction', '#{j(api_action)}');
   ManageIQ.angular.app.value('cancelEndpoint', '#{cancel_endpoint}');
   ManageIQ.angular.app.value('openUrl', '#{open_url}');
   ManageIQ.angular.app.value('dialogReplaceData', '#{@dialog_replace_data}');

--- a/app/views/shared/views/_compliance_history.html.haml
+++ b/app/views/shared/views/_compliance_history.html.haml
@@ -1,6 +1,6 @@
 #compliance_history_div
   = render :partial => "layouts/flash_msg"
-  .btn.btn-default{:id => "squash_button", :onclick => "miqSquashToggle('#{j_str(@ch_tree.name.to_s)}')", :title => _('Expand All')}
+  .btn.btn-default{:id => "squash_button", :onclick => "miqSquashToggle('#{j(@ch_tree.name.to_s)}')", :title => _('Expand All')}
     %i{:class => "fa fa-plus-square-o fa-lg"}
   %br{:style => "line-height: 2.5em"}
   %div

--- a/app/views/vm_common/_policies.html.haml
+++ b/app/views/vm_common/_policies.html.haml
@@ -5,7 +5,7 @@
   %h3
     = _('Policy Simulation Details')
 
-  .btn.btn-default{:id => "squash_button", :onclick => "miqSquashToggle('#{j_str(@policy_simulation_tree.name.to_s)}')", :title => _('Collapse All')}
+  .btn.btn-default{:id => "squash_button", :onclick => "miqSquashToggle('#{j(@policy_simulation_tree.name.to_s)}')", :title => _('Collapse All')}
     %i{:class => "fa fa-minus-square-o fa-lg"}
 
   = render(:partial => 'shared/tree', :locals => {:tree => @policy_simulation_tree, :name => @policy_simulation_tree.name})


### PR DESCRIPTION
This method was added as a wrapper around the Rails `j` method to handle non-string types. However, this feature was added in the Rails `j` method as of Rails 6.0.0-rc1 in rails/rails@dd0cfb03, and so is redundant.

This commit switches everything to the `j` method to be Rails idiomatic.

@jrafanie @GilbertCherrie Please review.