### PR TITLE
Fix button group reorder form buttons

### DIFF
--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -291,7 +291,7 @@ class MiqAeCustomizationController < ApplicationController
 
   # allowed function is used to show form buttons in custom-button form page.
   def allowed(action)
-    allowed = ['ab_button_new', 'ab_button_edit', 'old_dialogs_new', 'old_dialogs_edit', 'old_dialogs_copy']
+    allowed = ['ab_button_new', 'ab_button_edit', 'ab_group_reorder', 'old_dialogs_new', 'old_dialogs_edit', 'old_dialogs_copy']
     action ? allowed.include?(action.to_s) : false
   end
 


### PR DESCRIPTION
eThis pr fixes the button group reorder form since it was missing the save / reset / cancel buttons

Before:
<img width="1246" alt="Screenshot 2025-06-06 at 1 20 03 PM" src="https://github.com/user-attachments/assets/57886ef3-3705-401b-8ef4-b42834d7ac62" />

After:
<img width="1244" alt="Screenshot 2025-06-06 at 1 21 40 PM" src="https://github.com/user-attachments/assets/524b1009-75f0-4c09-8521-d2099d45bd68" />
