### PR TITLE
Better PingController errors

### DIFF
--- a/app/controllers/ping_controller.rb
+++ b/app/controllers/ping_controller.rb
@@ -1,6 +1,6 @@
 class PingController < ApplicationController
   def index
-    raise PG::Error unless ActiveRecord::Base.connectable?
+    ActiveRecord::Base.connectable!
 
     render :plain => 'pong', :status => 200
   end
@@ -8,7 +8,7 @@ class PingController < ApplicationController
   private def error_handler(e)
     message =
       case e
-      when PG::Error
+      when *ActiveRecord::Base::CONNECTIVITY_ERRORS
         "Unable to connect to the database"
       else
         "Unknown"

--- a/spec/controllers/ping_controller_spec.rb
+++ b/spec/controllers/ping_controller_spec.rb
@@ -9,16 +9,16 @@ describe PingController do
   end
 
   it 'fails gracefully with database errors' do
-    expect(ActiveRecord::Base).to receive(:connectable?).and_return(false)
+    expect(ActiveRecord::Base).to receive(:connectable!).and_raise(PG::ConnectionBad)
 
     get :index
 
     expect(response.status).to eq(500)
-    expect(response.body).to eq("ERROR: Unable to connect to the database (PG::Error)")
+    expect(response.body).to eq("ERROR: Unable to connect to the database (PG::ConnectionBad)")
   end
 
   it 'fails gracefully with non-database errors' do
-    expect(ActiveRecord::Base).to receive(:connectable?).and_raise(RuntimeError)
+    expect(ActiveRecord::Base).to receive(:connectable!).and_raise(RuntimeError)
 
     get :index
 


### PR DESCRIPTION
Use the new ActiveRecord::Base.connectable! method to get at the actual exception and provide better feednback on ping failures

Follow up to
- #9619 

Depends on
- [x] https://github.com/ManageIQ/manageiq/pull/23587

@jrafanie Please review.