### PR TITLE
Added optional notification discard on log-in

### DIFF
--- a/cypress/support/commands/login.js
+++ b/cypress/support/commands/login.js
@@ -1,12 +1,38 @@
 /* eslint-disable no-undef */
 
-// user: String of username to log in with, default is admin.
-// password: String of password to log in with, default is smartvm.
-Cypress.Commands.add('login', (user = 'admin', password = 'smartvm') => {
-  cy.visit('/');
-
-  cy.get('#user_name').type(user);
-  cy.get('#user_password').type(password);
-  return cy.get('#login').click();
+Cypress.Commands.add('disableAlertsIfVisible', () => {
+  // Look for notification popups and disable them if present
+  return cy.get('body').then(($body) => {
+    const $link = $body.find(
+      '.miq-toast-wrapper .row .alert a:contains("Disable notifications")'
+    );
+    if ($link.length && $link.is(':visible')) {
+      cy.wrap($link).click({ force: true });
+    }
+    return cy.wrap(null);
+  });
 });
 
+// user: String of username to log in with, default is admin.
+// password: String of password to log in with, default is smartvm.
+Cypress.Commands.add(
+  'login',
+  (user = 'admin', password = 'smartvm', options = {}) => {
+    const { disableNotifications = false } = options;
+    if (disableNotifications) {
+      cy.intercept('GET', '/api/notifications').as('getNotifications');
+    }
+    cy.visit('/');
+
+    cy.get('#user_name').type(user);
+    cy.get('#user_password').type(password);
+    const triggerLogin = () => cy.get('#login').click();
+
+    if (disableNotifications) {
+      return triggerLogin()
+        .then(() => cy.wait('@getNotifications'))
+        .then(() => cy.disableAlertsIfVisible());
+    }
+    return triggerLogin();
+  }
+);


### PR DESCRIPTION
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
Pr that adds an option to dismiss notification alerts on cypress sign-in command

@miq-bot assign @jrafanie
@miq-bot add-label cypress