### PR TITLE
Fix builtin method summary screen

### DIFF
--- a/app/helpers/catalog_helper/orchestration_template_helper.rb
+++ b/app/helpers/catalog_helper/orchestration_template_helper.rb
@@ -45,7 +45,7 @@ module CatalogHelper::OrchestrationTemplateHelper
     ]
     miq_structured_list({
                           :title => _('Content'),
-                          :mode  => "method_built_in_data",
+                          :mode  => "method_inline_data",
                           :rows  => rows
                         })
   end

--- a/app/helpers/miq_ae_class_helper.rb
+++ b/app/helpers/miq_ae_class_helper.rb
@@ -341,13 +341,24 @@ module MiqAeClassHelper
                         })
   end
 
-  def method_built_in_data(ae_method)
+  def method_inline_data(ae_method)
     rows = [
       row_data('', {:input => 'code_mirror', :props => {:mode => 'ruby', :payload => ae_method.data}})
     ]
     miq_structured_list({
                           :title => _('Data'),
-                          :mode  => "method_built_in_data",
+                          :mode  => "method_inline_data",
+                          :rows  => rows
+                        })
+  end
+
+  def method_builtin_data(ae_method)
+    rows = [
+      row_data(_('Builtin name'), ae_method.data),
+    ]
+    miq_structured_list({
+                          :title => _('Data'),
+                          :mode  => "method_builtin_data",
                           :rows  => rows
                         })
   end

--- a/app/helpers/miq_ae_customization_helper.rb
+++ b/app/helpers/miq_ae_customization_helper.rb
@@ -44,7 +44,7 @@ module MiqAeCustomizationHelper
     ]
     miq_structured_list({
                           :title => _('Content'),
-                          :mode  => "method_built_in_data",
+                          :mode  => "method_inline_data",
                           :rows  => rows
                         })
   end

--- a/app/views/miq_ae_class/_method_inputs.html.haml
+++ b/app/views/miq_ae_class/_method_inputs.html.haml
@@ -12,22 +12,9 @@
       = render :partial => "embedded_methods"
     = render :partial => "domain_overrides", :locals => {:node_prefix => "aem", :model => "Method"}
     - if @ae_method.location == "inline"
-      - if @in_a_form
-        %h3= @ae_method.location == 'builtin' ? _('Builtin name') : _('Data')
-        = text_area("method1",
-          "data",
-          :value    => @ae_method.data,
-          :size     => "90x20",
-          :disabled => true,
-          :style    => "display:none;")
-        -# Create a MyCodeMirror editor for the text area
-        = render :partial => "/layouts/my_code_mirror",
-          :locals  => {:text_area_id => "method1_data",
-            :mode                    => "ruby",
-            :line_numbers            => true,
-            :read_only               => true}
-      - else
-        = method_built_in_data(@ae_method)
+      = method_inline_data(@ae_method)
+    - elsif @ae_method.location == 'builtin'
+      = method_builtin_data(@ae_method)
     - elsif @ae_method.location == 'expression'
       = @expression
     - elsif playbook_style_location?(@ae_method.location)


### PR DESCRIPTION
Fix builtin method summary screen. 

Before:
<img width="1281" height="404" alt="Screenshot 2025-08-11 at 12 05 10 PM" src="https://github.com/user-attachments/assets/e8474ec6-a3fb-45ed-851a-766d2978e039" />

After:
<img width="1285" height="472" alt="Screenshot 2025-08-11 at 12 06 53 PM" src="https://github.com/user-attachments/assets/2b74b1bc-91d1-425c-b439-e16b316880f1" />

Also, the previous function `method_built_in_data` was named incorrectly. It is intended to represent inline_data and display the code mirror. This has been changed to `method_inline_data` and the uses of it have been replaced with the new name instead.