### PR TITLE
Extract the tenant id from the x_node

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -9,13 +9,8 @@ module OpsController::OpsRbac
   }.freeze
 
   def role_allows?(**options)
-    if MiqProductFeature.my_root_tenant_identifier?(options[:feature]) && params.key?(:id) && params[:id] != 'xx-tn'
-      if params[:id].to_s.include?('tn')
-        _, id, _ = TreeBuilder.extract_node_model_and_id(params[:id].to_s)
-      else
-        id = params[:id].to_s
-      end
-
+    if MiqProductFeature.my_root_tenant_identifier?(options[:feature]) && self.x_node.to_s.start_with?("tn-")
+        _, id, _ = TreeBuilder.extract_node_model_and_id(self.x_node.to_s)
       options[:feature] = MiqProductFeature.tenant_identifier(options[:feature], id)
     end
 


### PR DESCRIPTION
Using params for the action rbac_tenant_delete is correct for this action.

It should not be used for any role_allows? calls as they can be for doing different actions/product features.  For example, after deleting a tenant, the subsequent call to replace the right cell and update the screen after the deletion should not refer to an already deleted tenant.

Fixes #9512.  Replaces #9523

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
