### PR TITLE
Bump node and ruby versions for cypress

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -11,9 +11,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-        - '3.1'
+        - '3.3'
         node-version:
-        - 18
+        - 20
         cypress-browser:
         - chrome
         - firefox


### PR DESCRIPTION
I believe node here was missed in:
https://github.com/ManageIQ/manageiq/issues/23425

It was changed in UI classic here:
https://github.com/ManageIQ/manageiq-ui-classic/pull/9405

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
