### PR TITLE
[WIP] Cache login across specs

### DIFF
--- a/cypress/support/commands/login.js
+++ b/cypress/support/commands/login.js
@@ -3,10 +3,18 @@
 // user: String of username to log in with, default is admin.
 // password: String of password to log in with, default is smartvm.
 Cypress.Commands.add('login', (user = 'admin', password = 'smartvm') => {
-  cy.visit('/');
+  cy.session([user, password], () => {
+    cy.visit('/dashboard/login');
+    cy.get('#user_name').type(user);
+    cy.get('#user_password').type(password);
+    cy.get('#login').click();
 
-  cy.get('#user_name').type(user);
-  cy.get('#user_password').type(password);
-  return cy.get('#login').click();
+  }, {
+    validate() {
+      cy.request('/api').its('status').should('eq', 200)
+    },
+    cacheAcrossSpecs: true
+  })
+  cy.visit('/utilization')
 });
 


### PR DESCRIPTION
Seems to be cached for each spec in a file.  The next file will reset the local storage and cookies so it appears to need to be done once per file.

Add validation to something that responds quickly..., /api

Previously, we'd land on /dashboard/show after login, now, visit a faster page, /utilization after establishing or restoring session.

TODO: 

- [ ] We should probably clear the shared session or ensure we use a separate session for the login tests.
- [ ] Ensure we're not sharing session information beyond login.  Things like previously open trees, nodes, etc. will likely cause test contamination if it's stored in session.  We want the shared login but nothing else.
- [ ] The redirect after login loading /dashboard/show is a waste of time.  Only dashboard tests need that page.  For now, I did some other faster page but ideally, we could login without a redirect and each test could say what URL that start on.  I'm not sure how much if that's feasible and may introduce other problems in the application in service of cypress testing, so it's possibly not a good idea.
- [ ] I don't know if it's possible to share the login across test files.  In other words, I think the most we can do is share the login with the same test file.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
