### PR TITLE
Bypass feature validation for dynamic tenant features

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -17,6 +17,8 @@ module OpsController::OpsRbac
       end
 
       options[:feature] = MiqProductFeature.tenant_identifier(options[:feature], id)
+      # dynamic tenant feature identifiers need to bypass feature validation
+      options[:skip_feature_validation] = true
     end
 
     super(**options)

--- a/cypress/e2e/ui/Settings/Application-Settings/settings_access_control.cy.js
+++ b/cypress/e2e/ui/Settings/Application-Settings/settings_access_control.cy.js
@@ -1,0 +1,70 @@
+/* eslint-disable no-undef */
+
+const textConstants = {
+  // Menu options
+  settingsMenuOption: 'Settings',
+  appSettingsMenuOption: 'Application Settings',
+  toolBarConfigMenu: 'Configuration',
+
+  // added item information
+  initialTenantName: 'Test-name',
+  initialTenantDescription: 'test description',
+
+  // List items
+  accessControlAccordion: 'Access Control',
+
+  // flash message assertions
+  flashMessageOperationAdded: 'added',
+  flashMessageOperationDeleted: 'delete',
+  flashTypeSuccess: 'success',
+
+  // Configuration menu options and browser alert text snippets
+  deleteItem: 'Delete this item',
+}
+
+const {
+  accessControlAccordion,
+  appSettingsMenuOption,
+  deleteItem,
+  flashMessageOperationAdded,
+  flashMessageOperationDeleted,
+  flashTypeSuccess,
+  initialTenantDescription,
+  initialTenantName,
+  settingsMenuOption,
+  toolBarConfigMenu,
+} = textConstants;
+
+describe('Settings > Application Settings > Access Control', () => {
+  beforeEach(() => {
+    cy.login();
+    cy.menu(settingsMenuOption, appSettingsMenuOption);
+    cy.accordion(accessControlAccordion);
+  });
+
+  it('should be able to create and delete a tenant', () => {
+    cy.selectAccordionItem([
+       /^ManageIQ Region/,
+       'Tenants',
+       'My Company',
+    ]);
+
+    cy.toolbar(toolBarConfigMenu, 'Add child Tenant to this Tenant');
+    cy.getFormInputFieldById('name').type(initialTenantName);
+    cy.getFormInputFieldById('description').type(initialTenantDescription);
+    cy.getFormFooterButtonByType('Add', 'submit').click();
+    cy.expect_flash(flashTypeSuccess, flashMessageOperationAdded);
+    cy.selectAccordionItem([
+       /^ManageIQ Region/,
+       'Tenants',
+       'My Company',
+       initialTenantName
+    ]);
+
+    cy.expect_browser_confirm_with_text({
+      confirmTriggerFn: () => cy.toolbar(toolBarConfigMenu, deleteItem),
+      containsText: deleteItem,
+    });
+    cy.expect_flash(flashTypeSuccess, flashMessageOperationDeleted);
+  });
+});

