### PR TITLE
Add cypress commands for throttling and notification stubs

### DIFF
--- a/cypress/fixtures/empty_notifications.json
+++ b/cypress/fixtures/empty_notifications.json
@@ -1,0 +1,24 @@
+{
+    "name": "notifications",
+    "count": 0,
+    "subcount": 0,
+    "pages": 0,
+    "resources": [],
+    "actions": [
+        {
+            "name": "mark_as_seen",
+            "method": "post",
+            "href": "http://localhost:3000/api/notifications"
+        },
+        {
+            "name": "delete",
+            "method": "post",
+            "href": "http://localhost:3000/api/notifications"
+        }
+    ],
+    "links": {
+        "self": "http://localhost:3000/api/notifications?offset=0",
+        "first": "http://localhost:3000/api/notifications?offset=0",
+        "last": "http://localhost:3000/api/notifications?offset=0"
+    }
+}

--- a/cypress/fixtures/empty_notifications_expanded.json
+++ b/cypress/fixtures/empty_notifications_expanded.json
@@ -1,0 +1,24 @@
+{
+    "name": "notifications",
+    "count": 0,
+    "subcount": 0,
+    "pages": 0,
+    "resources": [],
+    "actions": [
+        {
+            "name": "mark_as_seen",
+            "method": "post",
+            "href": "http://localhost:3000/api/notifications"
+        },
+        {
+            "name": "delete",
+            "method": "post",
+            "href": "http://localhost:3000/api/notifications"
+        }
+    ],
+    "links": {
+        "self": "http://localhost:3000/api/notifications?expand=resources&attributes=details&sort_by=id&sort_order=desc&limit=100&offset=0",
+        "first": "http://localhost:3000/api/notifications?expand=resources&attributes=details&sort_by=id&sort_order=desc&limit=100&offset=0",
+        "last": "http://localhost:3000/api/notifications?expand=resources&attributes=details&sort_by=id&sort_order=desc&limit=100&offset=0"
+    }
+}

--- a/cypress/support/commands/stub_notifications.js
+++ b/cypress/support/commands/stub_notifications.js
@@ -1,0 +1,9 @@
+Cypress.Commands.add('stub_notifications', () => {
+    cy.intercept('GET', '/api/notifications', (req) => {
+      req.reply({fixture: 'empty_notifications.json'});
+    });
+
+    cy.intercept('GET', '/api/notifications?expand=resources&attributes=details*', (req) => {
+      req.reply({fixture: 'empty_notifications_expanded.json'});
+    });
+});

--- a/cypress/support/commands/throttle_response.js
+++ b/cypress/support/commands/throttle_response.js
@@ -1,0 +1,16 @@
+// Usage: cy.throttle_response(1000, 56);
+Cypress.Commands.add('throttle_response', (response_delay, throttle_kbps) => {
+  cy.intercept(
+    {
+      url: 'http://localhost:3000/**',
+      middleware: true,
+    },
+    (req) => {
+        req.on('response', (res) => {
+            // Add response delay and throttle network to simulate slower networks
+            res.setDelay(response_delay).setThrottle(throttle_kbps)
+        })
+    }
+  )
+});
+

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -45,6 +45,7 @@ import './commands/gtl.js'
 import './commands/login.js'
 import './commands/menu.js'
 import './commands/toolbar.js'
+import './commands/throttle_response.js'
 
 // Assertions
 import './assertions/expect_rates_table.js';
@@ -65,3 +66,8 @@ Cypress.on('uncaught:exception', (err, runnable) => {
         return false;
     }
 });
+
+beforeEach(() => {
+  // Global hook run once before each test
+  // cy.throttle_response(500, 56);
+})

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -44,6 +44,7 @@ import './commands/explorer.js'
 import './commands/gtl.js'
 import './commands/login.js'
 import './commands/menu.js'
+import './commands/stub_notifications.js'
 import './commands/toolbar.js'
 import './commands/throttle_response.js'
 
@@ -70,4 +71,5 @@ Cypress.on('uncaught:exception', (err, runnable) => {
 beforeEach(() => {
   // Global hook run once before each test
   // cy.throttle_response(500, 56);
+  // cy.stub_notifications();
 })


### PR DESCRIPTION
This PR adds commands to delay and throttle network responses and to stub notifications with empty fixtures.

Neither is enabled by default but an example is provided.  We can enable them at will in tests or in the global beforeEach.

cc @GilbertCherrie @Fryguy 