### PR TITLE
Cypress fixes 2 - fix test text assertions to match prior code changes

### DIFF
--- a/cypress/e2e/ui/menu.cy.js
+++ b/cypress/e2e/ui/menu.cy.js
@@ -381,7 +381,9 @@ describe('Menu', () => {
         });
 
         it('Simulation', () => {
-          cy.menu('Automation', 'Embedded Automate', 'Simulation').expect_explorer_title('Simulation');
+          // TODO: change the simulation page to use the correct class so we can use explorer_title_text or expect_show_list_title
+          cy.menu('Automation', 'Embedded Automate', 'Simulation');
+          cy.get('div.simulation-title-text').contains('Simulation');
         });
 
         it('Generic Objects', () => {

--- a/cypress/e2e/ui/menu.cy.js
+++ b/cypress/e2e/ui/menu.cy.js
@@ -339,11 +339,11 @@ describe('Menu', () => {
         });
 
         it('Templates', () => {
-          cy.menu('Automation', 'Automation', 'Templates').expect_show_list_title('Templates (Ansible Tower)');
+          cy.menu('Automation', 'Automation', 'Templates').expect_show_list_title('Templates');
         });
 
         it('Jobs', () => {
-          cy.menu('Automation', 'Automation', 'Jobs').expect_show_list_title('Ansible Tower Jobs');
+          cy.menu('Automation', 'Automation', 'Jobs').expect_show_list_title('Automation Jobs');
         });
       });
 


### PR DESCRIPTION
*    Simulation was converted to react, not following selector naming
   See: d560e2842d77e718

    We should use explorer_title_text or #main-content h1 so we can use
    can use the existing helpers to find the title text easily.

    For now, look for simulation-title-text to match the change above.

*    Ansible Tower was renamed in d472432
