### PR TITLE
Fix task page bugs

### DIFF
--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -128,7 +128,11 @@ class MiqTaskController < ApplicationController
   # Delete selected tasks
   def delete_tasks
     assert_privileges("miq_task_delete")
-    delete_tasks_from_table(find_checked_items, "Delete selected tasks")
+
+    checked_items = find_checked_items
+    new_checked_items = find_checked_items.select { |item| params["select-row-#{item}"] == "on" }
+
+    delete_tasks_from_table(new_checked_items, "Delete selected tasks")
     jobs
     @refresh_partial = "layouts/tasks"
   end
@@ -329,6 +333,12 @@ class MiqTaskController < ApplicationController
   def tasks_scopes(opts, use_times = true)
     scope = []
 
+    # Add time scope
+    if use_times
+      t = format_timezone(opts[:time_period].to_i != 0 ? opts[:time_period].days.ago : Time.now, Time.zone, "raw")
+      scope << [:with_updated_on_between, t.beginning_of_day, t.end_of_day]
+    end
+
     # Specify user scope
     if @tabform == "tasks_1"
       scope << [:with_userid, session[:userid]]
@@ -345,12 +355,6 @@ class MiqTaskController < ApplicationController
       scope << [:with_status_in, *status]
     else
       scope << :no_status_selected
-    end
-
-    # Add time scope
-    if use_times
-      t = format_timezone(opts[:time_period].to_i != 0 ? opts[:time_period].days.ago : Time.now, Time.zone, "raw")
-      scope << [:with_updated_on_between, t.beginning_of_day, t.end_of_day]
     end
 
     # Add zone scope

--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -129,7 +129,6 @@ class MiqTaskController < ApplicationController
   def delete_tasks
     assert_privileges("miq_task_delete")
 
-    checked_items = find_checked_items
     new_checked_items = find_checked_items.select { |item| params["select-row-#{item}"] == "on" }
 
     delete_tasks_from_table(new_checked_items, "Delete selected tasks")
@@ -333,12 +332,6 @@ class MiqTaskController < ApplicationController
   def tasks_scopes(opts, use_times = true)
     scope = []
 
-    # Add time scope
-    if use_times
-      t = format_timezone(opts[:time_period].to_i != 0 ? opts[:time_period].days.ago : Time.now, Time.zone, "raw")
-      scope << [:with_updated_on_between, t.beginning_of_day, t.end_of_day]
-    end
-
     # Specify user scope
     if @tabform == "tasks_1"
       scope << [:with_userid, session[:userid]]
@@ -355,6 +348,12 @@ class MiqTaskController < ApplicationController
       scope << [:with_status_in, *status]
     else
       scope << :no_status_selected
+    end
+
+    # Add time scope
+    if use_times
+      t = format_timezone(opts[:time_period].to_i != 0 ? opts[:time_period].days.ago : Time.now, Time.zone, "raw")
+      scope << [:with_updated_on_between, t.beginning_of_day, t.end_of_day]
     end
 
     # Add zone scope

--- a/app/javascript/components/settings-tasks-form/index.jsx
+++ b/app/javascript/components/settings-tasks-form/index.jsx
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import { FormSpy } from '@data-driven-forms/react-form-renderer';
 import createSchema from './settings-tasks-form.schema';
 import loadTable from './load-table-helper';
-import GtlView from '../gtl-view';
 
 const SettingsTasksForm = ({
   allTasks, zones, users, timePeriods, taskStates, tz,
@@ -47,7 +46,6 @@ const SettingsTasksForm = ({
           loadDefaultTable();
         }}
       />
-      <GtlView showUrl="/miq_task/show" />
     </div>
   );
 };

--- a/app/views/layouts/_tasks.html.haml
+++ b/app/views/layouts/_tasks.html.haml
@@ -1,2 +1,3 @@
 #main_div
   = render :partial => 'miq_task/tasks_options'
+  = render :partial => 'layouts/gtl'


### PR DESCRIPTION
Fix the delete on the tasks page.

Before:
Clicking delete on the task page made it seem like nothing was happening because no flash message would appear. The tasks are not deleted immediately, instead the deletion of the task is queued so it should alert the user of this in a flash message or else it seems like the task is not being deleted.

After:
This pr fixes this issue by alerting the user that the task deletion is queued and will occur.
<img width="1243" alt="Screenshot 2025-06-09 at 12 29 08 PM" src="https://github.com/user-attachments/assets/98f514f6-f280-4805-ad87-24ec86b8c378" />
