### PR TITLE
Update request

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "nwsapi": "^2.2.1",
     "path-to-regexp": "~8.0.0",
     "patternfly": "~3.59.5",
-    "request": "cypress-io/request#v3.0.9",
+    "request": "npm:@cypress/request@^3.0.9",
     "terser": "~4.8.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1488,7 +1488,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cypress/request@npm:^3.0.9":
+"@cypress/request@npm:^3.0.9, request@npm:@cypress/request@^3.0.9":
   version: 3.0.9
   resolution: "@cypress/request@npm:3.0.9"
   dependencies:
@@ -16349,32 +16349,6 @@ __metadata:
   peerDependencies:
     request: ^2.34
   checksum: 10/6df0cf75cbddd08b568e462570fb63033f040efdf961f39af572e52821a831a13ee9027db7ba78f1d980759cc7913f2a12a34424deac5a0ec56c5d8ebbf45391
-  languageName: node
-  linkType: hard
-
-"request@cypress-io/request#v3.0.9":
-  version: 0.0.0-development
-  resolution: "request@https://github.com/cypress-io/request.git#commit=3cffd53a243630c517fb31c3cedc0a65012f4868"
-  dependencies:
-    aws-sign2: "npm:~0.7.0"
-    aws4: "npm:^1.8.0"
-    caseless: "npm:~0.12.0"
-    combined-stream: "npm:~1.0.6"
-    extend: "npm:~3.0.2"
-    forever-agent: "npm:~0.6.1"
-    form-data: "npm:~4.0.4"
-    http-signature: "npm:~1.4.0"
-    is-typedarray: "npm:~1.0.0"
-    isstream: "npm:~0.1.2"
-    json-stringify-safe: "npm:~5.0.1"
-    mime-types: "npm:~2.1.19"
-    performance-now: "npm:^2.1.0"
-    qs: "npm:6.14.0"
-    safe-buffer: "npm:^5.1.2"
-    tough-cookie: "npm:^5.0.0"
-    tunnel-agent: "npm:^0.6.0"
-    uuid: "npm:^8.3.2"
-  checksum: 10/699c4f93b30f10ff7dceb94eded5eada25ae6c815df2cac2fd4f4611467a5a690722ce6b17cee2356adc2df3ec105f1f00816edf9fd01746b03c7c2000296c78
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update request package to use cypress/request version 3.0.9 since we are already on the latest version of the request package and it is no longer being updated.