### PR TITLE
Added automated tests with cypress for C & U Gap Collection form

### DIFF
--- a/cypress/e2e/ui/Settings/Application-Settings/c_and_u_gap_collection.cy.js
+++ b/cypress/e2e/ui/Settings/Application-Settings/c_and_u_gap_collection.cy.js
@@ -1,0 +1,126 @@
+/* eslint-disable no-undef */
+import { flashClassMap } from '../../../../support/assertions/assertion_constants';
+
+// Menu options
+const SETTINGS_MENU_OPTION = 'Settings';
+const APP_SETTINGS_MENU_OPTION = 'Application Settings';
+
+// List items
+const DIAGNOSTICS_ACCORDION_ITEM = 'Diagnostics';
+const MANAGEIQ_REGION_ACCORD_ITEM = /^ManageIQ Region:/;
+const ZONE_ACCORD_ITEM = /^Zone:/;
+
+// Field values
+const TIMEZONE_FIELD_LABEL = 'Timezone';
+const START_DATE_FIELD_LABEL = 'Start Date';
+const END_DATE_FIELD_LABEL = 'End Date';
+const FORM_HEADER = 'Diagnostics Zone';
+const FORM_SUBHEADER_SNIPPET = 'Collection Options';
+const TIMEZONE_TYPE_HAWAII = '(GMT-10:00) Hawaii';
+const START_DATE = '06/25/2026';
+const END_DATE = '06/28/2026';
+
+// Flash message text snippets
+const FLASH_MESSAGE_GAP_COLLECTION_INITIATED = 'initiated';
+const FLASH_MESSAGE_DATE_RANGE_INVALID = 'cannot';
+
+function fillGapCollectionForm(startDateValue, endDateValue) {
+  // Select "Hawaii" from timezone dropdown
+  cy.getFormLabelByForAttribute({ forValue: 'timezone' }).click();
+  cy.contains('[role="option"]', TIMEZONE_TYPE_HAWAII).click();
+  // Add start date
+  cy.getFormInputFieldByIdAndType({ inputId: 'startDate' }).type(
+    startDateValue
+  );
+  // Click elsewhere to close the start date calendar popup
+  cy.get('h3').contains(FORM_SUBHEADER_SNIPPET).click();
+  // Add end date
+  cy.getFormInputFieldByIdAndType({ inputId: 'endDate' }).type(endDateValue);
+  // Click elsewhere to close the end date calendar popup
+  cy.get('h3').contains(FORM_SUBHEADER_SNIPPET).click();
+}
+
+function saveFormAndAssertFlashMessage(flashMessageType, flashMessage) {
+  cy.interceptApi({
+    alias: 'saveGapCollectionApi',
+    urlPattern: '/ops/cu_repair?button=submit',
+    triggerFn: () =>
+      cy
+        .getFormFooterButtonByTypeWithText({
+          buttonText: 'Save',
+          buttonType: 'submit',
+        })
+        .click(),
+    onApiResponse: () => cy.expect_flash(flashMessageType, flashMessage),
+  });
+}
+
+describe('Automate C & U Gap Collection form operations: Settings > Application Settings > Diagnostics > ManageIQ Region > Zone Default Zone > C & U Gap Collection', () => {
+  beforeEach(() => {
+    cy.login();
+    // Navigate to Application settings and expand Diagnostics accordion
+    cy.menu(SETTINGS_MENU_OPTION, APP_SETTINGS_MENU_OPTION);
+    cy.accordion(DIAGNOSTICS_ACCORDION_ITEM);
+    // Select "Zone:" accordion item
+    cy.selectAccordionItem([MANAGEIQ_REGION_ACCORD_ITEM, ZONE_ACCORD_ITEM]);
+    // Select "C & U Gap Collection" tab
+    cy.tabs({ tabLabel: 'C & U Gap Collection' });
+  });
+
+  it('Validate form elements', () => {
+    // Assert form header is visible
+    cy.expect_explorer_title(FORM_HEADER).should('be.visible');
+    // Assert form sub-header is visible
+    cy.contains('#main-content .bx--form h3', FORM_SUBHEADER_SNIPPET).should(
+      'be.visible'
+    );
+    // Assert timezone label & field is visible and enabled
+    cy.getFormLabelByForAttribute({ forValue: 'timezone' })
+      .should('be.visible')
+      .and('contain.text', TIMEZONE_FIELD_LABEL);
+    cy.getFormInputFieldByIdAndType({ inputId: 'timezone' })
+      .should('be.visible')
+      .and('be.enabled');
+    // Assert start date label & field is visible and enabled
+    cy.getFormLabelByForAttribute({ forValue: 'startDate' })
+      .should('be.visible')
+      .and('contain.text', START_DATE_FIELD_LABEL);
+    cy.getFormInputFieldByIdAndType({ inputId: 'startDate' })
+      .should('be.visible')
+      .and('be.enabled');
+    // Assert end date label & field is visible and enabled
+    cy.getFormLabelByForAttribute({ forValue: 'endDate' })
+      .should('be.visible')
+      .and('contain.text', END_DATE_FIELD_LABEL);
+    cy.getFormInputFieldByIdAndType({ inputId: 'endDate' })
+      .should('be.visible')
+      .and('be.enabled');
+    // Assert save button is visible and disabled
+    cy.getFormFooterButtonByTypeWithText({
+      buttonText: 'Save',
+      buttonType: 'submit',
+    })
+      .should('be.visible')
+      .and('be.disabled');
+  });
+
+  it('Should fail if start date is greater than end date', () => {
+    // Fill the form with end date less than start date
+    fillGapCollectionForm(END_DATE, START_DATE);
+    // Save form and assert flash error message
+    saveFormAndAssertFlashMessage(
+      flashClassMap.error,
+      FLASH_MESSAGE_DATE_RANGE_INVALID
+    );
+  });
+
+  it('Validate gap collection initiation', () => {
+    // Fill the form
+    fillGapCollectionForm(START_DATE, END_DATE);
+    // Save form and assert flash success message
+    saveFormAndAssertFlashMessage(
+      flashClassMap.success,
+      FLASH_MESSAGE_GAP_COLLECTION_INITIATED
+    );
+  });
+});


### PR DESCRIPTION
CP4AIOPS-18405
Pr that adds cypress tests for C & U Gap Collection form: Settings > Application Settings > Diagnostics > ManageIQ Region > Zone Default Zone > C & U Gap Collection
 - Validate form elements
 - Validate error with an invalid date range
 - Validate Save functionality
 
@miq-bot assign @GilbertCherrie
@miq-bot add-label cypress
@miq-bot add-label test
 
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
