### PR TITLE
Auto-cancel in-progress CI builds for branches and PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,9 +6,12 @@ on:
     branches-ignore:
     - renovate/*
     - dependabot/*
-  workflow_dispatch:
   schedule:
   - cron: 0 0 * * *
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -6,9 +6,12 @@ on:
     branches-ignore:
     - renovate/*
     - dependabot/*
-  workflow_dispatch:
   schedule:
   - cron: 0 0 * * 0
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
 jobs:
   cypress:
     runs-on: ubuntu-latest


### PR DESCRIPTION
@jrafanie Please review. This is equivalent to Travis' auto-cancel branch builds and auto-cancel PR builds that we used to have. This should cut down on unnecessary builds, especially when someone updates a branch with new changes.

Example (I made a small change to this PR and force pushed). This is what happened to the previous in-progress run:

<img width="1267" height="1124" alt="Auto-cancel_in-progress_CI_builds_for_branches_and_PRs_·_ManageIQ_manageiq-ui-classic_1a2ce3c" src="https://github.com/user-attachments/assets/a148dd53-ffa8-4c98-849f-4f08d05c7fea" />
