### PR TITLE
Replace babel-eslint with @babel/eslint-parser in eslint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
     "browser": true,
     "jquery": true
   },
-  "parser": "babel-eslint",
+  "parser": "@babel/eslint-parser",
   "parserOptions": {
     "ecmaVersion": 5,
     "sourceType": "script",


### PR DESCRIPTION
Follow-up to https://github.com/ManageIQ/manageiq-ui-classic/pull/9583: `babel-eslint` was replaced by `@babel/eslint-parser`, but ESLint settings remained unchanged, leading to `yarn lint` command failure:
<img width="1618" height="188" alt="image" src="https://github.com/user-attachments/assets/52b4656e-9ab9-4f55-b2ef-191af4dfd96c" />

@miq-bot assign @GilbertCherrie 
@miq-bot add-label configuration management

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
