### PR TITLE
Fix error on VM reconfigure when host is nil

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -213,6 +213,8 @@ module Mixins
 
         # determine available switches for this host...
         def get_vlan_options(host)
+          return [] unless host.present?
+
           switch_ids = Rbac.filtered(host.switches).pluck(:id)
           Rbac.filtered(Lan.where(:switch_id => switch_ids).order(:name)).pluck(:name)
         end

--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -213,7 +213,7 @@ module Mixins
 
         # determine available switches for this host...
         def get_vlan_options(host)
-          return [] unless host.present?
+          return [] if host.blank?
 
           switch_ids = Rbac.filtered(host.switches).pluck(:id)
           Rbac.filtered(Lan.where(:switch_id => switch_ids).order(:name)).pluck(:name)


### PR DESCRIPTION
For VMs without any host, reconfigure resulted in internal server error `[NoMethodError] undefined method `switches' for nil:NilClass`

Before fix -

<img width="1498" alt="Before" src="https://github.com/user-attachments/assets/573ddc11-34b8-4c33-850e-3c336ecc525f" />


After fix - 

<img width="1504" alt="After" src="https://github.com/user-attachments/assets/e40bdaac-5ece-4d25-82a4-587bdb9692bc" />

@miq-bot add-label bug


<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
