### PR TITLE
Consolidate tests that click rows in the settings details table

### DIFF
--- a/cypress/e2e/ui/Settings/Application-Settings/settings_details_tab.cy.js
+++ b/cypress/e2e/ui/Settings/Application-Settings/settings_details_tab.cy.js
@@ -10,22 +10,23 @@ describe('Settings > Application Settings > Details', () => {
   });
 
   describe('Settings Details Tab', () => {
-    it('Region row is replaced by region form when clicked', () => {
+    it('Click row and reroute', () => {
       cy.get('.bx--front-line').contains('Region 0').click({force: true});
       cy.get('.bx--label').contains('Description').should('exist');
-    });
-    it('Clicks on analysis profiles row and reroutes', () => {
+      cy.get('[data-nodeid="0.0"].node-treeview-settings_tree').contains('ManageIQ Region').click();
+
       cy.get('.bx--front-line').contains('Analysis Profiles').click({force: true});
       cy.get('#explorer_title_text').contains('Settings Analysis Profiles').should('exist');
-    });
-    it('Clicks on zones row and reroutes', () => {
+      cy.get('[data-nodeid="0.0"].node-treeview-settings_tree').contains('ManageIQ Region').click();
+
       cy.get('.bx--front-line').contains('Zones').click({force: true});
       cy.get('#explorer_title_text').contains('Settings Zones').should('exist');
-    });
-    it('Clicks on schedules row and reroutes', () => {
+      cy.get('[data-nodeid="0.0"].node-treeview-settings_tree').contains('ManageIQ Region').click();
+
       cy.get('.bx--front-line').contains('Schedules').click({force: true});
       cy.get('#explorer_title_text').contains('Settings Schedules').should('exist');
     });
+
     it('Updates region name when changed', () => {
       cy.get('.bx--front-line').contains('Region 0').click({force: true});
       cy.get('#description').clear().type('Region 1');


### PR DESCRIPTION
These tests are basically the same thing.  If this form were to break, all
these tests would likely fail.  It's probably better to avoid the extra
setup/teardown for each test by consolidating into a single test.

See also:
https://docs.cypress.io/app/core-concepts/best-practices#Creating-Tiny-Tests-With-A-Single-Assertion

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
