### PR TITLE
Not all the tests in the describe blocks needed restore

### DIFF
--- a/cypress/e2e/ui/Settings/Application-Settings/tenant.cy.js
+++ b/cypress/e2e/ui/Settings/Application-Settings/tenant.cy.js
@@ -273,10 +273,6 @@ describe('Automate Tenant form operations: Settings > Application Settings > Acc
   });
 
   describe('Validate Parent Tenant operations: Edit, Add Project, Manage Quotas', () => {
-    afterEach(() => {
-      cy.appDbState('restore');
-    });
-
     describe('Validate Edit parent tenant', () => {
       beforeEach(() => {
         cy.toolbar(CONFIG_TOOLBAR_BUTTON, EDIT_TENANT_CONFIG_OPTION);
@@ -313,6 +309,10 @@ describe('Automate Tenant form operations: Settings > Application Settings > Acc
     });
 
     describe('Validate Add Project to parent tenant', () => {
+      afterEach(() => {
+        cy.appDbState('restore');
+      });
+
       it('Validate Add Project function', () => {
         addProjectToTenant();
       });
@@ -321,6 +321,10 @@ describe('Automate Tenant form operations: Settings > Application Settings > Acc
     describe('Validate Manage Quotas in parent tenant', () => {
       beforeEach(() => {
         cy.toolbar(CONFIG_TOOLBAR_BUTTON, MANAGE_QUOTAS_CONFIG_OPTION);
+      });
+
+      afterEach(() => {
+        cy.appDbState('restore');
       });
 
       it('Validate Reset & Cancel buttons in Manage Quotas form', () => {
@@ -341,13 +345,13 @@ describe('Automate Tenant form operations: Settings > Application Settings > Acc
   });
 
   describe('Validate Child Tenant operations: Add, Edit, Add Project, Manage Quotas', () => {
-    afterEach(() => {
-      cy.appDbState('restore');
-    });
-
     describe('Validate Add child tenant function', () => {
       beforeEach(() => {
         cy.toolbar(CONFIG_TOOLBAR_BUTTON, ADD_CHILD_TENANT_CONFIG_OPTION);
+      });
+
+      afterEach(() => {
+        cy.appDbState('restore');
       });
 
       it('Validate Add child tenant form elements', () => {
@@ -400,6 +404,10 @@ describe('Automate Tenant form operations: Settings > Application Settings > Acc
         cy.toolbar(CONFIG_TOOLBAR_BUTTON, EDIT_TENANT_CONFIG_OPTION);
       });
 
+      afterEach(() => {
+        cy.appDbState('restore');
+      });
+
       it('Validate Edit child tenant form elements', () => {
         validateFormElements();
         cancelFormWithOptionalFlashCheck();
@@ -432,6 +440,10 @@ describe('Automate Tenant form operations: Settings > Application Settings > Acc
         createAndSelectChildTenant();
       });
 
+      afterEach(() => {
+        cy.appDbState('restore');
+      });
+
       it('Validate Add Project function', () => {
         addProjectToTenant();
       });
@@ -447,6 +459,10 @@ describe('Automate Tenant form operations: Settings > Application Settings > Acc
       beforeEach(() => {
         createAndSelectChildTenant();
         cy.toolbar(CONFIG_TOOLBAR_BUTTON, MANAGE_QUOTAS_CONFIG_OPTION);
+      });
+
+      afterEach(() => {
+        cy.appDbState('restore');
       });
 
       it('Validate Reset & Cancel buttons in Manage Quotas form', () => {


### PR DESCRIPTION
Fixes #9658's overzealous grouping of common setup/teardown in describe blocks even though some tests didn't have that setup previously.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
