### PR TITLE
Support string interval coming from report preview

### DIFF
--- a/app/controllers/application_controller/wait_for_task.rb
+++ b/app/controllers/application_controller/wait_for_task.rb
@@ -11,7 +11,7 @@ module ApplicationController::WaitForTask
     @edit = session[:edit]  # If in edit, need to preserve @edit object
     raise Forbidden, _('Invalid input for "wait_for_task".') unless params[:task_id]
 
-    async_interval = params[:async_interval] || 1000 # Default interval to 1 second
+    async_interval = params.fetch(:async_interval, 1000).to_i # Default interval to 1 second
 
     task = MiqTask.find(params[:task_id].to_i)
     if task.state != "Finished" # Task not done --> retry


### PR DESCRIPTION
I hit this when running the UI tests without a simulate_queue_worker running. I believe this is a bug that can happen where this code path provides an interval of type string.

With no workers running, such as rails server with no simulate queue worker: Go to: Overview->Reports->Reports accordion->Configuration->New Report

Give it a name, title, "base the report on" such as availability zone, add a field such as Ems Ref to the selected fields.  Then, click "preview" tab. Click "generate report preview" button... Before this change, it blows up with:

[TypeError] no implicit conversion of Integer into String

Note, this is a similar change as #9444

![image (54)](https://github.com/user-attachments/assets/38085181-f1af-4daf-9ab5-74e3aff5f942)


<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
