### PR TITLE
Fix toolbar button function calls

### DIFF
--- a/app/javascript/components/miq-toolbar.jsx
+++ b/app/javascript/components/miq-toolbar.jsx
@@ -5,7 +5,8 @@ import PropTypes from 'prop-types';
 import { Toolbar } from './toolbar';
 
 import DashboardToolbar from './dashboard_toolbar';
-import { convertMultParamsToRailsMultParams } from '../toolbar-actions/util'
+import { convertMultParamsToRailsMultParams } from '../toolbar-actions/util';
+import { sendDataWithRx } from '../miq_observable';
 
 /* global miqJqueryRequest, miqSerializeForm */
 /* eslint no-restricted-globals: ["off", "miqJqueryRequest", "miqSerializeForm"] */
@@ -89,9 +90,7 @@ const onClick = (button) => {
     }
   } else if (button.data && button.data.function) {
     // Client-side buttons use 'function' and 'function-data'.
-    /* eslint no-new-func: "off" */
-    const fn = new Function(`return ${button.data.function}`);
-    fn().call(button, button.data['function-data']);
+    sendDataWithRx(button.data['function-data']);
     return;
   } else { // Most of (classic) buttons.
     // If no url was specified, run standard button ajax transaction.


### PR DESCRIPTION
The buttons that use button.data and button.function-data all use sendDataWithRx. This pr changes the toolbar code to directly call this function and send function-data instead of dynamically building a function.