### PR TITLE
Include accordion name in error message

### DIFF
--- a/cypress/support/commands/explorer.js
+++ b/cypress/support/commands/explorer.js
@@ -33,9 +33,9 @@ Cypress.Commands.add('accordionItem', (name) => {
  * If the path is not found, it will throw an error.
  */
 Cypress.Commands.add('selectAccordionItem', (accordionPath) => {
-  cy.get('div.panel-collapse.collapse.in li.list-group-item').then(($items) => {
-    // Converting jQuery collection to an array for easier manipulation
-    const listItems = [...$items];
+  cy.get('div.panel-collapse.collapse.in').then((expandedAccordion) => {
+    // Converting the list-items jQuery collection to an array for easier manipulation
+    const listItems = [...expandedAccordion.find('li.list-group-item')];
 
     /**
      * Function to recursively expand the accordion and click the target item.
@@ -105,16 +105,16 @@ Cypress.Commands.add('selectAccordionItem', (accordionPath) => {
           return;
         }
       }
-      // If we reach here, it means the label was not found
+      // Reaching this point indicates the label was not found - throw an error and exit.
+      // Traversing up through the ancestors to get the name of the accordion where the lookup was performed
+      const accordionPanel = expandedAccordion
+        .closest('.panel')
+        .find('.panel-heading h4.panel-title a')
+        .text();
       const errorMessage = `${
         isClickableNode ? 'Target' : 'Intermediate'
-      } node - "${accordionLabel}" was not found`;
-      Cypress.log({
-        name: 'error',
-        displayName: '❗ CypressError:',
-        message: errorMessage,
-      });
-      throw new Error(errorMessage);
+      } node - "${accordionLabel}" was not found in the expanded "${accordionPanel}" accordion panel.`;
+      cy.logAndThrowError(errorMessage);
     };
 
     // Start the recursive call from the first label in the given path


### PR DESCRIPTION
PR to include accordion name in the error message when target/intermediate node is not found.

This is the tree structure and the list items we iterate over are nested inside "panel-collapse collapse in", and the corresponding accordion title is found in the "panel panel-heading". So, we need to locate the ancestor `panel` element and retrieve the text from its `panel-heading` child.
<img width="2318" height="1008" alt="image" src="https://github.com/user-attachments/assets/bb137035-37d4-448f-a5e1-37bc7dac6695" />

@miq-bot assign @jrafanie 
@miq-bot add-label cypress
@miq-bot add-label test

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
