### PR TITLE
Fixed toolbar to throw error on wrong option

### DIFF
--- a/cypress/README.md
+++ b/cypress/README.md
@@ -56,6 +56,10 @@ ManageIQ implements the following cypress extensions:
 * `cy.toolbarItems(toolbarButton)` - returns an array of objects {text: String, disabled: Boolean} for the toolbar dropdown buttons for when a toolbar button is clicked. `toolbarButton` is the string for the text of the toolbar button that you want to click on.
 * `cy.toolbar(toolbarButton, toolbarOption)` - click on the toolbar button specified by the user. Can also then click on a specified dropdown button as well. `toolbarButton` is the string for the text of the toolbar button that you want to click on. `toolbarOption` is the string for the text of the toolbar dropdown option that you want to click on.
 
+##### custom_logging_commands
+
+* `cy.logAndThrowError(messageToLog, messageToThrow)` - Logs a custom error message to Cypress log and then throws an error. `messageToLog` is the message to display in the Cypress command log. `messageToThrow` is the optional error message to throw, defaults to `messageToLog`. e.g. `cy.logAndThrowError('This is the logged message', 'This is the thrown error message');`, `cy.logAndThrowError('This is the message that gets logged and thrown');`
+
 #### Assertions
 
 * `cy.expect_explorer_title(title)` - check that the title on an explorer screen matches the provided title. `title`: String for the title.

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -54,7 +54,7 @@ ManageIQ implements the following cypress extensions:
 ##### toolbar
 
 * `cy.toolbarItems(toolbarButton)` - returns an array of objects {text: String, disabled: Boolean} for the toolbar dropdown buttons for when a toolbar button is clicked. `toolbarButton` is the string for the text of the toolbar button that you want to click on.
-* `cy.toolbar(toolbarButton, dropdownButton)` - click on the toolbar button specified by the user. Can also then click on a specified dropdown button as well. `toolbarButton` is the string for the text of the toolbar button that you want to click on. `dropdownButton` is the string for the text of the toolbar dropdown button that you want to click on. s
+* `cy.toolbar(toolbarButton, toolbarOption)` - click on the toolbar button specified by the user. Can also then click on a specified dropdown button as well. `toolbarButton` is the string for the text of the toolbar button that you want to click on. `toolbarOption` is the string for the text of the toolbar dropdown option that you want to click on.
 
 #### Assertions
 

--- a/cypress/support/commands/custom_logging_commands.js
+++ b/cypress/support/commands/custom_logging_commands.js
@@ -1,0 +1,19 @@
+/* eslint-disable no-undef */
+
+/**
+ * Logs a custom error message to Cypress log and then throws an error.
+ *
+ * @param {string} messageToLog - The message to display in the Cypress command log.
+ * @param {string} [messageToThrow] - Optional error message to throw, defaults to messageToLog
+ *
+ * Usage:
+ * cy.logAndThrowError('This is the logged message', 'This is the thrown error message');
+ */
+Cypress.Commands.add('logAndThrowError', (messageToLog, messageToThrow) => {
+  Cypress.log({
+    name: 'error',
+    displayName: '❗ CypressError:',
+    message: messageToLog,
+  });
+  throw new Error(messageToThrow || messageToLog);
+});

--- a/cypress/support/commands/toolbar.js
+++ b/cypress/support/commands/toolbar.js
@@ -12,14 +12,7 @@ Cypress.Commands.add('toolbar', (toolbarButton, toolbarOption = '') => {
       );
 
       if (!targetToolbarButton) {
-        // throw error if given toolbar button is not found
-        const errorMessage = `Toolbar button: "${toolbarButton}" was not found`;
-        Cypress.log({
-          name: 'error',
-          displayName: '❗ CypressError:',
-          message: errorMessage,
-        });
-        throw new Error(errorMessage);
+        cy.logAndThrowError(`Toolbar button: "${toolbarButton}" was not found`);
       }
       return cy.wrap(targetToolbarButton).click();
     });
