### PR TITLE
Updated selector for flash message

### DIFF
--- a/cypress/support/assertions/expect_alerts.js
+++ b/cypress/support/assertions/expect_alerts.js
@@ -15,7 +15,7 @@ Cypress.Commands.add(
   (flashType = flashClassMap.success, containsText) => {
     if (Object.values(flashClassMap).includes(flashType)) {
       const flashMessageElement = cy
-        .get(`#main_div #flash_msg_div .alert-${flashType}`)
+        .get(`#main_div .alert-${flashType}`)
         .should('be.visible');
 
       if (containsText) {


### PR DESCRIPTION
So far, I’ve seen flash messages rendered inside `flash_msg_div`, but I’ve now observed them appearing without that parent structure.
**Flashs with `flash_msg_div` parent:**
<img width="2168" height="602" alt="image" src="https://github.com/user-attachments/assets/f932b618-087a-4be8-bdbc-175a5cda4df1" />
<img width="2018" height="360" alt="image" src="https://github.com/user-attachments/assets/94a5b7fa-d221-411b-96f8-9f49b6cc34a1" />
**Flashs without `flash_msg_div` parent:**
<img width="2680" height="916" alt="image" src="https://github.com/user-attachments/assets/1e82d443-e008-4ead-9dbc-10e091a94c8f" />

@miq-bot add-label cypress
@miq-bot assign @jrafanie 

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
