### PR TITLE
Moved flash message type object to a common constants file for reuse

### DIFF
--- a/cypress/support/assertions/assertion_constants.js
+++ b/cypress/support/assertions/assertion_constants.js
@@ -1,0 +1,6 @@
+export const flashClassMap = {
+  warning: 'warning',
+  error: 'danger',
+  info: 'info',
+  success: 'success',
+};

--- a/cypress/support/assertions/expect_alerts.js
+++ b/cypress/support/assertions/expect_alerts.js
@@ -1,11 +1,5 @@
 /* eslint-disable no-undef */
-
-const flashClassMap = {
-  warning: 'warning',
-  error: 'danger',
-  info: 'info',
-  success: 'success',
-};
+import { flashClassMap } from './assertion_constants';
 
 /**
  * Custom Cypress command to validate flash messages.


### PR DESCRIPTION
This PR adds a common flash message type object(`flashClassMap`) to be reused across tests, to keep it consistent and reduce duplication.
Instead of this:
<img width="1066" height="388" alt="image" src="https://github.com/user-attachments/assets/e99af438-49b9-45b3-8815-9ba7bbbc867c" />
The common constant object(`flashClassMap`)  can be imported and used like:
<img width="1456" height="498" alt="image" src="https://github.com/user-attachments/assets/9177614d-ea76-4347-84d6-9ef12a072fb3" />

@miq-bot assign @jrafanie 
@miq-bot add-label cypress

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
