### PR TITLE
Revert "Fix searchbar formtoken issue"

### DIFF
--- a/app/javascript/components/search-bar/index.jsx
+++ b/app/javascript/components/search-bar/index.jsx
@@ -9,6 +9,10 @@ import {
 } from '@carbon/icons-react';
 
 const SearchBar = ({ searchText, advancedSearch, action }) => {
+  const formToken = () => {
+    const csrfToken = document.querySelector('meta[name=csrf-token]');
+    return csrfToken ? csrfToken.getAttribute('content') : '';
+  };
   const [data, setData] = useState({
     formText: searchText || '',
     loading: false,
@@ -92,7 +96,7 @@ const SearchBar = ({ searchText, advancedSearch, action }) => {
   return (
     <div className="search_bar">
       <Form onSubmit={onSearch} method="post" id="search-bar-form">
-        <input type="hidden" name="authenticity_token" />
+        <input type="hidden" name="authenticity_token" value={formToken()} />
         <TextInput
           id="search_text"
           labelText={__('Search')}

--- a/app/javascript/spec/search-bar/__snapshots__/search-bar.spec.js.snap
+++ b/app/javascript/spec/search-bar/__snapshots__/search-bar.spec.js.snap
@@ -12,6 +12,7 @@ exports[`Search Bar component should render the search bar component 1`] = `
     <input
       name="authenticity_token"
       type="hidden"
+      value=""
     />
     <TextInput
       hideLabel={true}
@@ -72,6 +73,7 @@ exports[`Search Bar component should render the search bar component with advanc
     <input
       name="authenticity_token"
       type="hidden"
+      value=""
     />
     <TextInput
       hideLabel={true}
@@ -132,6 +134,7 @@ exports[`Search Bar component should render the search bar component with search
     <input
       name="authenticity_token"
       type="hidden"
+      value=""
     />
     <TextInput
       hideLabel={true}


### PR DESCRIPTION
Revert #9367 as it causing an issue with the search bar on explorer pages. When using the search bar on an explorer page it is timing out the user and logging them out. The search bar on non-explorer pages seems to work fine without the form token.