### PR TITLE
Replaced jQuery trigger-click with cy.click() in accordion command

### DIFF
--- a/cypress/support/commands/explorer.js
+++ b/cypress/support/commands/explorer.js
@@ -10,9 +10,8 @@ Cypress.Commands.add('accordion', (title) => {
   ret.then((el) => {
     // Do not collapse if already expanded
     if (el.is('.collapsed')) {
-      el.trigger('click');
+      cy.wrap(el).click();
     }
-    return el;
   });
 
   return ret.parents('.panel');


### PR DESCRIPTION
This PR converted jQuery `trigger('click')` usage to `cy.wrap().click()` for better Cypress integration, in the accordion command.

### Before:
When using `el.trigger('click')` in Cypress, the click action doesn't appear in the Cypress command log panel because it's using jQuery's event triggering system directly, bypassing Cypress's command infrastructure.
So when trying to intercept & wait on the `accordion_select` api, the `cy.wait('@alias')` command gets enqueued first in the Cypress command queue
<img width="1618" height="638" alt="image" src="https://github.com/user-attachments/assets/8113153f-f9c0-40a6-a3b2-c618baab0523" />

### After:
Cypress tracks the click in its command queue, so the request and wait proceed sequentially.
<img width="2812" height="1154" alt="image" src="https://github.com/user-attachments/assets/bba94b70-6aee-49a7-9520-d50c5d783025" />

@miq-bot assign @GilbertCherrie
@miq-bot add-reviewer @elsamaryv
@miq-bot add-label cypress

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
