### PR TITLE
Fix copy code from codemirror

### DIFF
--- a/app/javascript/components/miq-structured-list/miq-structured-list-body/value-tags/miq-structured-list-inputs.jsx
+++ b/app/javascript/components/miq-structured-list/miq-structured-list-body/value-tags/miq-structured-list-inputs.jsx
@@ -45,7 +45,6 @@ const MiqStructuredListInputs = ({ value, action }) => {
         lineNumbers: true,
         matchBrackets: true,
         theme: 'eclipse',
-        readOnly: 'nocursor',
         viewportMargin: Infinity,
       }}
       value={payload}


### PR DESCRIPTION
Fixes: 

Before:
<img width="928" height="721" alt="Before" src="https://github.com/user-attachments/assets/2eee5ced-f7f9-4410-86ab-c66321c57573" />

After:
<img width="923" height="566" alt="CodeMirror" src="https://github.com/user-attachments/assets/463e91ba-e3f4-4045-b962-b770650a1810" />
