### PR TITLE
Ensure disk resize request works in French UI

### DIFF
--- a/app/javascript/components/reconfigure-vm-form/helpers/general.js
+++ b/app/javascript/components/reconfigure-vm-form/helpers/general.js
@@ -50,4 +50,8 @@ export const formsData = {
 /** Function to get the value in MB
  * converts the value to GB to MB based on the passed unit
  */
-export const sizeInMB = (value, unit) => (unit === __('GB') ? value * 1024 : value);
+export const sizeInMB = (value, unit) => {
+  // Check if unit is GB or a localized version of GB (like "Go" in French)
+  const isGigabyte = unit === 'GB' || unit === __('GB');
+  return isGigabyte ? value * 1024 : value;
+};


### PR DESCRIPTION
Fixes [#23636](https://github.com/ManageIQ/manageiq/issues/23636)

Issue: Disk resize in the French UI appeared successful but did not update the disk size.
It was caused by a mismatch in unit handling: the French UI displayed unit as “Go”, but the backend expected the unit value to be 'GB'.

@miq-bot add-reviewer @GilbertCherrie 

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
