### PR TITLE
Switch cy.on to cy.once to unregister handler after scope

### DIFF
--- a/cypress/support/assertions/expect_alerts.js
+++ b/cypress/support/assertions/expect_alerts.js
@@ -64,7 +64,7 @@ Cypress.Commands.add(
   'expect_browser_confirm_with_text',
   ({ confirmTriggerFn, containsText, proceed = true }) => {
     let alertTriggered = false;
-    cy.on('window:confirm', (actualText) => {
+    cy.once('window:confirm', (actualText) => {
       alertTriggered = true;
       if (containsText) {
         expect(actualText.toLowerCase()).to.include(containsText.toLowerCase());


### PR DESCRIPTION
### Problem:
When `expect_browser_confirm_with_text` is used more than once in a suite
<img width="872" height="576" alt="image" src="https://github.com/user-attachments/assets/f5a9c15b-2c87-4098-8678-a761d0763da8" />
The first alert assertion succeeds by verifying **'remove this Namespace'** in the alert text:
<img width="1778" height="712" alt="image" src="https://github.com/user-attachments/assets/c407ccf0-5d28-4a3d-85e0-7becf3ec4316" />
<img width="1756" height="252" alt="image" src="https://github.com/user-attachments/assets/13d3f146-ebd9-42af-b10d-3af9076fb891" />

The second assertion fails because it still checks for **'remove this Namespace'** instead of **'remove this Domain'**:
<img width="1706" height="656" alt="image" src="https://github.com/user-attachments/assets/eea898bc-076c-4e41-8150-be12b81edc33" />
<img width="1882" height="378" alt="image" src="https://github.com/user-attachments/assets/e3ade7c7-83cd-4c43-b62e-5f7bf9e5ea4a" />

The issue is related to JavaScript closures. `cy.on()` registers an event handler that persists throughout the entire test. It will be called every time the event occurs, until the test ends or the handler is manually removed. `cy.once()` registers an event handler that automatically removes itself after being triggered once. It will only be called the first time the event occurs after registration.

### After:
First assertion:
<img width="1806" height="404" alt="image" src="https://github.com/user-attachments/assets/7342e18d-8271-468e-ae79-05d8d2b71d80" />
Second assertion:
<img width="1764" height="346" alt="image" src="https://github.com/user-attachments/assets/d7634b99-e822-4dca-861c-855bf040fb32" />


@miq-bot assign @GilbertCherrie
@miq-bot add-label cypress
@miq-bot add-label refactoring
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
