### PR TITLE
Drop Tenant#use_config_for_attributes

### DIFF
--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -751,7 +751,7 @@ class OpsController < ApplicationController
     presenter[:right_cell_text] = @right_cell_text
     presenter[:osf_node] = x_node
     presenter.reset_one_trans
-    presenter.focus('server_company')
+    presenter.focus('server_name')
     presenter[:ajax_action] = {
       :controller => controller_name,
       :action     => @ajax_action,

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -433,7 +433,6 @@ module OpsController::Settings::Common
           add_flash(_("Configuration settings saved"))
         end
         if @sb[:active_tab] == "settings_server" && @sb[:selected_server_id] == MiqServer.my_server.id # Reset session variables for names fields, if editing current server config
-          session[:customer_name] = @update[:server][:company]
           session[:vmdb_name] = @update[:server][:name]
         end
         set_user_time_zone if @sb[:active_tab] == "settings_server"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1332,9 +1332,7 @@ module ApplicationHelper
 
   # Return a proper column for an appropriate target klass
   def columns_for_klass(klass)
-    if klass == 'Tenant'
-      [:name, :use_config_for_attributes]
-    elsif klass.safe_constantize.column_names.include?('name')
+    if klass.safe_constantize.column_names.include?('name')
       [:name]
     else
       [:description]

--- a/app/javascript/components/ops-tenant-form/ops-tenant-form.jsx
+++ b/app/javascript/components/ops-tenant-form/ops-tenant-form.jsx
@@ -19,7 +19,7 @@ const OpsTenantForm = ({
   useEffect(() => {
     if (recordId) {
       miqSparkleOn();
-      API.get(`/api/tenants/${recordId}?expand=resources&attributes=name,description,use_config_for_attributes,ancestry,divisible`)
+      API.get(`/api/tenants/${recordId}?expand=resources&attributes=name,description,ancestry,divisible`)
         .then(setInitialValues)
         .then(() => {
           miqSparkleOff();
@@ -78,7 +78,7 @@ const OpsTenantForm = ({
     <div>
       <MiqFormRenderer
         initialValues={initialValues}
-        schema={createSchema(!recordId, !initialValues.ancestry, ancestry || initialValues.ancestry, initialValues.id)}
+        schema={createSchema(!recordId, ancestry || initialValues.ancestry, initialValues.id)}
         onSubmit={handleSubmit}
         onCancel={handleCancel}
         canReset={!!recordId}

--- a/app/javascript/components/ops-tenant-form/ops-tenant-form.schema.js
+++ b/app/javascript/components/ops-tenant-form/ops-tenant-form.schema.js
@@ -16,7 +16,7 @@ export const asyncValidator = (value = '', ancestry, itemId) =>
 
 const asyncValidatorDebounced = debouncePromise(asyncValidator);
 
-const createSchema = (newRecord, showUseConfig, ancestry, itemId) => {
+const createSchema = (newRecord, ancestry, itemId) => {
   let fields = [{
     component: componentTypes.TEXT_FIELD,
     id: 'name',
@@ -36,44 +36,6 @@ const createSchema = (newRecord, showUseConfig, ancestry, itemId) => {
     validateOnMount: true,
   }];
 
-  if (!newRecord && showUseConfig) {
-    fields.push({
-      component: componentTypes.SWITCH,
-      id: 'use_config_for_attributes',
-      name: 'use_config_for_attributes',
-      label: 'Use Configuration Settings',
-      onText: __('Yes'),
-      offText: __('No'),
-    });
-
-    const enabledName = {
-      ...fields[0],
-      isDisabled: false,
-      condition: {
-        when: 'use_config_for_attributes',
-        is: false,
-      },
-    };
-
-    const disabledName = {
-      component: componentTypes.SUB_FORM,
-      id: 'disabled-placeholder',
-      name: 'disabled-placeholder',
-      fields: [{
-        ...fields[0],
-        isDisabled: true,
-      }],
-      condition: {
-        when: 'use_config_for_attributes',
-        is: true,
-      },
-    };
-    fields = [
-      enabledName,
-      disabledName,
-      ...fields.slice(1),
-    ];
-  }
   return {
     fields,
   };

--- a/app/javascript/spec/ansible-edit-catalog-form/mockdata.js
+++ b/app/javascript/spec/ansible-edit-catalog-form/mockdata.js
@@ -168,7 +168,6 @@ export const initalDataForFirstTestCase = {
                 "ancestry": "1/2",
                 "divisible": true,
                 "description": "admin tenant",
-                "use_config_for_attributes": false,
                 "default_miq_group_id": 21,
                 "source_type": "CloudTenant",
                 "source_id": 2
@@ -190,7 +189,6 @@ export const initalDataForFirstTestCase = {
                 "ancestry": "1/2",
                 "divisible": true,
                 "description": "cloud-southeast",
-                "use_config_for_attributes": false,
                 "default_miq_group_id": 22,
                 "source_type": "CloudTenant",
                 "source_id": 5
@@ -212,7 +210,6 @@ export const initalDataForFirstTestCase = {
                 "ancestry": "1/2",
                 "divisible": true,
                 "description": "cloud-user-demo",
-                "use_config_for_attributes": false,
                 "default_miq_group_id": 23,
                 "source_type": "CloudTenant",
                 "source_id": 1
@@ -234,7 +231,6 @@ export const initalDataForFirstTestCase = {
                 "ancestry": "1/2",
                 "divisible": true,
                 "description": "cloudwest",
-                "use_config_for_attributes": false,
                 "default_miq_group_id": 24,
                 "source_type": "CloudTenant",
                 "source_id": 7
@@ -256,7 +252,6 @@ export const initalDataForFirstTestCase = {
                 "ancestry": "1/2",
                 "divisible": true,
                 "description": "Loic Tenant",
-                "use_config_for_attributes": false,
                 "default_miq_group_id": 25,
                 "source_type": "CloudTenant",
                 "source_id": 6
@@ -278,7 +273,6 @@ export const initalDataForFirstTestCase = {
                 "ancestry": "1/2",
                 "divisible": true,
                 "description": "openshift_demo",
-                "use_config_for_attributes": false,
                 "default_miq_group_id": 26,
                 "source_type": "CloudTenant",
                 "source_id": 3
@@ -300,7 +294,6 @@ export const initalDataForFirstTestCase = {
                 "ancestry": "1/2",
                 "divisible": true,
                 "description": "testtel",
-                "use_config_for_attributes": false,
                 "default_miq_group_id": 27,
                 "source_type": "CloudTenant",
                 "source_id": 4
@@ -322,7 +315,6 @@ export const initalDataForFirstTestCase = {
                 "ancestry": "1/2",
                 "divisible": true,
                 "description": "test-ivy",
-                "use_config_for_attributes": false,
                 "default_miq_group_id": 50,
                 "source_type": "CloudTenant",
                 "source_id": 13
@@ -344,7 +336,6 @@ export const initalDataForFirstTestCase = {
                 "ancestry": "1/2",
                 "divisible": true,
                 "description": "Massachusetts",
-                "use_config_for_attributes": false,
                 "default_miq_group_id": 34,
                 "source_type": "CloudTenant",
                 "source_id": 8
@@ -366,7 +357,6 @@ export const initalDataForFirstTestCase = {
                 "ancestry": "1/2",
                 "divisible": true,
                 "description": "testetot",
-                "use_config_for_attributes": false,
                 "default_miq_group_id": 41,
                 "source_type": "CloudTenant",
                 "source_id": 10
@@ -388,7 +378,6 @@ export const initalDataForFirstTestCase = {
                 "ancestry": "1/2/9",
                 "divisible": true,
                 "description": "test-ivr",
-                "use_config_for_attributes": false,
                 "default_miq_group_id": 51,
                 "source_type": "CloudTenant",
                 "source_id": 12
@@ -410,7 +399,6 @@ export const initalDataForFirstTestCase = {
                 "ancestry": "1/2",
                 "divisible": true,
                 "description": "loic",
-                "use_config_for_attributes": false,
                 "default_miq_group_id": 46,
                 "source_type": null,
                 "source_id": null
@@ -432,7 +420,6 @@ export const initalDataForFirstTestCase = {
                 "ancestry": "1/2",
                 "divisible": true,
                 "description": "Training environment",
-                "use_config_for_attributes": false,
                 "default_miq_group_id": 36,
                 "source_type": null,
                 "source_id": null
@@ -454,7 +441,6 @@ export const initalDataForFirstTestCase = {
                 "ancestry": "1",
                 "divisible": true,
                 "description": "OpenStack Cloud Provider OpenStack",
-                "use_config_for_attributes": false,
                 "default_miq_group_id": 20,
                 "source_type": "ExtManagementSystem",
                 "source_id": 7
@@ -476,7 +462,6 @@ export const initalDataForFirstTestCase = {
                 "ancestry": "1",
                 "divisible": true,
                 "description": "new",
-                "use_config_for_attributes": false,
                 "default_miq_group_id": 38,
                 "source_type": null,
                 "source_id": null

--- a/app/javascript/spec/ops-tenant-form/ops-tenant-form.spec.js
+++ b/app/javascript/spec/ops-tenant-form/ops-tenant-form.spec.js
@@ -35,7 +35,7 @@ describe('OpstTenantForm', () => {
   });
 
   it('should mount form without initialValues', async(done) => {
-    fetchMock.getOnce(`/api/tenants/${initialProps.recordId}?expand=resources&attributes=name,description,use_config_for_attributes,ancestry,divisible`, {
+    fetchMock.getOnce(`/api/tenants/${initialProps.recordId}?expand=resources&attributes=name,description,ancestry,divisible`, {
       name: 'foo',
     });
     let wrapper;
@@ -52,7 +52,7 @@ describe('OpstTenantForm', () => {
   });
 
   it('should mount and set initialValues', async(done) => {
-    fetchMock.getOnce('/api/tenants/123?expand=resources&attributes=name,description,use_config_for_attributes,ancestry,divisible', {
+    fetchMock.getOnce('/api/tenants/123?expand=resources&attributes=name,description,ancestry,divisible', {
       name: 'foo',
     });
     let wrapper;
@@ -111,11 +111,10 @@ describe('OpstTenantForm', () => {
   });
 
   it('should correctly edit existing entity.', async(done) => {
-    fetchMock.getOnce('/api/tenants/123?expand=resources&attributes=name,description,use_config_for_attributes,ancestry,divisible', {
+    fetchMock.getOnce('/api/tenants/123?expand=resources&attributes=name,description,ancestry,divisible', {
       name: 'foo',
       description: 'bar',
       ancestry: null,
-      use_config_for_attributes: true,
       divisible: false,
     });
     fetchMock.getOnce('/api/tenants?filter[]=name=foo&expand=resources', {
@@ -141,7 +140,6 @@ describe('OpstTenantForm', () => {
         name: 'foo',
         description: 'desc',
         divisible: false,
-        use_config_for_attributes: true,
       });
       expect(miqRedirectBack).toHaveBeenCalledWith('Project "foo" has been successfully saved.', 'success', '/foo/bar');
       done();

--- a/app/views/ops/_settings_server_tab.html.haml
+++ b/app/views/ops/_settings_server_tab.html.haml
@@ -29,15 +29,6 @@
           = _("Not Available")
     .form-group
       %label.col-md-2.control-label
-        = _("Company Name")
-      .col-md-8
-        = text_field_tag("server_company",
-                          @edit[:new][:server][:company],
-                          :maxlength => 20,
-                          :class => "form-control",
-                          "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-    .form-group
-      %label.col-md-2.control-label
         = _("Appliance Name")
       .col-md-8
         = text_field_tag("server_name",


### PR DESCRIPTION
Dependent upon:
- [x] https://github.com/ManageIQ/manageiq/pull/23463

Before
======

use_config_for_attributes used to not allow editing of the name field

![SCR-20250603-kuwt](https://github.com/user-attachments/assets/8cc7209f-272a-44ac-afad-36601b9eb5db)


![SCR-20250603-isyl](https://github.com/user-attachments/assets/6913eecd-9bed-4c36-b653-1be2e90dad08)


After
=====

Tenant model works just a standard model

![SCR-20250603-ktlz](https://github.com/user-attachments/assets/3d95a1ce-528f-43ee-89c6-f91423479e48)


![SCR-20250603-isft](https://github.com/user-attachments/assets/78ba3a3c-d692-4cd6-bd99-5f9d144a9f7c)
