### PR TITLE
Disable miq_debug for cypress for now

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -35,6 +35,7 @@ jobs:
         - 11211:11211
     env:
       TEST_SUITE: spec:cypress
+      CYPRESS: true
       CYPRESS_BROWSER: ${{ matrix.cypress-browser }}
       PGHOST: localhost
       PGPASSWORD: smartvm

--- a/app/javascript/oldjs/application.js
+++ b/app/javascript/oldjs/application.js
@@ -31,7 +31,7 @@ require('./miq_toolbar.js');
 require('./miq_c3.js');
 require('./miq_explorer.js');
 
-if (process.env.NODE_ENV === 'development') {
+if (process.env.NODE_ENV === 'development' && process.env.CYPRESS !== 'true') {
   require('./miq_debug.js');
   require('./miq_debug.css');
 }


### PR DESCRIPTION
This should allow us to remove a lot of the force: true we had to add for many DOM elements near the top of the page as the notifications could cover these elements and various cypress interactions with covered elements would fail.

Note, we'll need to figure out how to test notifications differently.

Related to changes in https://github.com/ManageIQ/manageiq/pull/23461
