### PR TITLE
Replaced getDay() with getDate() for accurate date value

### DIFF
--- a/spec/javascripts/directives/checkchange_spec.js
+++ b/spec/javascripts/directives/checkchange_spec.js
@@ -35,18 +35,19 @@ describe('checkchange initialization', function() {
 
       $scope.$digest();
       var newDate = new Date();
-      form.repo_path.$setViewValue(moment.utc([newDate.getFullYear(), newDate.getMonth(), newDate.getDay()]));
+      form.repo_path.$setViewValue(moment.utc([newDate.getFullYear(), newDate.getMonth(), newDate.getDate()]));
       expect(form.repo_path.$pristine).toBe(false);
       expect(form.$pristine).toBe(false);
     });
 
     it('should set the value and form to a pristine state when a date is unchanged', function() {
       var newDate = new Date();
+      var mockDate = moment.utc([newDate.getFullYear(), newDate.getMonth(), newDate.getDate()]).toDate();
       $scope.repoModel = {repo_path : undefined};
-      $scope.modelCopy = {repo_path : moment.utc([newDate.getFullYear(), newDate.getMonth(), newDate.getDay()]).toDate()};
+      $scope.modelCopy = {repo_path : mockDate};
 
       $scope.$digest();
-      form.repo_path.$setViewValue(moment.utc([newDate.getFullYear(), newDate.getMonth(), newDate.getDay()]).toDate());
+      form.repo_path.$setViewValue(mockDate);
       expect(form.repo_path.$pristine).toBe(true);
       expect(form.$pristine).toBe(true);
     });


### PR DESCRIPTION
Replaced newDate.getDay() with newDate.getDate() to correctly retrieve the day of the month when constructing UTC dates. Using getDay() (which returns the day of the week) would build incorrect date, leading to mismatches during `modelDate.diff(copyDate, 'days') == 0)`checks. 

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->

@miq-bot add-label bug
