### PR TITLE
Fix wait_for_task comparison of String with 5000

### DIFF
--- a/app/controllers/application_controller/wait_for_task.rb
+++ b/app/controllers/application_controller/wait_for_task.rb
@@ -25,7 +25,7 @@ module ApplicationController::WaitForTask
 
   def browser_refresh_task(task_id, async_interval, should_flash: false)
     async_interval = 1000 if async_interval.to_i < 1000 # if it is not an integer, assign to 1 second
-    async_interval += 250 if async_interval < 5000 # Slowly move up to 5 second retries
+    async_interval += 250 if async_interval.to_i < 5000 # Slowly move up to 5 second retries
     render :update do |page|
       page << javascript_prologue
       ajax_call = remote_function(:url => {:action => 'wait_for_task', :task_id => task_id, :async_interval => async_interval})


### PR DESCRIPTION
If the `async_interval` is over `1000` and a string then the `async_interval += 250 if async_interval < 5000` will throw an exception.

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/9443

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
