### PR TITLE
Rollback the tenant test changes due to timing issue failures

### DIFF
--- a/cypress/e2e/ui/Settings/Application-Settings/tenant.cy.js
+++ b/cypress/e2e/ui/Settings/Application-Settings/tenant.cy.js
@@ -202,6 +202,7 @@ function resetParentTenantForm() {
   );
 }
 
+// TODO: Aside from test that validates deletion, replace with a more reliable cleanup mechanism when ready
 function deleteAccordionItems(accordionsToDelete) {
   cy.get(`#${ACCESS_CONTROL_ACCORDION_ITEM_ID} li.list-group-item`).each(
     (item) => {
@@ -260,6 +261,28 @@ function editQuotasTable(quotaName = ALLOCATED_STORAGE_QUOTA, quotaValue) {
   });
 }
 
+function rollbackQuotas() {
+  cy.toolbar(CONFIG_TOOLBAR_BUTTON, MANAGE_QUOTAS_CONFIG_OPTION);
+  let quotaDisabled = false;
+  cy.get('#rbac_details .miq-data-table table tbody tr').each((row) => {
+    const quotaValueInputWrapper = row.find('div.bx--text-input-wrapper');
+    const isEnabled = !quotaValueInputWrapper.hasClass(
+      'bx--text-input-wrapper--readonly'
+    );
+    if (isEnabled) {
+      quotaDisabled = true;
+      cy.wrap(row).find('span.bx--toggle__switch').click();
+    }
+  });
+  // Save the form only if any quotas are reverted to disabled.
+  cy.then(() => {
+    if (quotaDisabled) {
+      // Saving the form
+      saveFormWithOptionalFlashCheck({ assertFlashMessage: false });
+    }
+  });
+}
+
 describe('Automate Tenant form operations: Settings > Application Settings > Access Control > Tenants', () => {
   beforeEach(() => {
     cy.login();
@@ -276,10 +299,6 @@ describe('Automate Tenant form operations: Settings > Application Settings > Acc
     describe('Validate Edit parent tenant', () => {
       beforeEach(() => {
         cy.toolbar(CONFIG_TOOLBAR_BUTTON, EDIT_TENANT_CONFIG_OPTION);
-      });
-
-      afterEach(() => {
-        confirmUiNavigation(() => resetParentTenantForm());
       });
 
       it('Validate Edit tenant form elements', () => {
@@ -306,25 +325,25 @@ describe('Automate Tenant form operations: Settings > Application Settings > Acc
         );
         saveFormWithOptionalFlashCheck({ apiMethod: 'PUT' });
       });
+
+      afterEach(() => {
+        confirmUiNavigation(() => resetParentTenantForm());
+      });
     });
 
     describe('Validate Add Project to parent tenant', () => {
-      afterEach(() => {
-        cy.appDbState('restore');
-      });
-
       it('Validate Add Project function', () => {
         addProjectToTenant();
+      });
+
+      afterEach(() => {
+        confirmUiNavigation(() => deleteAccordionItems([PROJECT_NAME_VALUE]));
       });
     });
 
     describe('Validate Manage Quotas in parent tenant', () => {
       beforeEach(() => {
         cy.toolbar(CONFIG_TOOLBAR_BUTTON, MANAGE_QUOTAS_CONFIG_OPTION);
-      });
-
-      afterEach(() => {
-        cy.appDbState('restore');
       });
 
       it('Validate Reset & Cancel buttons in Manage Quotas form', () => {
@@ -341,6 +360,10 @@ describe('Automate Tenant form operations: Settings > Application Settings > Acc
         editQuotasTable(ALLOCATED_STORAGE_QUOTA, '10');
         saveFormWithOptionalFlashCheck();
       });
+
+      afterEach(() => {
+        confirmUiNavigation(() => rollbackQuotas());
+      });
     });
   });
 
@@ -348,10 +371,6 @@ describe('Automate Tenant form operations: Settings > Application Settings > Acc
     describe('Validate Add child tenant function', () => {
       beforeEach(() => {
         cy.toolbar(CONFIG_TOOLBAR_BUTTON, ADD_CHILD_TENANT_CONFIG_OPTION);
-      });
-
-      afterEach(() => {
-        cy.appDbState('restore');
       });
 
       it('Validate Add child tenant form elements', () => {
@@ -396,16 +415,18 @@ describe('Automate Tenant form operations: Settings > Application Settings > Acc
         );
         cancelFormWithOptionalFlashCheck(false);
       });
+
+      afterEach(() => {
+        confirmUiNavigation(() =>
+          deleteAccordionItems([INITIAL_CHILD_TENANT_NAME])
+        );
+      });
     });
 
     describe('Validate Edit child tenant', () => {
       beforeEach(() => {
         createAndSelectChildTenant();
         cy.toolbar(CONFIG_TOOLBAR_BUTTON, EDIT_TENANT_CONFIG_OPTION);
-      });
-
-      afterEach(() => {
-        cy.appDbState('restore');
       });
 
       it('Validate Edit child tenant form elements', () => {
@@ -433,15 +454,18 @@ describe('Automate Tenant form operations: Settings > Application Settings > Acc
         );
         saveFormWithOptionalFlashCheck({ apiMethod: 'PUT' });
       });
+
+      afterEach(() => {
+        deleteAccordionItems([
+          INITIAL_CHILD_TENANT_NAME,
+          EDITED_TENANT_NAME_VALUE,
+        ]);
+      });
     });
 
     describe('Validate Add Project to child tenant', () => {
       beforeEach(() => {
         createAndSelectChildTenant();
-      });
-
-      afterEach(() => {
-        cy.appDbState('restore');
       });
 
       it('Validate Add Project function', () => {
@@ -453,16 +477,19 @@ describe('Automate Tenant form operations: Settings > Application Settings > Acc
         deleteAccordionItems([INITIAL_CHILD_TENANT_NAME]);
         cy.expect_flash(flashClassMap.error, FLASH_MESSAGE_CANT_DELETE);
       });
+
+      afterEach(() => {
+        confirmUiNavigation(() => {
+          deleteAccordionItems([PROJECT_NAME_VALUE]);
+          deleteAccordionItems([INITIAL_CHILD_TENANT_NAME]);
+        });
+      });
     });
 
     describe('Validate Manage Quotas in child tenant', () => {
       beforeEach(() => {
         createAndSelectChildTenant();
         cy.toolbar(CONFIG_TOOLBAR_BUTTON, MANAGE_QUOTAS_CONFIG_OPTION);
-      });
-
-      afterEach(() => {
-        cy.appDbState('restore');
       });
 
       it('Validate Reset & Cancel buttons in Manage Quotas form', () => {
@@ -478,6 +505,12 @@ describe('Automate Tenant form operations: Settings > Application Settings > Acc
       it('Validate Manage Quotas function', () => {
         editQuotasTable(ALLOCATED_VM_QUOTA, '10');
         saveFormWithOptionalFlashCheck();
+      });
+
+      afterEach(() => {
+        confirmUiNavigation(() => {
+          deleteAccordionItems([INITIAL_CHILD_TENANT_NAME]);
+        });
       });
     });
   });


### PR DESCRIPTION
This commit reverts #9660, #9658 and part of #9633.

The database reset in the tenant spec is colliding with another puma thread that is trying to do an API request at the same time.  We need to ensure the reset is done in isolation to 
avoid this test failure that is happening more than sporadically.

NOTE: This is to bring more stable testing in cypress until https://github.com/ManageIQ/manageiq-ui-classic/pull/9672 is merged

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