--- a/cypress/e2e/ui/Settings/Application-Settings/settings_access_control.cy.js
+++ b/cypress/e2e/ui/Settings/Application-Settings/settings_access_control.cy.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-undef */
+import { flashClassMap } from '../../../../support/assertions/assertion_constants';
 
 const textConstants = {
   // Menu options
@@ -16,7 +17,6 @@ const textConstants = {
   // flash message assertions
   flashMessageOperationAdded: 'added',
   flashMessageOperationDeleted: 'delete',
-  flashTypeSuccess: 'success',
 
   // Configuration menu options and browser alert text snippets
   deleteItem: 'Delete this item',
@@ -28,7 +28,6 @@ const {
   deleteItem,
   flashMessageOperationAdded,
   flashMessageOperationDeleted,
-  flashTypeSuccess,
   initialTenantDescription,
   initialTenantName,
   settingsMenuOption,
@@ -53,7 +52,7 @@ describe('Settings > Application Settings > Access Control', () => {
     cy.getFormInputFieldById('name').type(initialTenantName);
     cy.getFormInputFieldById('description').type(initialTenantDescription);
     cy.getFormFooterButtonByType('Add', 'submit').click();
-    cy.expect_flash(flashTypeSuccess, flashMessageOperationAdded);
+    cy.expect_flash(flashClassMap.success, flashMessageOperationAdded);
     cy.selectAccordionItem([
        /^ManageIQ Region/,
        'Tenants',
@@ -65,6 +64,6 @@ describe('Settings > Application Settings > Access Control', () => {
       confirmTriggerFn: () => cy.toolbar(toolBarConfigMenu, deleteItem),
       containsText: deleteItem,
     });
-    cy.expect_flash(flashTypeSuccess, flashMessageOperationDeleted);
+    cy.expect_flash(flashClassMap.success, flashMessageOperationDeleted);
   });
 });

--- a/cypress/e2e/ui/Settings/Application-Settings/settings_access_control.cy.js
+++ b/cypress/e2e/ui/Settings/Application-Settings/settings_access_control.cy.js
@@ -1,44 +1,26 @@
 /* eslint-disable no-undef */
 import { flashClassMap } from '../../../../support/assertions/assertion_constants';
 
-const textConstants = {
-  // Menu options
-  settingsMenuOption: 'Settings',
-  appSettingsMenuOption: 'Application Settings',
-  toolBarConfigMenu: 'Configuration',
-
-  // added item information
-  initialTenantName: 'Test-name',
-  initialTenantDescription: 'test description',
-
-  // List items
-  accessControlAccordion: 'Access Control',
-
-  // flash message assertions
-  flashMessageOperationAdded: 'added',
-  flashMessageOperationDeleted: 'delete',
-
-  // Configuration menu options and browser alert text snippets
-  deleteItem: 'Delete this item',
-}
-
-const {
-  accessControlAccordion,
-  appSettingsMenuOption,
-  deleteItem,
-  flashMessageOperationAdded,
-  flashMessageOperationDeleted,
-  initialTenantDescription,
-  initialTenantName,
-  settingsMenuOption,
-  toolBarConfigMenu,
-} = textConstants;
-
 describe('Settings > Application Settings > Access Control', () => {
+  // Navigation
+  const PRIMARY_MENU_OPTION = 'Settings';
+  const SECONDARY_MENU_OPTION = 'Application Settings';
+  const ACCORDION = 'Access Control';
+  const TOOLBAR_MENU = 'Configuration';
+
+  // Created item information
+  const INITIAL_TENANT_NAME = 'Test-name';
+  const INITIAL_TENANT_DESCRIPTION = 'test description';
+
+  // CRUD actions
+  const FLASH_MESSAGE_OPERATION_ADDED = 'added';
+  const FLASH_MESSAGE_OPERATION_DELETED = 'delete';
+  const DELETE_ITEM = 'Delete this item';
+
   beforeEach(() => {
     cy.login();
-    cy.menu(settingsMenuOption, appSettingsMenuOption);
-    cy.accordion(accessControlAccordion);
+    cy.menu(PRIMARY_MENU_OPTION, SECONDARY_MENU_OPTION);
+    cy.accordion(ACCORDION);
   });
 
   it('should be able to create and delete a tenant', () => {
@@ -48,22 +30,22 @@ describe('Settings > Application Settings > Access Control', () => {
        'My Company',
     ]);
 
-    cy.toolbar(toolBarConfigMenu, 'Add child Tenant to this Tenant');
-    cy.getFormInputFieldById('name').type(initialTenantName);
-    cy.getFormInputFieldById('description').type(initialTenantDescription);
+    cy.toolbar(TOOLBAR_MENU, 'Add child Tenant to this Tenant');
+    cy.getFormInputFieldById('name').type(INITIAL_TENANT_NAME);
+    cy.getFormInputFieldById('description').type(INITIAL_TENANT_DESCRIPTION);
     cy.getFormFooterButtonByType('Add', 'submit').click();
-    cy.expect_flash(flashClassMap.success, flashMessageOperationAdded);
+    cy.expect_flash(flashClassMap.success, FLASH_MESSAGE_OPERATION_ADDED);
     cy.selectAccordionItem([
        /^ManageIQ Region/,
        'Tenants',
        'My Company',
-       initialTenantName
+       INITIAL_TENANT_NAME
     ]);
 
     cy.expect_browser_confirm_with_text({
-      confirmTriggerFn: () => cy.toolbar(toolBarConfigMenu, deleteItem),
-      containsText: deleteItem,
+      confirmTriggerFn: () => cy.toolbar(TOOLBAR_MENU, DELETE_ITEM),
+      containsText: DELETE_ITEM,
     });
-    cy.expect_flash(flashClassMap.success, flashMessageOperationDeleted);
+    cy.expect_flash(flashClassMap.success, FLASH_MESSAGE_OPERATION_DELETED);
   });
 });


### PR DESCRIPTION
#   Bypass feature validation for dynamic tenant features

We expect a one to one feature assignment with existing product features.
This doesn't work with dynamic tenant features.

This dynamic tenant feature was only ever implemented for tenant quotas.

Related to:
https://github.com/ManageIQ/manageiq-ui-classic/pull/5123
https://github.com/ManageIQ/manageiq-ui-classic/pull/5129
https://github.com/ManageIQ/manageiq-ui-classic/pull/5142

Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/9512
#   Add a test for Settings, Access Control, Tenant Add and Delete

This recreates the issue found in https://github.com/ManageIQ/manageiq-ui-classic/issues/9512
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