@@ -34,14 +27,7 @@ Cypress.Commands.add('toolbar', (toolbarButton, toolbarOption = '') => {
         );
 
         if (!targetToolbarOption) {
-          // throw error if given toolbar option is not found
-          const errorMessage = `"${toolbarOption}" option was not found in the "${toolbarButton}" toolbar`;
-          Cypress.log({
-            name: 'error',
-            displayName: '❗ CypressError:',
-            message: errorMessage,
-          });
-          throw new Error(errorMessage);
+          cy.logAndThrowError(`"${toolbarOption}" option was not found in the "${toolbarButton}" toolbar`);
         }
         // returning the cypress chainable to the top of the command scope
         return cy.wrap(targetToolbarOption).click();

--- a/cypress/support/commands/toolbar.js
+++ b/cypress/support/commands/toolbar.js
@@ -1,55 +1,56 @@
 /* eslint-disable no-undef */
 
 // toolbarButton: String for the text of the toolbar button to click.
-// dropdownButton: String for the text of the dropdown button to click after the toolbar dropdown is opened.
-Cypress.Commands.add('toolbar', (toolbarButton, dropdownButton = '') => {
-  cy.get('#toolbar').get('button').then((toolbarButtons) => {
-    const nums = [...Array(toolbarButtons.length).keys()];
-    let toolbarButtonMatched = false;
-    nums.forEach((index) => {
-      const button = toolbarButtons[index].children[0];
-      if (button && button.innerText && button.innerText.includes(toolbarButton)) {
-        toolbarButtonMatched = true;
-        button.click();
-        return;
-      }
-    });
-    if (!toolbarButtonMatched) {
-      // throw error if given toolbar button is not found
-      const errorMessage = `Toolbar button: "${toolbarButton}" was not found`;
-      Cypress.log({
-        name: 'error',
-        displayName: '❗ CypressError:',
-        message: errorMessage,
-      });
-      throw new Error(errorMessage);
-    }
-  });
+// toolbarOption: String for the text of the dropdown button to click after the toolbar dropdown is opened.
+Cypress.Commands.add('toolbar', (toolbarButton, toolbarOption = '') => {
+  const clickToolbarButton = cy
+    .get('#toolbar')
+    .find('button')
+    .then((buttons) => {
+      const targetToolbarButton = [...buttons].find(
+        (btn) => btn.innerText.trim() === toolbarButton
+      );
 
-  if (dropdownButton) {
-    return cy.get('.bx--overflow-menu-options').then((dropdownButtons) => {
-      const buttons = dropdownButtons.children();
-      for (let index = 0; index < buttons.length; index++) {
-        const button = buttons[index];
-        if (
-          button &&
-          button.innerText &&
-          button.innerText.includes(dropdownButton)
-        ) {
-          return cy.wrap(button.children[0]).click();
-        }
+      if (!targetToolbarButton) {
+        // throw error if given toolbar button is not found
+        const errorMessage = `Toolbar button: "${toolbarButton}" was not found`;
+        Cypress.log({
+          name: 'error',
+          displayName: '❗ CypressError:',
+          message: errorMessage,
+        });
+        throw new Error(errorMessage);
       }
-      // throw error if given dropdown button is not found
-      const errorMessage = `"${dropdownButton}" option was not found in the "${toolbarButton}" toolbar`;
-      Cypress.log({
-        name: 'error',
-        displayName: '❗ CypressError:',
-        message: errorMessage,
+      return cy.wrap(targetToolbarButton).click();
+    });
+
+  // If toolbarOption is provided, wait for toolbar to open,
+  // then look for the given toolbar option
+  if (toolbarOption) {
+    return clickToolbarButton.then(() => {
+      return cy.get('.bx--overflow-menu-options li').then((toolbarOptions) => {
+        const targetToolbarOption = [...toolbarOptions].find(
+          (option) => option.innerText.trim() === toolbarOption
+        );
+
+        if (!targetToolbarOption) {
+          // throw error if given toolbar option is not found
+          const errorMessage = `"${toolbarOption}" option was not found in the "${toolbarButton}" toolbar`;
+          Cypress.log({
+            name: 'error',
+            displayName: '❗ CypressError:',
+            message: errorMessage,
+          });
+          throw new Error(errorMessage);
+        }
+        // returning the cypress chainable to the top of the command scope
+        return cy.wrap(targetToolbarOption).click();
       });
-      throw new Error(errorMessage);
     });
   }
-  return cy.wrap(null);
+
+  // else, just return the toolbar button click chain
+  return clickToolbarButton;
 });
 
 // toolbarButton: String for the text of the toolbar button to click.

--- a/cypress/support/commands/toolbar.js
+++ b/cypress/support/commands/toolbar.js
@@ -5,13 +5,25 @@
 Cypress.Commands.add('toolbar', (toolbarButton, dropdownButton = '') => {
   cy.get('#toolbar').get('button').then((toolbarButtons) => {
     const nums = [...Array(toolbarButtons.length).keys()];
+    let toolbarButtonMatched = false;
     nums.forEach((index) => {
       const button = toolbarButtons[index].children[0];
       if (button && button.innerText && button.innerText.includes(toolbarButton)) {
+        toolbarButtonMatched = true;
         button.click();
         return;
       }
     });
+    if (!toolbarButtonMatched) {
+      // throw error if given toolbar button is not found
+      const errorMessage = `Toolbar button: "${toolbarButton}" was not found`;
+      Cypress.log({
+        name: 'error',
+        displayName: '❗ CypressError:',
+        message: errorMessage,
+      });
+      throw new Error(errorMessage);
+    }
   });
 
   if (dropdownButton) {
@@ -27,7 +39,14 @@ Cypress.Commands.add('toolbar', (toolbarButton, dropdownButton = '') => {
           return cy.wrap(button.children[0]).click();
         }
       }
-      return cy.wrap(null);
+      // throw error if given dropdown button is not found
+      const errorMessage = `"${dropdownButton}" option was not found in the "${toolbarButton}" toolbar`;
+      Cypress.log({
+        name: 'error',
+        displayName: '❗ CypressError:',
+        message: errorMessage,
+      });
+      throw new Error(errorMessage);
     });
   }
   return cy.wrap(null);

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -40,21 +40,21 @@
 // ***********************************************************
 
 // Commands
-import './commands/explorer.js'
-import './commands/gtl.js'
-import './commands/login.js'
-import './commands/menu.js'
-import './commands/stub_notifications.js'
-import './commands/toolbar.js'
-import './commands/throttle_response.js'
-import './commands/custom_logging_commands.js'
+import './commands/custom_logging_commands.js';
+import './commands/explorer.js';
+import './commands/gtl.js';
+import './commands/login.js';
+import './commands/menu.js';
+import './commands/stub_notifications.js';
+import './commands/throttle_response.js';
+import './commands/toolbar.js';
 
 // Assertions
-import './assertions/expect_rates_table.js';
-import './assertions/expect_search_box.js'
-import './assertions/expect_title.js'
-import './assertions/expect_text.js'
 import './assertions/expect_alerts.js';
+import './assertions/expect_rates_table.js';
+import './assertions/expect_search_box.js';
+import './assertions/expect_text.js';
+import './assertions/expect_title.js';
 
 // This is needed to prevent Cypress tests from failing due to uncaught errors:
 // Undefined errors are occuring on every initial page load of Manage IQ

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -47,6 +47,7 @@ import './commands/menu.js'
 import './commands/stub_notifications.js'
 import './commands/toolbar.js'
 import './commands/throttle_response.js'
+import './commands/custom_logging_commands.js'
 
 // Assertions
 import './assertions/expect_rates_table.js';


### PR DESCRIPTION
### Before:
When an invalid toolbar option is provided - `cy.toolbar('Configuration', 'Add a new Timesheet')`, the test would still continue and fail at a later stage
<img width="2126" height="1850" alt="image" src="https://github.com/user-attachments/assets/464c9591-1b43-4ced-b49a-011fbf57bc02" />
### After:
Errors out when the toolbar option is not found:
<img width="1886" height="1620" alt="image" src="https://github.com/user-attachments/assets/d5f9b5f1-442d-4c11-b7cd-c47b61da8e57" />


### Before:
If a wrong toolbar button name is given - `cy.toolbar('Applications')`, the test continues execution and fails downstream, masking the actual cause:
<img width="2216" height="1720" alt="image" src="https://github.com/user-attachments/assets/d107617f-5202-48e8-8e3f-f958f42f2738" />
### After:
Errors out when the toolbar button name is not found:
<img width="1934" height="1692" alt="image" src="https://github.com/user-attachments/assets/6ce993c4-c554-4d0a-b423-af561242a5c8" />


### Before:
Even when the toolbar button name is incorrect - `cy.toolbar('Applications', 'Add a new Schedule')`, the test continues to look for a matching toolbar option:
<img width="2108" height="1726" alt="image" src="https://github.com/user-attachments/assets/40a1d809-52e7-407c-89b7-726e9ac0fc75" />
### After:
Immediately errors out when the toolbar button name is not found, skipping further option matching:
<img width="1890" height="1668" alt="image" src="https://github.com/user-attachments/assets/a988af51-1df0-4f43-959d-25b13447683c" />

### After:
Improved chainability when matches are found, can be used like:
   ```
cy.toolbar('Configuration').then(() => {
      // do something
    });
```
```
cy.toolbar('Configuration', 'Add a new Schedule').then(() => {
      // do something
    });
```


@miq-bot assign @GilbertCherrie 
@miq-bot add-label cypress
@miq-bot add-label test

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
