### PR TITLE
Revert "Update dependency bootstrap-switch to v3.4.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "awesome-debounce-promise": "^2.1.0",
     "bootstrap-filestyle": "~1.2.1",
     "bootstrap-select": "^1.13.18",
-    "bootstrap-switch": "3.4.0",
+    "bootstrap-switch": "3.3.4",
     "carbon-components": "~10.58.15",
     "carbon-components-react": "~7.60.0",
     "carbon-icons": "~7.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4882,16 +4882,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bootstrap-switch@npm:3.4.0":
-  version: 3.4.0
-  resolution: "bootstrap-switch@npm:3.4.0"
-  peerDependencies:
-    bootstrap: ^4.3.1
-    jquery: ">=1.12.4"
-  checksum: 10/551387442c991669ca9d5e59c00ce95d3534279dfc4420ed54587edf7e1d4247b73b2fcc6c23fa4ce648cda5b05f6f4a50b5e63fcdfadf4e0a82539728293683
-  languageName: node
-  linkType: hard
-
 "bootstrap-touchspin@npm:~3.1.1":
   version: 3.1.1
   resolution: "bootstrap-touchspin@npm:3.1.1"
@@ -13105,7 +13095,7 @@ __metadata:
     babel-loader: "npm:~8.4.0"
     bootstrap-filestyle: "npm:~1.2.1"
     bootstrap-select: "npm:^1.13.18"
-    bootstrap-switch: "npm:3.4.0"
+    bootstrap-switch: "npm:3.3.4"
     carbon-components: "npm:~10.58.15"
     carbon-components-react: "npm:~7.60.0"
     carbon-icons: "npm:~7.0.7"


### PR DESCRIPTION
Reverting due to this issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/9673