### PR TITLE
Update npmauditexclude list

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -15,14 +15,16 @@ npmAuditExcludePackages:
   # pending | low      | GHSA-j58c-ww9w-pwp5 | angular <=1.8.3              | 1.8.3 brought in by manageiq-ui-classic@workspace:.
   # pending | low      | GHSA-m9gf-397r-hwpg | angular >=1.3.0-rc.4 <=1.8.3 | 1.8.3 brought in by manageiq-ui-classic@workspace:.
   # pending | low      | GHSA-mqm9-c95h-x2p6 | angular <=1.8.3              | 1.8.3 brought in by manageiq-ui-classic@workspace:.
+  - angular-sanitize
+  # pending | moderate | GHSA-4p4w-6hg8-63wx | angular-sanitize >=1.3.1 <=1.8.3 | 1.8.3 brought in by manageiq-ui-classic@workspace:.
   - bootstrap
-  # pending | moderate | GHSA-9mvj-f7w8-pvh2 | bootstrap >=2.0.0 <=3.4.1 | 3.4.1 brought in by eonasdan-bootstrap-datetimepicker@virtual:6557af66f1a3f9d81b30dd080e0c619c011728fa0bded31959e34111c8a06d5f82c760d19a3100c59f98831cc7e73d48a91c41d41de6db59b14a282cb6169d79#npm:4.17.49
+  # pending | moderate | GHSA-9mvj-f7w8-pvh2 | bootstrap >=2.0.0 <=3.4.1 | 3.4.1 brought in by eonasdan-bootstrap-datetimepicker@virtual:5c616db0543848e1d5b60ddf9f1567af3b6c22b5b10c5930237ca94f8aa79437779f5e0c9acab451dae388870ac6914a83389ac4c8165cb0b02e27d6c3d96535#npm:4.17.49
   - bootstrap-sass
   # pending | moderate | GHSA-9mvj-f7w8-pvh2 | bootstrap-sass >=2.0.0 <=3.4.3 | 3.4.3 brought in by patternfly@npm:3.59.5
   - jquery
-  # pending | moderate | GHSA-rmxg-73gg-4p98 | jquery >=1.12.3 <3.0.0 | 2.2.4 brought in by manageiq-ui-classic@workspace:.
-  # pending | moderate | GHSA-gxr4-xjj5-5px2 | jquery >=1.2.0 <3.5.0  | 2.2.4, 3.4.1 brought in by manageiq-ui-classic@workspace:., patternfly@npm:3.59.5
   # pending | moderate | GHSA-6c3j-c64m-qhgq | jquery >=1.1.4 <3.4.0  | 2.2.4 brought in by manageiq-ui-classic@workspace:.
+  # pending | moderate | GHSA-gxr4-xjj5-5px2 | jquery >=1.2.0 <3.5.0  | 2.2.4, 3.4.1 brought in by manageiq-ui-classic@workspace:., patternfly@npm:3.59.5
   # pending | moderate | GHSA-jpcq-cgw6-v4j6 | jquery >=1.0.3 <3.5.0  | 2.2.4, 3.4.1 brought in by manageiq-ui-classic@workspace:., patternfly@npm:3.59.5
+  # pending | moderate | GHSA-rmxg-73gg-4p98 | jquery >=1.12.3 <3.0.0 | 2.2.4 brought in by manageiq-ui-classic@workspace:.
 
 yarnPath: .yarn/releases/yarn-4.9.2.cjs


### PR DESCRIPTION
Update the npmauditexclude list. Added angular-sanitize to the list since it is on the latest version and can't be removed since it is used by angular-patternfly