### PR TITLE
Ignore push event on bot PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,11 @@
 ---
 name: CI
 on:
-  push:
   pull_request:
+  push:
+    branches-ignore:
+    - renovate/*
+    - dependabot/*
   workflow_dispatch:
   schedule:
   - cron: 0 0 * * *

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -3,6 +3,9 @@ name: Cypress
 on:
   pull_request:
   push:
+    branches-ignore:
+    - renovate/*
+    - dependabot/*
   workflow_dispatch:
   schedule:
   - cron: 0 0 * * 0


### PR DESCRIPTION
@jrafanie Please review.

I noticed that renovate and dependabot PRs run twice because they build they branches in the main repo, and trigger both a push and pull_request event. We only need PR events for them, so we should exclude them.  I want to see how this works, then I plan to blast this out to the other repos.