### PR TITLE
Add custom commands for selecting form elements

### DIFF
--- a/cypress/README.md
+++ b/cypress/README.md
@@ -61,6 +61,13 @@ ManageIQ implements the following cypress extensions:
 
 * `cy.logAndThrowError(messageToLog, messageToThrow)` - Logs a custom error message to Cypress log and then throws an error. `messageToLog` is the message to display in the Cypress command log. `messageToThrow` is the optional error message to throw, defaults to `messageToLog`. e.g. `cy.logAndThrowError('This is the logged message', 'This is the thrown error message');`, `cy.logAndThrowError('This is the message that gets logged and thrown');`
 
+##### element_selectors
+
+* `cy.getFormFooterButtonByType(name, type)` - retrieves form footer button by its name and type. `name` is the name or text content of the button. `type` is the HTML button type (e.g., 'button', 'submit', 'reset'). Defaults to 'button'. e.g. `cy.getFormFooterButtonByType('Save');`, `cy.getFormFooterButtonByType('Reset', 'reset');`
+* `cy.getFormInputFieldById(inputId, type)` - retrieves a form input field by its ID and type. `inputId` is the ID of the input field. `type` is the HTML input type (e.g., 'text', 'email', 'password'). Defaults to 'text'. e.g. `cy.getFormInputFieldById('name');`, `cy.getFormInputFieldById('name', 'text');`
+* `getFormLabelByInputId(inputId)` - retrieves a form label associated with a specific input field by its ID. `inputId` is the ID of the input field. e.g. `cy.getFormLabelByInputId('name');`
+* `cy.getFormSelectFieldById(selectId)` - retrieves a form select field by its ID. `selectId` is the ID of the select field. e.g. `cy.getFormSelectFieldById('select-scan-limit');`
+
 #### Assertions
 
 * `cy.expect_explorer_title(title)` - check that the title on an explorer screen matches the provided title. `title`: String for the title.

--- a/cypress/support/commands/element_selectors.js
+++ b/cypress/support/commands/element_selectors.js
@@ -1,0 +1,57 @@
+/* eslint-disable no-undef */
+
+/**
+ * Retrieves a form footer button by its name and type.
+ *
+ * @param {string} name - The name or text content of the button.
+ * @param {string} [type='button'] - The HTML button type (e.g., 'button', 'submit', 'reset'). Defaults to 'button'.
+ * @returns {Element} The matched button element.
+ *
+ * Example:
+ *   cy.getFormFooterButtonByType('Save Changes');
+ *   cy.getFormFooterButtonByType('Reset', 'reset');
+ */
+Cypress.Commands.add('getFormFooterButtonByType', (name, type = 'button') =>
+  cy.contains(`#main-content .bx--btn-set button[type="${type}"]`, name)
+);
+
+/**
+ * Retrieves a form input field by its ID and type.
+ *
+ * @param {string} inputId - The ID of the input field.
+ * @param {string} [type='text'] - The HTML input type (e.g., 'text', 'email', 'password'). Defaults to 'text'.
+ * @returns {Element} The matched input field element.
+ *
+ * Example:
+ *   cy.getFormInputFieldById('name');
+ *   cy.getFormInputFieldById('name', 'text');
+ */
+Cypress.Commands.add('getFormInputFieldById', (inputId, type = 'text') =>
+  cy.get(`#main-content .bx--form input#${inputId}[type="${type}"]`)
+);
+
+/**
+ * Retrieves a form label associated with a specific input field by its ID.
+ *
+ * @param {string} inputId - The ID of the input field.
+ * @returns {Element} The matched label element.
+ *
+ * Example:
+ *   cy.getFormLabelByInputId('name');
+ */
+Cypress.Commands.add('getFormLabelByInputId', (inputId) =>
+  cy.get(`#main-content .bx--form label[for="${inputId}"]`)
+);
+
+/**
+ * Retrieves a form select field by its ID.
+ *
+ * @param {string} selectId - The ID of the select field.
+ * @returns {Element} The matched select field element.
+ *
+ * Example:
+ *   cy.getFormSelectFieldById('select-scan-limit');
+ */
+Cypress.Commands.add('getFormSelectFieldById', (selectId) =>
+  cy.get(`#main-content .bx--form select#${selectId}`)
+);

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -41,6 +41,7 @@
 
 // Commands
 import './commands/custom_logging_commands.js';
+import './commands/element_selectors.js';
 import './commands/explorer.js';
 import './commands/gtl.js';
 import './commands/login.js';


### PR DESCRIPTION
This PR adds reusable selector commands for form elements to avoid repeating selector strings and ease future updates.

@miq-bot assign @jrafanie 
@miq-bot add-label cypress
@miq-bot add-label test
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
