### PR TITLE
Fix simulation form and its cypress tests

### DIFF
--- a/app/javascript/components/automate-simulation-form/automate-simulation-form.schema.js
+++ b/app/javascript/components/automate-simulation-form/automate-simulation-form.schema.js
@@ -12,7 +12,7 @@ const loadTargets = (selectedTargetClass) => http.get(targetsURL(selectedTargetC
         })),
       ];
     }
-    return [];
+    return [{ label: `<${__('None')}>`, value: '-1' }];
   });
 
 const createSchema = (

--- a/cypress/e2e/ui/Embedded-Automate/simulation.cy.js
+++ b/cypress/e2e/ui/Embedded-Automate/simulation.cy.js
@@ -12,9 +12,9 @@ describe('Automation > Embedded Automate > Simulation', () => {
     it('Resets the form', () => {
       cy.get('#object_request').type('Test Request');
       cy.get('#target_class').click();
-      cy.get('[class="bx--list-box__menu-item__option"]').contains('Availability Zone').click({force: true});
+      cy.get('[class="bx--list-box__menu-item__option"]').contains('User').click({force: true});
 
-      cy.get('#selection_target').select('asia-northeast2-a');
+      cy.get('#selection_target').select('Administrator');
       cy.get('#left_div').scrollTo('bottom');
       cy.contains('button', 'Reset').click();
 
@@ -26,9 +26,9 @@ describe('Automation > Embedded Automate > Simulation', () => {
     it('Submits the form', () => {
       cy.get('#object_request').type('Test Request');
       cy.get('#target_class').click();
-      cy.get('[class="bx--list-box__menu-item__option"]').contains('Availability Zone').click({force: true});
+      cy.get('[class="bx--list-box__menu-item__option"]').contains('User').click({force: true});
 
-      cy.get('#selection_target').select('asia-northeast2-a');
+      cy.get('#selection_target').select('Administrator');
       cy.get('#left_div').scrollTo('bottom');
 
       cy.get('[name="attribute_1"]').type('attribute 1');
@@ -45,7 +45,7 @@ describe('Automation > Embedded Automate > Simulation', () => {
     });
     it('Loads the second dropdown', () => {
       cy.get('#target_class').click();
-      cy.get('[class="bx--list-box__menu-item__option"]').contains('Availability Zone').click({force: true});
+      cy.get('[class="bx--list-box__menu-item__option"]').contains('User').click({force: true});
       cy.get('#selection_target').should('exist');
     });
   });


### PR DESCRIPTION
Fix issues with the simulation form and its Cypress tests. Fixes a bug where the Selection field has no options when the field has no valid options. Also, this PR fixes issues with the Cypress tests. The Cypress tests are meant to run on an empty database and currently they rely on values from a populated database. This PR ensures the tests pass on an empty database.

Before:
<img width="1351" alt="Screenshot 2025-05-26 at 1 17 08 PM" src="https://github.com/user-attachments/assets/16707ad8-c74b-4436-9976-00e99b03ce75" />

After:
<img width="1351" alt="Screenshot 2025-05-26 at 1 13 12 PM" src="https://github.com/user-attachments/assets/55d32ddf-5476-47e3-bc62-049ef0030957" />
