### PR TITLE
rexml 3.4.3 Document.new no longer accepts strings with no root element

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -401,7 +401,7 @@ class MiqAeClassController < ApplicationController
   end
 
   def build_details_grid(view, mode = true)
-    xml = REXML::Document.load("")
+    xml = REXML::Document.load(nil)
     xml << REXML::XMLDecl.new(1.0, "UTF-8")
 
     # Create root element


### PR DESCRIPTION
Followup to https://github.com/ManageIQ/manageiq-gems-pending/pull/614

We generally create the xml document and add the root element and others afterwards. This is ok, but we need to call REXML::Document.new(nil) instead.  In 3.4.3 and future versions, it fails validation when the string provided to .new does not container a root element.

See the discussion in: https://www.github.com/ruby/rexml/pull/291

Note, this fixes the following errors with rexml 3.4.3:

```
  1) MiqAeClassController get selected Class/Instance/Method record back #get_class_node_info when the record exists returns class record and check count of override classes being returned
     Failure/Error: xml = REXML::Document.load("")

     REXML::ParseException:
       Malformed XML: No root element
       Line: 0
       Position: 0
       Last 80 unconsumed characters:
     # /Users/joerafaniello/.gem/ruby/3.3.9/gems/rexml-3.4.3/lib/rexml/parsers/baseparser.rb:271:in `pull_event'
     # /Users/joerafaniello/.gem/ruby/3.3.9/gems/rexml-3.4.3/lib/rexml/parsers/baseparser.rb:249:in `pull'
     # /Users/joerafaniello/.gem/ruby/3.3.9/gems/rexml-3.4.3/lib/rexml/parsers/treeparser.rb:21:in `parse'
     # /Users/joerafaniello/.gem/ruby/3.3.9/gems/rexml-3.4.3/lib/rexml/document.rb:466:in `build'
     # /Users/joerafaniello/.gem/ruby/3.3.9/gems/rexml-3.4.3/lib/rexml/document.rb:103:in `initialize'
     # /Users/joerafaniello/Code/manageiq-gems-pending/lib/gems/pending/util/xml/miq_rexml.rb:275:in `initialize'
     # /Users/joerafaniello/Code/manageiq-gems-pending/lib/gems/pending/util/xml/miq_rexml.rb:281:in `new'
     # /Users/joerafaniello/Code/manageiq-gems-pending/lib/gems/pending/util/xml/miq_rexml.rb:281:in `load'
     # ./app/controllers/miq_ae_class_controller.rb:404:in `build_details_grid'
     # ./app/controllers/miq_ae_class_controller.rb:2937:in `get_class_node_info'
     # ./spec/controllers/miq_ae_class_controller_spec.rb:355:in `block (5 levels) in <top (required)>'
     # /Users/joerafaniello/.gem/ruby/3.3.9/gems/webmock-3.25.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <main>'

  2) MiqAeClassController#replace_right_cell Can build the AE tree
     Failure/Error: xml = REXML::Document.load("")

     REXML::ParseException:
       Malformed XML: No root element
       Line: 0
       Position: 0
       Last 80 unconsumed characters:
     # /Users/joerafaniello/.gem/ruby/3.3.9/gems/rexml-3.4.3/lib/rexml/parsers/baseparser.rb:271:in `pull_event'
     # /Users/joerafaniello/.gem/ruby/3.3.9/gems/rexml-3.4.3/lib/rexml/parsers/baseparser.rb:249:in `pull'
     # /Users/joerafaniello/.gem/ruby/3.3.9/gems/rexml-3.4.3/lib/rexml/parsers/treeparser.rb:21:in `parse'
     # /Users/joerafaniello/.gem/ruby/3.3.9/gems/rexml-3.4.3/lib/rexml/document.rb:466:in `build'
     # /Users/joerafaniello/.gem/ruby/3.3.9/gems/rexml-3.4.3/lib/rexml/document.rb:103:in `initialize'
     # /Users/joerafaniello/Code/manageiq-gems-pending/lib/gems/pending/util/xml/miq_rexml.rb:275:in `initialize'
     # /Users/joerafaniello/Code/manageiq-gems-pending/lib/gems/pending/util/xml/miq_rexml.rb:281:in `new'
     # /Users/joerafaniello/Code/manageiq-gems-pending/lib/gems/pending/util/xml/miq_rexml.rb:281:in `load'
     # ./app/controllers/miq_ae_class_controller.rb:404:in `build_details_grid'
     # ./app/controllers/miq_ae_class_controller.rb:2937:in `get_class_node_info'
     # ./app/controllers/miq_ae_class_controller.rb:195:in `get_node_info'
     # ./app/controllers/miq_ae_class_controller.rb:294:in `replace_right_cell'
     # ./spec/controllers/miq_ae_class_controller_spec.rb:872:in `block (3 levels) in <top (required)>'
     # /Users/joerafaniello/.gem/ruby/3.3.9/gems/webmock-3.25.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <main>'

Finished in 2.65 seconds (files took 10.8 seconds to load)
48 examples, 2 failures

Failed examples:

rspec ./spec/controllers/miq_ae_class_controller_spec.rb:350 # MiqAeClassController get selected Class/Instance/Method record back #get_class_node_info when the record exists returns class record and check count of override classes being returned
rspec ./spec/controllers/miq_ae_class_controller_spec.rb:860 # MiqAeClassController#replace_right_cell Can build the AE tree
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
