### PR TITLE
Fix the settings ops schedule toolbar

### DIFF
--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -59,6 +59,7 @@ module OpsController::Settings::Schedules
 
   def schedule_edit
     assert_privileges("schedule_edit")
+    @in_a_form = true
     case params[:button]
     when "cancel"
       @schedule = MiqSchedule.find_by(:id => params[:id])


### PR DESCRIPTION
This bug was found by @asirvadAbrahamVarghese

Fix the settings ops toolbar to not display while in the schedule form, similar to the other forms on the ops page.

Before:
<img width="1207" alt="Screenshot 2025-06-23 at 4 01 28 PM" src="https://github.com/user-attachments/assets/3c4cdc9a-07c2-43ea-b854-9ce32e9a44b2" />
<img width="1211" alt="Screenshot 2025-06-23 at 4 02 02 PM" src="https://github.com/user-attachments/assets/42141e02-428d-4883-a1ef-5bea9a40b418" />

After:
Still has the configuration button outside of the form.
<img width="1234" alt="Screenshot 2025-06-23 at 4 03 56 PM" src="https://github.com/user-attachments/assets/95c7c623-117c-49c3-a9fc-ed4371fa5b31" />
<img width="1228" alt="Screenshot 2025-06-23 at 4 03 52 PM" src="https://github.com/user-attachments/assets/5c829746-1d93-48b4-b61c-61e066e744a1" />


No configuration button inside of the form.
<img width="1212" alt="Screenshot 2025-06-23 at 4 00 15 PM" src="https://github.com/user-attachments/assets/4b26365a-0d86-4790-8437-8323bd24960b" />
<img width="1213" alt="Screenshot 2025-06-23 at 4 00 36 PM" src="https://github.com/user-attachments/assets/1d4a9b21-1308-45a5-9e3a-72019979787a" />
