### PR TITLE
Remove incorrect and unneeded assertions

### DIFF
--- a/cypress/e2e/ui/Automation/Embedded-Automate/customization.cy.js
+++ b/cypress/e2e/ui/Automation/Embedded-Automate/customization.cy.js
@@ -155,9 +155,7 @@ describe('Automation > Embedded Automate > Customization', () => {
 
       cy.get('[id="explorer_title_text"]').contains('Configured System Provision Dialogs');
       cy.get('[class="list-group"]').contains('Test Description').should('be.visible').click({force: true});
-      cy.get('[id="main_div"]').contains('Copy of Test User');
       cy.get('[id="main_div"]').contains('Test Description');
-      cy.get('[class="CodeMirror-code"]').contains('---');
       cy.get('[title="Configuration"]').click({force: true});
       cy.get('[title="Remove this Dialog"]').click({force: true});
 


### PR DESCRIPTION
We copy the dialog with the same description but different name. We then select one of the two (copy or original) in the tree. Either the copy or original is now displayed, the assertion on the name could be wrong since we're asserting the name is the "copy" name.

We're in the cleanup code.  We don't really care about these assertions. We now select either of the two "Test Description" dialogs, remove the first, verify the main div is correct, select the second and remove it. There is no need to check the Name field or the CodeMirror-code to confirm the removal was correct.

Note, this was extracted from https://github.com/ManageIQ/manageiq-ui-classic/pull/9452

In this screenshot, you can see the cleanup code AFTER it selects one of the two "Test Description" dialogs.  One is the original, and the other is the copy with a different name.  Depending on which one it displayed first and which the cypress code selects, we will then try to remove one of them in the cleanup code.  Depending on which is selected, the check for "Copy of Test User" will or will not pass.  It's completely not needed.

![image](https://github.com/user-attachments/assets/8756a92a-9bae-4ce8-8e5d-88712743cf01)
