### PR TITLE
Resolve duplicate Basic Info heading in create catalog item form

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -298,12 +298,10 @@ class CatalogController < ApplicationController
         # when display in catalog is checked, replace div so tabs can be redrawn
         if (params[:st_prov_type] || (params[:display] && @edit[:new][:st_prov_type].starts_with?("generic"))) || params[:ovf_template_id]
           page.replace("form_div", :partial => "st_form")
-        end
-        if automate_tree_needed?
-          page.replace("basic_info_div", :partial => "form_basic_info")
-        end
-        if params[:display]
+        elsif params[:display]
           page << "miq_tabs_show_hide('#details_tab', '#{(params[:display] == "1")}')"
+        elsif automate_tree_needed?
+          page.replace("basic_info_div", :partial => "form_basic_info")
         end
         page.replace_html("provision_entry_point", :partial => "provision_entry_point") if params[:provision_entry_point_type]
         page.replace_html("reconfigure_entry_point", :partial => "reconfigure_entry_point") if params[:reconfigure_entry_point_type]


### PR DESCRIPTION
PR fixes the issue mentioned in https://github.com/ManageIQ/manageiq-ui-classic/issues/9526

### Before:
<img width="1500" height="994" alt="image" src="https://github.com/user-attachments/assets/43784a51-5f82-4251-8cb4-e3cce1412289" />

### After:
<img width="2314" height="1316" alt="image" src="https://github.com/user-attachments/assets/bd62bf9e-94d0-4928-9817-4a91fa57ee86" />

### Fix Analysis:
The problem was diagnosed and resolved with AI assistance, after slight tweaks
```
if automate_tree_needed?
          page.replace("basic_info_div", :partial => "form_basic_info")
```
was the culprit here that duplicates "Basic Information" heading when "Display in Catalog" checkbox's onChange gets fired.
Restructuring the code to use an if-elsif chain with`page.replace("basic_info_div"...)` condition moved to the last ensures it's not executed when `params[:display]` is true which prevents the duplicate headings issue.

I was just verifying through these catalog types (others seem to be disabled, possibly due to missing data):
Amazon
Ansible Automation Platform
Ansible Playbook
Azure
Generic
Google
OpenShift Template
OpenStack
Orchestration
Red Hat Virtualization
Terraform Template
VMware
VMware Content Library OVF Template

and they are either starting with generic(first condition) or `params[:display]` is true
so I was thinking whether we should completely remove the block for `page.replace("basic_info_div"...)`

@miq-bot assign @Fryguy
@miq-bot add-reviewer @agrare 
@miq-bot add-label bug

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
