### PR TITLE
Fixed error message typo in button selector command

### DIFF
--- a/cypress/support/commands/element_selectors.js
+++ b/cypress/support/commands/element_selectors.js
@@ -15,7 +15,7 @@ Cypress.Commands.add(
   'getFormFooterButtonByTypeWithText',
   ({ buttonType = 'button', buttonText } = {}) => {
     if (!buttonText) {
-      cy.logAndThrowError('buttonName is required');
+      cy.logAndThrowError('buttonText is required');
     }
     return cy.contains(
       `#main-content .bx--btn-set button[type="${buttonType}"]`,


### PR DESCRIPTION
PR to fix a typo as mentioned [here](https://github.com/ManageIQ/manageiq-ui-classic/pull/9598#discussion_r2337710030)

@miq-bot assign @jrafanie 
@miq-bot add-label cypress

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
