### PR TITLE
Cleanup files for cleaner merge backs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,6 +63,7 @@ jobs:
     - name: Run tests
       run: bundle exec rake
     - name: Report code coverage
-      if: ${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '3.3' && matrix.test-suite == 'spec' }}
+      if: "${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '3.3' &&
+        matrix.test-suite == 'spec' }}"
       continue-on-error: true
       uses: paambaati/codeclimate-action@v5

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ManageIQ::UI::Classic
 
 [![Gem Version](https://badge.fury.io/rb/manageiq-ui-classic.svg)](http://badge.fury.io/rb/manageiq-ui-classic)
-[![CI](https://github.com/ManageIQ/manageiq-ui-classic/actions/workflows/ci.yaml/badge.svg)](https://github.com/ManageIQ/manageiq-ui-classic/actions/workflows/ci.yaml)
+[![CI](https://github.com/ManageIQ/manageiq-ui-classic/actions/workflows/ci.yaml/badge.svg?branch=master)](https://github.com/ManageIQ/manageiq-ui-classic/actions/workflows/ci.yaml)
 [![Code Climate](https://codeclimate.com/github/ManageIQ/manageiq-ui-classic.svg)](https://codeclimate.com/github/ManageIQ/manageiq-ui-classic)
 [![Test Coverage](https://codeclimate.com/github/ManageIQ/manageiq-ui-classic/badges/coverage.svg)](https://codeclimate.com/github/ManageIQ/manageiq-ui-classic/coverage)
 [![Coverage Status](https://coveralls.io/repos/github/ManageIQ/manageiq-ui-classic/badge.svg?branch=master)](https://coveralls.io/github/ManageIQ/manageiq-ui-classic?branch=master)


### PR DESCRIPTION
Cleanup files for cleaner merge backs

When we run the script that removes the Ruby versions on the release branch, it ends up (basically) doing a YAML.load -> YAML.dump.  That causes a number of lines to change on the release branch.  Then when we later merge master back into the release branch, all of those lines come up as changes.

The README change introduces the branch to a) be more explicit and b) also more easily highlight that difference from master to the release branch when we merge master into the release branche.

This PR avoids that by doing some changes on master to later avoid (and thus highlight better) those differences.