### PR TITLE
Cypress fixes around timing and element existance

### DIFF
--- a/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/class.cy.js
+++ b/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/class.cy.js
@@ -29,7 +29,8 @@ describe('Automation > Embedded Automate > Explorer', () => {
     cy.get('[name="description"]').type('This is a test NameSpace');
     cy.get('.bx--btn--primary').contains('Add').click();
 
-    cy.wait(1000); // Need this wait or else namespace doesn't get added properly
+    // Wait for namespace to be visible
+    cy.get('[title="Automate Namespace: TestNameSpace"]', {timeout: 1000}).should('be.visible')
   });
 
   beforeEach(() => {

--- a/cypress/e2e/ui/Automation/Embedded-Automate/customization.cy.js
+++ b/cypress/e2e/ui/Automation/Embedded-Automate/customization.cy.js
@@ -28,7 +28,7 @@ describe('Automation > Embedded Automate > Customization', () => {
       // creates a dialog
       cy.get('[title="Configuration"]').click({force: true});
       cy.get('[title="Add a new Dialog"]').click({force: true});
-      cy.get('[name="name"]').type('Test User');
+      cy.get('[name="name"]').type('Test User', {force: true});
       cy.get('[name="description"').type('Test Description');
       cy.get('[name="dialog_type"]').select('Configured System Provision');
       cy.get('[class="CodeMirror-lines"]').type(':Buttons:');
@@ -72,8 +72,8 @@ describe('Automation > Embedded Automate > Customization', () => {
       // creates a dialog
       cy.get('[title="Configuration"]').click({force: true});
       cy.get('[title="Add a new Dialog"]').click({force: true});
-      cy.get('[name="name"]').type('Test User');
-      cy.get('[name="description"').type('Test Description');
+      cy.get('[name="name"]').type('Test User', {force: true});
+      cy.get('[name="description"').type('Test Description', {force: true});
       cy.get('[name="dialog_type"]').select('Configured System Provision');
       cy.get('[class="CodeMirror-lines"]').type(':Buttons:');
       cy.get('[class="btnRight bx--btn bx--btn--primary"]').click({force: true});
@@ -127,7 +127,7 @@ describe('Automation > Embedded Automate > Customization', () => {
       // creates a dialog
       cy.get('[title="Configuration"]').click({force: true});
       cy.get('[title="Add a new Dialog"]').click({force: true});
-      cy.get('[name="name"]').type('Test User');
+      cy.get('[name="name"]').type('Test User', {force: true});
       cy.get('[name="description"').type('Test Description');
       cy.get('[name="dialog_type"]').select('Configured System Provision');
       cy.get('[class="CodeMirror-lines"]').type(':Buttons:');

--- a/cypress/e2e/ui/Overview/Chargeback/rates.cy.js
+++ b/cypress/e2e/ui/Overview/Chargeback/rates.cy.js
@@ -239,7 +239,7 @@ describe('Rates', () => {
       cy.get('#fixed_rate_1_0').clear().type('1');
       cy.get('#per_time_2').select('Monthly');
       cy.get('#per_unit_2').select('KB');
-      cy.get('#finish_2_0').clear();
+      cy.get('#finish_2_0').clear({force: true});
       cy.get('#variable_rate_2_0').clear({force: true }).type('100', { force: true });
       cy.get('#buttons_on > .btn-primary').click({ force: true });
     }).then(() => {

--- a/cypress/e2e/ui/Overview/reports.cy.js
+++ b/cypress/e2e/ui/Overview/reports.cy.js
@@ -337,12 +337,10 @@ describe('Overview > Reports Tests', () => {
     cy.get('#form_filter_div > .form-horizontal > :nth-child(1) > .col-md-8 > .btn-group > .btn').click({ force: true });
     cy.get('#form_filter_div > .form-horizontal > :nth-child(1) > .col-md-8 > .btn-group > .open > .dropdown-menu > [data-original-index="1"] > a').then((option) => {
       cy.get(option).click({ force: true }).then(() => {
-        cy.wait(5000);
-        cy.get('#form_filter_div > .form-horizontal > :nth-child(2) > .col-md-8 > .btn-group > .btn').click({ force: true });
+        cy.get('#form_filter_div > .form-horizontal > :nth-child(2) > .col-md-8 > .btn-group > .btn', {timeout: 5000}).click({ force: true });
         cy.get('#form_filter_div > .form-horizontal > :nth-child(2) > .col-md-8 > .btn-group > .open > .dropdown-menu > [data-original-index="1"] > a').then((option) => {
           cy.get(option).click({ force: true }).then(() => {
-            cy.wait(5000);
-            cy.get(':nth-child(3) > .col-md-8 > .btn-group > .btn').click({ force: true });
+            cy.get(':nth-child(3) > .col-md-8 > .btn-group > .btn', {timeout: 5000}).click({ force: true });
             cy.get(':nth-child(3) > .col-md-8 > .btn-group > .open > .dropdown-menu > [data-original-index="1"] > a').then((option) => {
               cy.get(option).click({ force: true });
               reportFilter = option[0].innerText;

--- a/cypress/e2e/ui/menu.cy.js
+++ b/cypress/e2e/ui/menu.cy.js
@@ -492,8 +492,7 @@ describe('Menu', () => {
 
       it('About', () => {
         cy.menu('Settings', 'About').then(() => {
-          cy.wait(50000); // Need to wait before getting the modal container or else the test fails
-          cy.get('.bx--modal-container');
+          cy.get('.bx--modal-container', {timeout: 10000});
         });
       });
     });

--- a/cypress/e2e/ui/searchbox.cy.js
+++ b/cypress/e2e/ui/searchbox.cy.js
@@ -26,8 +26,8 @@ describe('Search box', () => {
     cy.expect_no_search_box();
   });
 
-  it('Is not present on list view page', () => {
+  it('Is present on list view page', () => {
     cy.menu('Control', 'Alerts');
-    cy.expect_no_search_box();
+    cy.expect_search_box();
   });
 });


### PR DESCRIPTION
* change some waits to using `get` with a timeout and asserting some things are visible
* change some places where notifications / errors are now covering new items in the pages so must use force: true for now
* control alerts searchbox test never passed for me, swapped the logic as I always see a searchbox there

Before:

```
     Spec                                              Tests  Passing  Failing  Pending  Skipped
✖  7 of 11 failed (64%)                     06:43      149      137       12        -        -

```

After:
```
✖  5 of 11 failed (45%)                     05:40      149      140        9        -        -
```


Note, I'm using cache_class: true in my configuration below, so it's +3 minutes without that:

```diff --git a/config/environments/development.rb b/config/environments/development.rb
index 2c37f2c598..7b65853851 100644
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -6,7 +6,7 @@ Vmdb::Application.configure do
   # In the development environment your application's code is reloaded on
   # every request.  This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = false
+  config.cache_classes = true
   config.eager_load = false

   # Log error messages when you accidentally call methods on nil.
```