### PR TITLE
Fix button form

### DIFF
--- a/app/stylesheet/ddf_override.scss
+++ b/app/stylesheet/ddf_override.scss
@@ -516,3 +516,13 @@
     margin-top: 40px;
   }
 }
+
+.object-attribute {
+  display: inline-flex;
+  width: 100%;
+
+  .attribute-label {
+    margin-left: 25%;
+    margin-right: 5%;
+  }
+}

--- a/app/views/layouts/_ae_resolve_options.html.haml
+++ b/app/views/layouts/_ae_resolve_options.html.haml
@@ -1,8 +1,121 @@
+- field_changed_url ||= "form_field_changed"
+- ae_sim_form       ||= false
+- ae_custom_button  ||= false
+- ae_ansible_custom_button ||= false
 - rec_id = @edit && @edit[:action_id].present? ? @edit[:action_id] : "new"
-- url = "/miq_ae_tools/resolve_automate_simulation/#{rec_id}"
-= react('AutomateSimulationForm',
-        :resolve               => resolve,
-        :maxNameLength         => ViewHelper::MAX_NAME_LEN,
-        :url                   => url,
-        :attrValuesPairs       => ApplicationController::AE_MAX_RESOLUTION_FIELDS.times,
-        :maxLength             => ViewHelper::MAX_NAME_LEN)
+#main-div
+  - if ae_sim_form
+    - url = "/miq_ae_tools/resolve_automate_simulation/#{rec_id}"
+    = react('AutomateSimulationForm',
+          :resolve               => resolve,
+          :maxNameLength         => ViewHelper::MAX_NAME_LEN,
+          :url                   => url,
+          :attrValuesPairs       => ApplicationController::AE_MAX_RESOLUTION_FIELDS.times,
+          :maxLength             => ViewHelper::MAX_NAME_LEN)
+  - else
+    - url = url_for_only_path(:action => field_changed_url, :id => rec_id)
+    .form
+      - if form_action == "ae_resolve" && !ae_ansible_custom_button
+        %h3
+          = _("Object Details")
+        .form-group
+          %label.control-label
+            = _("System/Process")
+
+          = select_tag('instance_name',
+                      options_for_select(resolve[:instance_names].sort_by(&:downcase),
+                      resolve[:new][:instance_name]),
+                      "data-miq_sparkle_on"  => true,
+                      "data-miq_sparkle_off" => true,
+                      :class    => "selectpicker form-control")
+          :javascript
+            miqInitSelectPicker();
+            miqSelectPickerEvent('instance_name', "#{url}")
+      - unless ae_ansible_custom_button
+        .form-group
+          %label.control-label
+            = _("Message")
+
+          = text_field_tag("object_message",
+                          resolve[:new][:object_message],
+                          :maxlength         => ViewHelper::MAX_NAME_LEN,
+                          :class             => "form-control form-control",
+                          "data-miq_observe" => {:interval => '.5',
+                                                  :url      => url}.to_json)
+          = javascript_tag("if (!$('#description').length) #{javascript_focus('object_message')}")
+        .form-group
+          %label.control-label
+            = _("Request")
+
+          = text_field_tag("object_request",
+                          resolve[:new][:object_request],
+                          :maxlength         => ViewHelper::MAX_NAME_LEN,
+                          :class            => "form-control form-control",
+                          "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+    - if form_action != "miq_action"
+      - if ae_custom_button
+        %hr
+        %h3
+          = _("Object Attribute")
+        .form-horizontal
+          .form-group.object-attribute
+            %label.attribute-label
+              = _("Type")
+            .attribute-value
+              = ui_lookup(:model => @resolve[:target_class])
+      - else
+        %hr
+        %h3
+          = _("Object Attribute")
+        .form
+          .form-group
+            %label.control-label
+              = _("Type")
+            %hr
+            = select_tag('target_class',
+                        options_for_select([["<#{_('None')}>", nil]] + resolve[:target_classes].invert.to_a,
+                        resolve[:new][:target_class]),
+                        "data-miq_sparkle_on"  => true,
+                        "data-miq_sparkle_off" => true,
+                        :class    => "selectpicker form-control")
+            :javascript
+              miqInitSelectPicker();
+              miqSelectPickerEvent('target_class', "#{url}")
+          - if resolve[:new][:target_class] && !resolve[:new][:target_class].blank? && resolve[:targets]
+            .form-group
+              %label.control-label
+                = _("Selection")
+
+              = select_tag('target_id',
+                          options_for_select([["<#{_('Choose')}>", nil]] + resolve[:targets],
+                                              resolve[:new][:target_id]),
+                          "data-miq_sparkle_on"  => true,
+                          "data-miq_sparkle_off" => true,
+                          :class    => "selectpicker form-control")
+              :javascript
+                miqInitSelectPicker();
+                miqSelectPickerEvent('target_id', "#{url}")
+    %hr
+    %h3
+      = _("Attribute/Value Pairs")
+    .form-horizontal
+      - ApplicationController::AE_MAX_RESOLUTION_FIELDS.times do |i|
+        - f = "attribute_" + (i + 1).to_s
+        - v = "value_" + (i + 1).to_s
+        .form-group
+          %label.col-md-2.control-label
+            = (i + 1).to_s
+          .col-md-4
+            = text_field_tag(f,
+                            resolve[:new][:attrs][i][0],
+                            :maxlength         => ViewHelper::MAX_NAME_LEN,
+                            :class            => "form-control",
+                            "data-miq_observe" => {:interval => '.5',
+                                                    :url => url}.to_json)
+          .col-md-4
+            = text_field_tag(v,
+                            resolve[:new][:attrs][i][1],
+                            :maxlength         => ViewHelper::MAX_NAME_LEN,
+                            :class            => "form-control",
+                            "data-miq_observe" => {:interval => '.5',
+                                                    :url => url}.to_json)

--- a/app/views/miq_ae_tools/resolve_react.html.haml
+++ b/app/views/miq_ae_tools/resolve_react.html.haml
@@ -1,1 +1,0 @@
-= render :partial => "resolve"

--- a/app/views/shared/buttons/_ab_form.html.haml
+++ b/app/views/shared/buttons/_ab_form.html.haml
@@ -1,3 +1,4 @@
+= render :partial => "layouts/flash_msg"
 #ab_form
   #custom_button_tabs
     %ul.nav.nav-tabs{'role' => 'tablist'}


### PR DESCRIPTION
Fix the button form. This was broken by this pr: https://github.com/ManageIQ/manageiq-ui-classic/pull/9202. This pr fixes the button form so it correctly renders and fixes a small styling issue.

Before:
The form buttons are missing and fields are missing on the "Advanced" tab of the button form.
<img width="1238" alt="Screenshot 2025-06-04 at 12 16 35 PM" src="https://github.com/user-attachments/assets/5c53a05d-d9ec-48de-9a59-02807867fe61" />
<img width="1238" alt="Screenshot 2025-06-04 at 12 16 43 PM" src="https://github.com/user-attachments/assets/adec2493-4cd6-4bcf-a927-155dd8ec5c6d" />

After:
<img width="1235" alt="Screenshot 2025-06-04 at 12 17 18 PM" src="https://github.com/user-attachments/assets/39a501ed-c1d2-4fac-ac9a-05141f82a35f" />
<img width="1243" alt="Screenshot 2025-06-04 at 12 17 48 PM" src="https://github.com/user-attachments/assets/8079bc13-6a4f-4e12-9625-ddd75363cabe" />





