### PR TITLE
Add intercept api command

### DIFF
--- a/cypress/e2e/ui/validate-intercept-api-command.cy.js
+++ b/cypress/e2e/ui/validate-intercept-api-command.cy.js
@@ -1,0 +1,73 @@
+/* eslint-disable no-undef */
+
+// TODO: Remove this test once interceptApi command becomes stable
+describe('Validate intercept command', () => {
+  beforeEach(() => {
+    cy.login();
+    // Navigate to Application settings
+    cy.menu('Settings', 'Application Settings');
+  });
+
+  it('Should register the alias, intercept & wait when API fired', () => {
+    cy.accordion('Diagnostics');
+    cy.interceptApi({
+      alias: 'treeSelectApi',
+      urlPattern: /\/ops\/tree_select\?id=.*&text=.*/,
+      triggerFn: () => cy.selectAccordionItem([/^ManageIQ Region:/, /^Zone:/]),
+    }).then(() => {
+      // verifies that the alias is set and the request is intercepted & awaited
+      expect(Cypress.env('interceptedAliases')).to.have.property(
+        'treeSelectApi'
+      );
+    });
+  });
+
+  it('Should register multiple unique aliases', () => {
+    // first api with alias 'accordionSelectApi'
+    cy.interceptApi({
+      alias: 'accordionSelectApi',
+      urlPattern: /\/ops\/accordion_select\?id=.*/,
+      triggerFn: () => cy.accordion('Diagnostics'),
+    });
+    // second api with alias 'treeSelectApi'
+    cy.interceptApi({
+      alias: 'treeSelectApi',
+      urlPattern: /\/ops\/tree_select\?id=.*&text=.*/,
+      triggerFn: () => cy.selectAccordionItem([/^ManageIQ Region:/, /^Zone:/]),
+    }).then(() => {
+      // verifies that both the aliases are set and the request is intercepted & awaited
+      expect(Cypress.env('interceptedAliases')).to.include.all.keys(
+        'accordionSelectApi',
+        'treeSelectApi'
+      );
+    });
+  });
+
+  it('Should not register duplicate alias', () => {
+    // add first api with alias 'accordionSelectApi'
+    cy.interceptApi({
+      alias: 'accordionSelectApi',
+      urlPattern: /\/ops\/accordion_select\?id=.*/,
+      triggerFn: () => cy.accordion('Diagnostics'),
+    }).then(() => {
+      expect(Object.keys(Cypress.env('interceptedAliases')).length).to.equal(1);
+    });
+    // second first api with alias 'treeSelectApi'
+    cy.interceptApi({
+      alias: 'treeSelectApi',
+      urlPattern: /\/ops\/tree_select\?id=.*&text=.*/,
+      triggerFn: () => cy.selectAccordionItem([/^ManageIQ Region:/, /^Zone:/]),
+    }).then(() => {
+      expect(Object.keys(Cypress.env('interceptedAliases')).length).to.equal(2);
+    });
+    // third api with a duplicate alias as above 'accordionSelectApi'
+    cy.interceptApi({
+      alias: 'accordionSelectApi',
+      urlPattern: /\/ops\/accordion_select\?id=.*/,
+      triggerFn: () => cy.accordion('Access Control'),
+    }).then(() => {
+      // assert that the alias is not overwritten
+      expect(Object.keys(Cypress.env('interceptedAliases')).length).to.equal(2);
+    });
+  });
+});

--- a/cypress/support/commands/api_commands.js
+++ b/cypress/support/commands/api_commands.js
@@ -1,0 +1,44 @@
+/* eslint-disable no-undef */
+
+/**
+ * Custom command to intercept API calls and wait for them to complete.
+ * This command will:
+ * 1. Register an intercept for the given alias and URL pattern if not already registered
+ * 2. Execute the trigger function that makes the API call
+ * 3. Wait for the intercepted request to complete if it was triggered
+ *
+ * @param {Object} options - The options for the intercept
+ * @param {string} options.alias - Unique alias for this interception
+ * @param {string} options.method - HTTP method (default: 'POST')
+ * @param {string|RegExp} options.urlPattern - URL pattern to intercept
+ * @param {Function} options.triggerFn - Function that triggers the API call
+ */
+Cypress.Commands.add(
+  'interceptApi',
+  ({ alias, method = 'POST', urlPattern, triggerFn }) => {
+    /* ===== TODO: Remove this block once interceptApi command becomes stable ===== */
+    const envVars = Cypress.env();
+    cy.log('Cypress Environment Variables:');
+    cy.log(JSON.stringify(envVars, null, 2));
+    /* ======================================================= */
+
+    // Check if this request is already registered
+    const isAlreadyRegistered = !!Cypress.env('interceptedAliases')[alias];
+
+    // Register the intercept if not already done
+    if (!isAlreadyRegistered) {
+      cy.intercept(method, urlPattern).as(alias);
+
+      // Store the alias in the tracking object
+      const interceptedAliases = Cypress.env('interceptedAliases');
+      interceptedAliases[alias] = alias;
+      Cypress.env('interceptedAliases', interceptedAliases);
+    }
+
+    // Execute the function that triggers the API call
+    triggerFn();
+
+    // Wait for the intercepted request to complete
+    cy.wait(`@${alias}`);
+  }
+);

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -40,6 +40,7 @@
 // ***********************************************************
 
 // Commands
+import './commands/api_commands.js';
 import './commands/custom_logging_commands.js';
 import './commands/element_selectors.js';
 import './commands/explorer.js';
@@ -76,4 +77,7 @@ beforeEach(() => {
   // Global hook run once before each test
   // cy.throttle_response(500, 56);
   // cy.stub_notifications();
+  
+  // Reset the intercepted aliases tracking object
+  Cypress.env('interceptedAliases', {});
 })


### PR DESCRIPTION
PR to add new command to intercept apis that handles duplicate intercepts (Follow up work from: https://github.com/ManageIQ/manageiq-ui-classic/pull/9546 as suggested [here](https://github.com/ManageIQ/manageiq-ui-classic/pull/9516#discussion_r2223067473))

### Before:
Intercepted with alias 'editEventForServer' in the beforeEach block:
<img width="3456" height="1716" alt="image" src="https://github.com/user-attachments/assets/c43468c2-0938-4fad-9931-40f3c76212fc" />

Intercepting the same endpoint with 'editEventForServer' as alias again later in the test:
<img width="2340" height="1384" alt="image" src="https://github.com/user-attachments/assets/dd528c32-f189-4d43-ad3e-a93a19ffe7e3" />

Or intercepting the same endpoint with a different alias 'editEventForServerSecond':
<img width="3016" height="1498" alt="image" src="https://github.com/user-attachments/assets/b0b6e44c-b65c-48c0-b6f1-2c0b0f39e100" />

### After:
Intercepted with alias 'editEventForServer' in the beforeEach block:
<img width="2686" height="1518" alt="image" src="https://github.com/user-attachments/assets/b2409e7b-06f3-4df7-80d9-57126a76a468" />
'editEventForServer' will be intercepted by default since its in the same scope as that of beforeEach, only wait for that alias is required:
<img width="2994" height="1480" alt="image" src="https://github.com/user-attachments/assets/7eec80f3-867e-4820-a90d-a4c4ebd4b689" />

@miq-bot assign @jrafanie 
@miq-bot add-label cypress
@miq-bot add-label test



<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
