### PR TITLE
Updated to throw an error when the specified toolbar option is disabled

### DIFF
--- a/cypress/support/commands/toolbar.js
+++ b/cypress/support/commands/toolbar.js
@@ -21,13 +21,15 @@ Cypress.Commands.add('toolbar', (toolbarButton, toolbarOption = '') => {
   // then look for the given toolbar option
   if (toolbarOption) {
     return clickToolbarButton.then(() => {
-      return cy.get('.bx--overflow-menu-options li').then((toolbarOptions) => {
+      return cy.get('.bx--overflow-menu-options li button').then((toolbarOptions) => {
         const targetToolbarOption = [...toolbarOptions].find(
           (option) => option.innerText.trim() === toolbarOption
         );
 
         if (!targetToolbarOption) {
-          cy.logAndThrowError(`"${toolbarOption}" option was not found in the "${toolbarButton}" toolbar`);
+          cy.logAndThrowError(
+            `"${toolbarOption}" option was not found in the "${toolbarButton}" toolbar`
+          );
         }
         // returning the cypress chainable to the top of the command scope
         return cy.wrap(targetToolbarOption).click();


### PR DESCRIPTION
### Before:
Unclear what issue occurred when the option was disabled and the command attempted to click it:
<img width="3078" height="1202" alt="image" src="https://github.com/user-attachments/assets/367e8727-40be-477c-b337-7d2deed8a7db" />

### After:
~Throws an error if the option is disabled:~ - Refer [comment](https://github.com/ManageIQ/manageiq-ui-classic/pull/9618#issuecomment-3317646786) for the fix result
<img width="2790" height="1444" alt="image" src="https://github.com/user-attachments/assets/636c2a3b-3af8-4ab1-902c-d1839caebad3" />

@miq-bot assign @GilbertCherrie 
@miq-bot add-reviewer @elsamaryv 
@miq-bot add-label cypress
@miq-bot add-label enhancement

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
