### PR TITLE
Rails 7.2 - Fix breakage and deprecation

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -349,7 +349,7 @@ module ApplicationController::CiProcessing
   # Refresh the power states for selected or single VMs
   def refreshvms(privilege = DEFAULT_PRIVILEGE)
     if privilege == DEFAULT_PRIVILEGE
-      ActiveSupport::Deprecation.warn(<<-MSG.strip_heredoc)
+      Vmdb::Deprecation.warn(<<-MSG.strip_heredoc, caller_locations[1..-1])
       Please pass the privilege you want to check for when refreshing
       MSG
       privilege = params[:pressed]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,7 @@ Dir[Rails.root.join('spec', 'shared', '**', '*.rb')].each { |f| require f }
 Dir[ManageIQ::UI::Classic::Engine.root.join('spec/shared/**/*.rb')].each { |f| require f }
 
 RSpec.configure do |config|
-  config.fixture_path = Rails.root.join("spec/fixtures")
+  config.fixture_paths = [Rails.root.join("spec/fixtures")]
   config.use_transactional_fixtures = true
   config.use_instantiated_fixtures  = false
 


### PR DESCRIPTION
* Fix AS::Deprecation error around using deprecator or an instance
Similar to https://github.com/ManageIQ/manageiq/pull/23249
* Fix 'Rails 7.1 has deprecated the singular fixture_path'
Rails 7.1 has deprecated the singular fixture_path in favour of an array.You should migrate to plural
