### PR TITLE
Added automated tests with cypress for Namespace form

### DIFF
--- a/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/namespace.cy.js
+++ b/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/namespace.cy.js
@@ -9,7 +9,6 @@ const textConstants = {
   // Toolbar options
   toolbarConfiguration: 'Configuration',
   toolbarAddNewDomain: 'Add a New Domain',
-  toolbarRemoveDomain: 'Remove this Domain',
   toolbarAddNewNamespace: 'Add a New Namespace',
   toolbarEditNamespace: 'Edit this Namespace',
   toolbarRemoveNamespace: 'Remove this Namespace',
@@ -40,9 +39,6 @@ const textConstants = {
   addNamespaceFormHeader: 'Adding a new Automate Namespace',
   editNamespaceFormHeader: 'Editing Automate Namespace',
   namespaceFormSubHeader: 'Info',
-
-  // List items
-  dataStoreAccordionItem: 'Datastore',
 
   // Buttons
   addButton: 'Add',
@@ -84,7 +80,6 @@ const {
   toolbarAddNewNamespace,
   toolbarEditNamespace,
   toolbarRemoveNamespace,
-  toolbarRemoveDomain,
   addNamespaceFormHeader,
   editNamespaceFormHeader,
   namespaceFormSubHeader,
@@ -103,7 +98,6 @@ const {
   flashMessageNameAlreadyExists,
   flashMessageResetNamespace,
   browserConfirmRemoveMessage,
-  dataStoreAccordionItem,
   nameInputFieldId,
   descriptionInputFieldId,
   namespacePathInputFieldId,
@@ -125,7 +119,6 @@ function selectAccordionTree(textValue) {
   const aliasObject = {
     [domainName]: 'getCreatedDomainInfo',
     [namespaceName]: 'getCreatedNamespaceInfo',
-    [dataStoreAccordionItem]: 'getDataStoreAccordionItemInfo',
   };
   cy.intercept(
     'POST',
@@ -192,6 +185,33 @@ function createNamespaceAndOpenEditForm() {
   cy.toolbar(toolbarConfiguration, toolbarEditNamespace);
 }
 
+function extractDomainIdAndTokenFromResponse(interception) {
+  const rawTreeObject = interception?.response?.body?.reloadTrees?.ae_tree;
+  if (rawTreeObject) {
+    const rawTreeParsed = JSON.parse(rawTreeObject);
+    rawTreeParsed.every((treeObject) => {
+      // Exit iteration once id is extracted from nodes array
+      return treeObject?.nodes?.every((nodeObject) => {
+        if (nodeObject?.text === domainName) {
+          const domainId = nodeObject?.key?.split('-')?.[1];
+          const csrfToken = interception?.request?.headers?.['x-csrf-token'];
+          const idAndToken = {
+            domainId,
+            csrfToken,
+          };
+          // Creating an aliased state to store id and token
+          cy.wrap(idAndToken).as('idAndToken');
+
+          // Stop iterating once the domain id is found
+          return false;
+        }
+        // Continue iterating
+        return true;
+      });
+    });
+  }
+}
+
 describe('Automate operations on Namespaces: Automation -> Embedded Automate -> Explorer -> {Any-created-domain} -> Namespace form', () => {
   beforeEach(() => {
     cy.login();
@@ -208,7 +228,9 @@ describe('Automate operations on Namespaces: Automation -> Embedded Automate -> 
       'addNamespaceApi'
     );
     cy.contains(buttonSelector(submitButtonType), addButton).click();
-    cy.wait('@addNamespaceApi');
+    cy.wait('@addNamespaceApi').then((interception) => {
+      extractDomainIdAndTokenFromResponse(interception);
+    });
     cy.expect_flash(flashTypeSuccess, flashMessageAddSuccess);
     // Selecting the created domain from the accordion list items
     selectAccordionTree(domainName);
@@ -334,15 +356,21 @@ describe('Automate operations on Namespaces: Automation -> Embedded Automate -> 
   });
 
   afterEach(() => {
-    // Selecting the created domain(Test_Domain) from the accordion list items
-    selectAccordionTree(dataStoreAccordionItem);
-    cy.accordionItem(domainName);
-    cy.wait('@getCreatedDomainInfo');
-    // Removing the domain
-    cy.expect_browser_confirm_with_text({
-      confirmTriggerFn: () =>
-        cy.toolbar(toolbarConfiguration, toolbarRemoveDomain),
-      containsText: browserConfirmRemoveMessage,
+    // retrieve the id and token from the aliased state
+    // to invoke api for deleting the created domain
+    cy.get('@idAndToken').then((data) => {
+      const { domainId, csrfToken } = data;
+      if (domainId && csrfToken) {
+        cy.request({
+          method: 'POST',
+          url: `/miq_ae_class/x_button/${domainId}?pressed=miq_ae_domain_delete`,
+          headers: {
+            'X-CSRF-Token': csrfToken,
+          },
+        }).then((response) => {
+          expect(response.status).to.eq(200);
+        });
+      }
     });
   });
 });

--- a/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/namespace.cy.js
+++ b/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/namespace.cy.js
@@ -1,0 +1,348 @@
+/* eslint-disable no-undef */
+
+const textConstants = {
+  // Menu options
+  automationMenuOption: 'Automation',
+  embeddedAutomationMenuOption: 'Embedded Automate',
+  explorerMenuOption: 'Explorer',
+
+  // Toolbar options
+  toolbarConfiguration: 'Configuration',
+  toolbarAddNewDomain: 'Add a New Domain',
+  toolbarRemoveDomain: 'Remove this Domain',
+  toolbarAddNewNamespace: 'Add a New Namespace',
+  toolbarEditNamespace: 'Edit this Namespace',
+  toolbarRemoveNamespace: 'Remove this Namespace',
+
+  // Common selectors
+  inputFieldSelector: (inputId) =>
+    `#main-content #datastore-form-wrapper input#${inputId}`,
+  buttonSelector: (type) => `#main-content .bx--btn-set button[type="${type}"]`,
+  inputFieldLabelSelector: (forValue) =>
+    `#main-content #datastore-form-wrapper label[for="${forValue}"]`,
+
+  // Element ids
+  nameInputFieldId: 'name',
+  descriptionInputFieldId: 'description',
+  namespacePathInputFieldId: 'namespacePath',
+
+  // Button types
+  submitButtonType: 'submit',
+  normalButtonType: 'button',
+
+  // Field values
+  domainName: 'Test_Domain',
+  description: 'Test description',
+  namespaceName: 'Test_Namespace',
+  editedNamespaceName: 'Test_Namespace_Edited',
+  editedDescription: 'Test description edited',
+  invalidNamespaceName: 'Test Namespace',
+  addNamespaceFormHeader: 'Adding a new Automate Namespace',
+  editNamespaceFormHeader: 'Editing Automate Namespace',
+  namespaceFormSubHeader: 'Info',
+
+  // List items
+  dataStoreAccordionItem: 'Datastore',
+
+  // Buttons
+  addButton: 'Add',
+  cancelButton: 'Cancel',
+  saveButton: 'Save',
+  resetButton: 'Reset',
+
+  // Flash message types
+  flashTypeSuccess: 'success',
+  flashTypeWarning: 'warning',
+  flashTypeError: 'error',
+
+  // Flash message text snippets
+  flashMessageAddSuccess: 'added',
+  flashMessageSaveSuccess: 'saved',
+  flashMessageCancelled: 'cancel',
+  flashMessageInvalidNamespace: 'contain only alphanumeric',
+  flashMessageNamespaceRemoved: 'delete successful',
+  flashMessageNameAlreadyExists: 'taken',
+  flashMessageResetNamespace: 'reset',
+  browserConfirmRemoveMessage: 'remove',
+};
+
+const {
+  automationMenuOption,
+  embeddedAutomationMenuOption,
+  explorerMenuOption,
+  inputFieldSelector,
+  buttonSelector,
+  inputFieldLabelSelector,
+  addButton,
+  cancelButton,
+  resetButton,
+  saveButton,
+  domainName,
+  description,
+  toolbarConfiguration,
+  toolbarAddNewDomain,
+  toolbarAddNewNamespace,
+  toolbarEditNamespace,
+  toolbarRemoveNamespace,
+  toolbarRemoveDomain,
+  addNamespaceFormHeader,
+  editNamespaceFormHeader,
+  namespaceFormSubHeader,
+  namespaceName,
+  editedNamespaceName,
+  editedDescription,
+  invalidNamespaceName,
+  flashTypeError,
+  flashTypeSuccess,
+  flashTypeWarning,
+  flashMessageAddSuccess,
+  flashMessageSaveSuccess,
+  flashMessageCancelled,
+  flashMessageNamespaceRemoved,
+  flashMessageInvalidNamespace,
+  flashMessageNameAlreadyExists,
+  flashMessageResetNamespace,
+  browserConfirmRemoveMessage,
+  dataStoreAccordionItem,
+  nameInputFieldId,
+  descriptionInputFieldId,
+  namespacePathInputFieldId,
+  submitButtonType,
+  normalButtonType,
+} = textConstants;
+
+function addNamespace(nameFieldValue = namespaceName) {
+  // Navigating to the Add Namespace form
+  cy.toolbar(toolbarConfiguration, toolbarAddNewNamespace);
+  // Creating a new namespace
+  cy.get(inputFieldSelector(nameInputFieldId)).type(nameFieldValue);
+  cy.get(inputFieldSelector(descriptionInputFieldId)).type(description);
+  cy.contains(buttonSelector(submitButtonType), addButton).click();
+  cy.wait('@addNamespaceApi');
+}
+
+function selectAccordionTree(textValue) {
+  const aliasObject = {
+    [domainName]: 'getCreatedDomainInfo',
+    [namespaceName]: 'getCreatedNamespaceInfo',
+    [dataStoreAccordionItem]: 'getDataStoreAccordionItemInfo',
+  };
+  cy.intercept(
+    'POST',
+    new RegExp(`/miq_ae_class/tree_select\\?id=.*&text=${textValue}`)
+  ).as(aliasObject[textValue]);
+  cy.accordionItem(textValue);
+  cy.wait(`@${aliasObject[textValue]}`);
+}
+
+function validateNamespaceFormFields(isEditForm = false) {
+  // Validate form header visibility
+  cy.expect_explorer_title(
+    isEditForm
+      ? `${editNamespaceFormHeader} "${namespaceName}"`
+      : addNamespaceFormHeader
+  );
+  // Validate sub header visibility
+  cy.get('#main-content #datastore-form-wrapper h3').contains(
+    namespaceFormSubHeader
+  );
+  // Validate name-space path field visibility
+  cy.get(inputFieldLabelSelector(namespacePathInputFieldId)).should(
+    'be.visible'
+  );
+  cy.get(inputFieldSelector(namespacePathInputFieldId))
+    .should('be.visible')
+    .and('be.disabled')
+    .and(
+      'have.value',
+      isEditForm ? `/${domainName}/${namespaceName}` : `/${domainName}`
+    );
+  // Validate name field visibility
+  cy.get(inputFieldLabelSelector(nameInputFieldId)).should('be.visible');
+  cy.get(inputFieldSelector(nameInputFieldId))
+    .should('be.visible')
+    .and('be.enabled');
+  // Validate description field visibility
+  cy.get(inputFieldLabelSelector(descriptionInputFieldId)).should('be.visible');
+  cy.get(inputFieldSelector(descriptionInputFieldId))
+    .should('be.visible')
+    .and('be.enabled');
+  // Validate cancel button visibility
+  cy.get(buttonSelector(normalButtonType))
+    .contains(cancelButton)
+    .should('be.visible');
+  // Validate add/save button visibility
+  cy.get(buttonSelector(submitButtonType))
+    .contains(isEditForm ? saveButton : addButton)
+    .should('be.visible');
+  if (isEditForm) {
+    // Validate reset button visibility
+    cy.get(buttonSelector(normalButtonType))
+      .contains(resetButton)
+      .should('be.visible');
+  }
+}
+
+function createNamespaceAndOpenEditForm() {
+  // Adding a new namespace
+  addNamespace();
+  // Selecting the created namespace from the accordion list items
+  selectAccordionTree(namespaceName);
+  // Opening the edit form
+  cy.toolbar(toolbarConfiguration, toolbarEditNamespace);
+}
+
+describe('Automate operations on Namespaces: Automation -> Embedded Automate -> Explorer -> {Any-created-domain} -> Namespace form', () => {
+  beforeEach(() => {
+    cy.login();
+    cy.menu(
+      automationMenuOption,
+      embeddedAutomationMenuOption,
+      explorerMenuOption
+    );
+    // Creating a domain to test namespace operations
+    cy.toolbar(toolbarConfiguration, toolbarAddNewDomain);
+    cy.get(inputFieldSelector(nameInputFieldId)).type(domainName);
+    cy.get(inputFieldSelector(descriptionInputFieldId)).type(description);
+    cy.intercept('POST', '/miq_ae_class/create_namespace/new?button=add').as(
+      'addNamespaceApi'
+    );
+    cy.contains(buttonSelector(submitButtonType), addButton).click();
+    cy.wait('@addNamespaceApi');
+    cy.expect_flash(flashTypeSuccess, flashMessageAddSuccess);
+    // Selecting the created domain from the accordion list items
+    selectAccordionTree(domainName);
+  });
+
+  it('Validate Add Namespace form fields', () => {
+    // Navigating to the Add Namespace form
+    cy.toolbar(toolbarConfiguration, toolbarAddNewNamespace);
+
+    // Validating the form fields
+    validateNamespaceFormFields();
+
+    // Cancelling the form
+    cy.contains(buttonSelector(normalButtonType), cancelButton).click();
+  });
+
+  it('Validate Cancel button', () => {
+    // Navigating to the Add Namespace form
+    cy.toolbar(toolbarConfiguration, toolbarAddNewNamespace);
+
+    // Cancelling the form
+    cy.contains(buttonSelector(normalButtonType), cancelButton)
+      .should('be.enabled')
+      .click();
+    cy.expect_flash(flashTypeWarning, flashMessageCancelled);
+  });
+
+  it('Validate Name field allows only alphanumeric and _ . - $ characters', () => {
+    // Trying to add a namespace with invalid characters
+    addNamespace(invalidNamespaceName);
+    cy.expect_flash(flashTypeError, flashMessageInvalidNamespace);
+
+    // Cancelling the form
+    cy.contains(buttonSelector(normalButtonType), cancelButton).click();
+  });
+
+  it('Validate Edit Namespace form fields', () => {
+    // Create a namespace and open the edit form
+    createNamespaceAndOpenEditForm();
+
+    // Validating the form fields
+    validateNamespaceFormFields(true);
+
+    // Cancelling the form
+    cy.contains(buttonSelector(normalButtonType), cancelButton).click();
+  });
+
+  it('Checking whether add, edit & delete namespace works', () => {
+    // Adding a new namespace
+    addNamespace();
+    cy.expect_flash(flashTypeSuccess, flashMessageAddSuccess);
+
+    // Selecting the created namespace from the accordion list items
+    selectAccordionTree(namespaceName);
+    // Editing the namespace
+    cy.toolbar(toolbarConfiguration, toolbarEditNamespace);
+    // Checking if the Save button is disabled initially
+    cy.contains(buttonSelector(submitButtonType), saveButton).should(
+      'be.disabled'
+    );
+    cy.get(inputFieldSelector(descriptionInputFieldId))
+      .clear()
+      .type(editedDescription);
+    cy.contains(buttonSelector(submitButtonType), saveButton)
+      .should('be.enabled')
+      .click();
+    cy.expect_flash(flashTypeSuccess, flashMessageSaveSuccess);
+
+    // Deleting the namespace
+    cy.expect_browser_confirm_with_text({
+      confirmTriggerFn: () =>
+        cy.toolbar(toolbarConfiguration, toolbarRemoveNamespace),
+      containsText: browserConfirmRemoveMessage,
+    });
+    cy.expect_flash(flashTypeSuccess, flashMessageNamespaceRemoved);
+  });
+
+  it('Checking whether creating a duplicate namespace is restricted', () => {
+    // Adding a new namespace
+    addNamespace();
+    // Trying to add duplicate namespace
+    addNamespace();
+    cy.expect_flash(flashTypeError, flashMessageNameAlreadyExists);
+
+    // Cancelling the form
+    cy.contains(buttonSelector(normalButtonType), cancelButton).click();
+  });
+
+  it('Checking whether Cancel & Reset buttons work fine in the Edit form', () => {
+    // Create a namespace and open the edit form
+    createNamespaceAndOpenEditForm();
+
+    /* Validating Reset button */
+    // Checking if the Reset button is disabled initially
+    cy.contains(buttonSelector(normalButtonType), resetButton).should(
+      'be.disabled'
+    );
+    // Editing name and description fields
+    cy.get(inputFieldSelector(nameInputFieldId))
+      .clear()
+      .type(editedNamespaceName);
+    cy.get(inputFieldSelector(descriptionInputFieldId))
+      .clear()
+      .type(editedDescription);
+    // Resetting
+    cy.contains(buttonSelector(normalButtonType), resetButton)
+      .should('be.enabled')
+      .click();
+    cy.expect_flash(flashTypeWarning, flashMessageResetNamespace);
+    // Confirming the edited fields contain the old values after resetting
+    cy.get(inputFieldSelector(nameInputFieldId)).should(
+      'have.value',
+      namespaceName
+    );
+    cy.get(inputFieldSelector(descriptionInputFieldId)).should(
+      'have.value',
+      description
+    );
+
+    /* Validating Cancel button */
+    cy.contains(buttonSelector(normalButtonType), cancelButton).click();
+    cy.expect_flash(flashTypeWarning, flashMessageCancelled);
+  });
+
+  afterEach(() => {
+    // Selecting the created domain(Test_Domain) from the accordion list items
+    selectAccordionTree(dataStoreAccordionItem);
+    cy.accordionItem(domainName);
+    cy.wait('@getCreatedDomainInfo');
+    // Removing the domain
+    cy.expect_browser_confirm_with_text({
+      confirmTriggerFn: () =>
+        cy.toolbar(toolbarConfiguration, toolbarRemoveDomain),
+      containsText: browserConfirmRemoveMessage,
+    });
+  });
+});

--- a/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/namespace.cy.js
+++ b/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/namespace.cy.js
@@ -40,6 +40,9 @@ const textConstants = {
   editNamespaceFormHeader: 'Editing Automate Namespace',
   namespaceFormSubHeader: 'Info',
 
+  // List items
+  dataStoreAccordionItem: 'Datastore',
+
   // Buttons
   addButton: 'Add',
   cancelButton: 'Cancel',
@@ -98,6 +101,7 @@ const {
   flashMessageNameAlreadyExists,
   flashMessageResetNamespace,
   browserConfirmRemoveMessage,
+  dataStoreAccordionItem,
   nameInputFieldId,
   descriptionInputFieldId,
   namespacePathInputFieldId,
@@ -124,7 +128,10 @@ function selectAccordionTree(textValue) {
     'POST',
     new RegExp(`/miq_ae_class/tree_select\\?id=.*&text=${textValue}`)
   ).as(aliasObject[textValue]);
-  cy.accordionItem(textValue);
+  // Datastore is already set in the tree path, add domain/namespace to the path
+  const pathToTargetNode =
+    textValue === namespaceName ? [domainName, namespaceName] : [domainName];
+  cy.selectAccordionItem([dataStoreAccordionItem, ...pathToTargetNode]);
   cy.wait(`@${aliasObject[textValue]}`);
 }
 

--- a/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/namespace.cy.js
+++ b/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/namespace.cy.js
@@ -13,13 +13,6 @@ const textConstants = {
   toolbarEditNamespace: 'Edit this Namespace',
   toolbarRemoveNamespace: 'Remove this Namespace',
 
-  // Common selectors
-  inputFieldSelector: (inputId) =>
-    `#main-content #datastore-form-wrapper input#${inputId}`,
-  buttonSelector: (type) => `#main-content .bx--btn-set button[type="${type}"]`,
-  inputFieldLabelSelector: (forValue) =>
-    `#main-content #datastore-form-wrapper label[for="${forValue}"]`,
-
   // Element ids
   nameInputFieldId: 'name',
   descriptionInputFieldId: 'description',
@@ -27,7 +20,6 @@ const textConstants = {
 
   // Button types
   submitButtonType: 'submit',
-  normalButtonType: 'button',
 
   // Field values
   domainName: 'Test_Domain',
@@ -68,9 +60,6 @@ const {
   automationMenuOption,
   embeddedAutomationMenuOption,
   explorerMenuOption,
-  inputFieldSelector,
-  buttonSelector,
-  inputFieldLabelSelector,
   addButton,
   cancelButton,
   resetButton,
@@ -104,16 +93,15 @@ const {
   descriptionInputFieldId,
   namespacePathInputFieldId,
   submitButtonType,
-  normalButtonType,
 } = textConstants;
 
 function addNamespace(nameFieldValue = namespaceName) {
   // Navigating to the Add Namespace form
   cy.toolbar(toolbarConfiguration, toolbarAddNewNamespace);
   // Creating a new namespace
-  cy.get(inputFieldSelector(nameInputFieldId)).type(nameFieldValue);
-  cy.get(inputFieldSelector(descriptionInputFieldId)).type(description);
-  cy.contains(buttonSelector(submitButtonType), addButton).click();
+  cy.getFormInputFieldById(nameInputFieldId).type(nameFieldValue);
+  cy.getFormInputFieldById(descriptionInputFieldId).type(description);
+  cy.getFormFooterButtonByType(addButton, submitButtonType).click();
   cy.wait('@addNamespaceApi');
 }
 
@@ -141,41 +129,39 @@ function validateNamespaceFormFields(isEditForm = false) {
     namespaceFormSubHeader
   );
   // Assert name-space path field label is visible
-  cy.get(inputFieldLabelSelector(namespacePathInputFieldId)).should(
-    'be.visible'
-  );
+  cy.getFormLabelByInputId(namespacePathInputFieldId).should('be.visible');
   // Assert name-space path field is visible and disabled
-  cy.get(inputFieldSelector(namespacePathInputFieldId))
+  cy.getFormInputFieldById(namespacePathInputFieldId)
     .should('be.visible')
     .and('be.disabled')
     .invoke('val')
     .should('include', domainName);
   // Assert name field label is visible
-  cy.get(inputFieldLabelSelector(nameInputFieldId)).should('be.visible');
+  cy.getFormLabelByInputId(nameInputFieldId).should('be.visible');
   // Assert name field is visible and enabled
-  cy.get(inputFieldSelector(nameInputFieldId))
+  cy.getFormInputFieldById(nameInputFieldId)
     .should('be.visible')
     .and('be.enabled');
   // Assert description field label is visible
-  cy.get(inputFieldLabelSelector(descriptionInputFieldId)).should('be.visible');
+  cy.getFormLabelByInputId(descriptionInputFieldId).should('be.visible');
   // Assert description field is visible and enabled
-  cy.get(inputFieldSelector(descriptionInputFieldId))
+  cy.getFormInputFieldById(descriptionInputFieldId)
     .should('be.visible')
     .and('be.enabled');
   // Assert cancel button is visible and enabled
-  cy.contains(buttonSelector(normalButtonType), cancelButton)
+  cy.getFormFooterButtonByType(cancelButton)
     .should('be.visible')
     .and('be.enabled');
   // Assert add/save button is visible and disabled
-  cy.contains(
-    buttonSelector(submitButtonType),
-    isEditForm ? saveButton : addButton
+  cy.getFormFooterButtonByType(
+    isEditForm ? saveButton : addButton,
+    submitButtonType
   )
     .should('be.visible')
     .and('be.disabled');
   if (isEditForm) {
     // Assert reset button is visible and disabled
-    cy.contains(buttonSelector(normalButtonType), resetButton)
+    cy.getFormFooterButtonByType(resetButton)
       .should('be.visible')
       .and('be.disabled');
   }
@@ -229,12 +215,12 @@ describe('Automate operations on Namespaces: Automation -> Embedded Automate -> 
     /* TODO: DATA_SETUP - Refactor to use API for domain data setup */
     // Creating a domain to test namespace operations
     cy.toolbar(toolbarConfiguration, toolbarAddNewDomain);
-    cy.get(inputFieldSelector(nameInputFieldId)).type(domainName);
-    cy.get(inputFieldSelector(descriptionInputFieldId)).type(description);
+    cy.getFormInputFieldById(nameInputFieldId).type(domainName);
+    cy.getFormInputFieldById(descriptionInputFieldId).type(description);
     cy.intercept('POST', '/miq_ae_class/create_namespace/new?button=add').as(
       'addNamespaceApi'
     );
-    cy.contains(buttonSelector(submitButtonType), addButton).click();
+    cy.getFormFooterButtonByType(addButton, submitButtonType).click();
     cy.wait('@addNamespaceApi').then((interception) => {
       extractDomainIdAndTokenFromResponse(interception);
     });
@@ -251,7 +237,7 @@ describe('Automate operations on Namespaces: Automation -> Embedded Automate -> 
     validateNamespaceFormFields();
 
     // Cancelling the form
-    cy.contains(buttonSelector(normalButtonType), cancelButton).click();
+    cy.getFormFooterButtonByType(cancelButton).click();
   });
 
   it('Validate Cancel button', () => {
@@ -259,9 +245,7 @@ describe('Automate operations on Namespaces: Automation -> Embedded Automate -> 
     cy.toolbar(toolbarConfiguration, toolbarAddNewNamespace);
 
     // Cancelling the form
-    cy.contains(buttonSelector(normalButtonType), cancelButton)
-      .should('be.enabled')
-      .click();
+    cy.getFormFooterButtonByType(cancelButton).should('be.enabled').click();
     cy.expect_flash(flashTypeWarning, flashMessageCancelled);
   });
 
@@ -271,7 +255,7 @@ describe('Automate operations on Namespaces: Automation -> Embedded Automate -> 
     cy.expect_flash(flashTypeError, flashMessageInvalidNamespace);
 
     // Cancelling the form
-    cy.contains(buttonSelector(normalButtonType), cancelButton).click();
+    cy.getFormFooterButtonByType(cancelButton).click();
   });
 
   it('Validate Edit Namespace form fields', () => {
@@ -282,7 +266,7 @@ describe('Automate operations on Namespaces: Automation -> Embedded Automate -> 
     validateNamespaceFormFields(true);
 
     // Cancelling the form
-    cy.contains(buttonSelector(normalButtonType), cancelButton).click();
+    cy.getFormFooterButtonByType(cancelButton).click();
   });
 
   it('Checking whether add, edit & delete namespace works', () => {
@@ -295,13 +279,13 @@ describe('Automate operations on Namespaces: Automation -> Embedded Automate -> 
     // Editing the namespace
     cy.toolbar(toolbarConfiguration, toolbarEditNamespace);
     // Checking if the Save button is disabled initially
-    cy.contains(buttonSelector(submitButtonType), saveButton).should(
+    cy.getFormFooterButtonByType(saveButton, submitButtonType).should(
       'be.disabled'
     );
-    cy.get(inputFieldSelector(descriptionInputFieldId))
+    cy.getFormInputFieldById(descriptionInputFieldId)
       .clear()
       .type(editedDescription);
-    cy.contains(buttonSelector(submitButtonType), saveButton)
+    cy.getFormFooterButtonByType(saveButton, submitButtonType)
       .should('be.enabled')
       .click();
     cy.expect_flash(flashTypeSuccess, flashMessageSaveSuccess);
@@ -324,7 +308,7 @@ describe('Automate operations on Namespaces: Automation -> Embedded Automate -> 
     cy.expect_flash(flashTypeError, flashMessageNameAlreadyExists);
 
     // Cancelling the form
-    cy.contains(buttonSelector(normalButtonType), cancelButton).click();
+    cy.getFormFooterButtonByType(cancelButton).click();
   });
 
   it('Checking whether Cancel & Reset buttons work fine in the Edit form', () => {
@@ -333,33 +317,29 @@ describe('Automate operations on Namespaces: Automation -> Embedded Automate -> 
 
     /* Validating Reset button */
     // Checking if the Reset button is disabled initially
-    cy.contains(buttonSelector(normalButtonType), resetButton).should(
-      'be.disabled'
-    );
+    cy.getFormFooterButtonByType(resetButton).should('be.disabled');
     // Editing name and description fields
-    cy.get(inputFieldSelector(nameInputFieldId))
+    cy.getFormInputFieldById(nameInputFieldId)
       .clear()
       .type(editedNamespaceName);
-    cy.get(inputFieldSelector(descriptionInputFieldId))
+    cy.getFormInputFieldById(descriptionInputFieldId)
       .clear()
       .type(editedDescription);
     // Resetting
-    cy.contains(buttonSelector(normalButtonType), resetButton)
-      .should('be.enabled')
-      .click();
+    cy.getFormFooterButtonByType(resetButton).should('be.enabled').click();
     cy.expect_flash(flashTypeWarning, flashMessageResetNamespace);
     // Confirming the edited fields contain the old values after resetting
-    cy.get(inputFieldSelector(nameInputFieldId)).should(
+    cy.getFormInputFieldById(nameInputFieldId).should(
       'have.value',
       namespaceName
     );
-    cy.get(inputFieldSelector(descriptionInputFieldId)).should(
+    cy.getFormInputFieldById(descriptionInputFieldId).should(
       'have.value',
       description
     );
 
     /* Validating Cancel button */
-    cy.contains(buttonSelector(normalButtonType), cancelButton).click();
+    cy.getFormFooterButtonByType(cancelButton).click();
     cy.expect_flash(flashTypeWarning, flashMessageCancelled);
   });
 

--- a/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/namespace.cy.js
+++ b/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/namespace.cy.js
@@ -36,8 +36,7 @@ const textConstants = {
   editedNamespaceName: 'Test_Namespace_Edited',
   editedDescription: 'Test description edited',
   invalidNamespaceName: 'Test Namespace',
-  addNamespaceFormHeader: 'Adding a new Automate Namespace',
-  editNamespaceFormHeader: 'Editing Automate Namespace',
+  namespaceFormHeader: 'Automate Namespace',
   namespaceFormSubHeader: 'Info',
 
   // List items
@@ -83,8 +82,7 @@ const {
   toolbarAddNewNamespace,
   toolbarEditNamespace,
   toolbarRemoveNamespace,
-  addNamespaceFormHeader,
-  editNamespaceFormHeader,
+  namespaceFormHeader,
   namespaceFormSubHeader,
   namespaceName,
   editedNamespaceName,
@@ -136,50 +134,50 @@ function selectAccordionTree(textValue) {
 }
 
 function validateNamespaceFormFields(isEditForm = false) {
-  // Validate form header visibility
-  cy.expect_explorer_title(
-    isEditForm
-      ? `${editNamespaceFormHeader} "${namespaceName}"`
-      : addNamespaceFormHeader
-  );
-  // Validate sub header visibility
+  // Assert form header is visible
+  cy.expect_explorer_title(namespaceFormHeader);
+  // Assert sub header is visible
   cy.get('#main-content #datastore-form-wrapper h3').contains(
     namespaceFormSubHeader
   );
-  // Validate name-space path field visibility
+  // Assert name-space path field label is visible
   cy.get(inputFieldLabelSelector(namespacePathInputFieldId)).should(
     'be.visible'
   );
+  // Assert name-space path field is visible and disabled
   cy.get(inputFieldSelector(namespacePathInputFieldId))
     .should('be.visible')
     .and('be.disabled')
-    .and(
-      'have.value',
-      isEditForm ? `/${domainName}/${namespaceName}` : `/${domainName}`
-    );
-  // Validate name field visibility
+    .invoke('val')
+    .should('include', domainName);
+  // Assert name field label is visible
   cy.get(inputFieldLabelSelector(nameInputFieldId)).should('be.visible');
+  // Assert name field is visible and enabled
   cy.get(inputFieldSelector(nameInputFieldId))
     .should('be.visible')
     .and('be.enabled');
-  // Validate description field visibility
+  // Assert description field label is visible
   cy.get(inputFieldLabelSelector(descriptionInputFieldId)).should('be.visible');
+  // Assert description field is visible and enabled
   cy.get(inputFieldSelector(descriptionInputFieldId))
     .should('be.visible')
     .and('be.enabled');
-  // Validate cancel button visibility
-  cy.get(buttonSelector(normalButtonType))
-    .contains(cancelButton)
-    .should('be.visible');
-  // Validate add/save button visibility
-  cy.get(buttonSelector(submitButtonType))
-    .contains(isEditForm ? saveButton : addButton)
-    .should('be.visible');
+  // Assert cancel button is visible and enabled
+  cy.contains(buttonSelector(normalButtonType), cancelButton)
+    .should('be.visible')
+    .and('be.enabled');
+  // Assert add/save button is visible and disabled
+  cy.contains(
+    buttonSelector(submitButtonType),
+    isEditForm ? saveButton : addButton
+  )
+    .should('be.visible')
+    .and('be.disabled');
   if (isEditForm) {
-    // Validate reset button visibility
-    cy.get(buttonSelector(normalButtonType))
-      .contains(resetButton)
-      .should('be.visible');
+    // Assert reset button is visible and disabled
+    cy.contains(buttonSelector(normalButtonType), resetButton)
+      .should('be.visible')
+      .and('be.disabled');
   }
 }
 

--- a/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/namespace.cy.js
+++ b/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/namespace.cy.js
@@ -177,6 +177,7 @@ function validateNamespaceFormFields(isEditForm = false) {
 }
 
 function createNamespaceAndOpenEditForm() {
+  /* TODO: DATA_SETUP - Use API for namespace setup, excluding the test meant to validate functionality via UI */
   // Adding a new namespace
   addNamespace();
   // Selecting the created namespace from the accordion list items
@@ -220,6 +221,7 @@ describe('Automate operations on Namespaces: Automation -> Embedded Automate -> 
       embeddedAutomationMenuOption,
       explorerMenuOption
     );
+    /* TODO: DATA_SETUP - Refactor to use API for domain data setup */
     // Creating a domain to test namespace operations
     cy.toolbar(toolbarConfiguration, toolbarAddNewDomain);
     cy.get(inputFieldSelector(nameInputFieldId)).type(domainName);
@@ -309,6 +311,7 @@ describe('Automate operations on Namespaces: Automation -> Embedded Automate -> 
   });
 
   it('Checking whether creating a duplicate namespace is restricted', () => {
+    /* TODO: DATA_SETUP - Use API for namespace setup, excluding the test meant to validate functionality via UI */
     // Adding a new namespace
     addNamespace();
     // Trying to add duplicate namespace


### PR DESCRIPTION
CP4AIOPS-16490
Pr that adds cypress tests for Namespace form(Automation -> Embedded Automate -> Explorer -> {Any-created-domain} -> Namespace form)
 - Validates add Namespace form behaviour
 - Validates adding a Namespace
 - Validates editing a Namespace
 - Validates deleting a Namespace
 - Validates edit Namespace form behaviour
 - Validates duplicate namespace creation restriction
 
 @miq-bot assign @GilbertCherrie
@miq-bot add-label cypress
@miq-bot add-label test
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
