### PR TITLE
Made the selector more generic

### DIFF
--- a/cypress/support/commands/element_selectors.js
+++ b/cypress/support/commands/element_selectors.js
@@ -44,7 +44,7 @@ Cypress.Commands.add(
       cy.logAndThrowError('inputId is required');
     }
     return cy.get(
-      `#main-content .bx--form input[id="${inputId}"][type="${inputType}"]`
+      `#main-content form input[id="${inputId}"][type="${inputType}"]`
     );
   }
 );
@@ -64,7 +64,7 @@ Cypress.Commands.add('getFormLabelByForAttribute', ({ forValue }) => {
   if (!forValue) {
     cy.logAndThrowError('forValue is required');
   }
-  return cy.get(`#main-content .bx--form label[for="${forValue}"]`);
+  return cy.get(`#main-content form label[for="${forValue}"]`);
 });
 
 /**
@@ -82,7 +82,7 @@ Cypress.Commands.add('getFormSelectFieldById', ({ selectId }) => {
   if (!selectId) {
     cy.logAndThrowError('selectId is required');
   }
-  return cy.get(`#main-content .bx--form select[id="${selectId}"]`);
+  return cy.get(`#main-content form select[id="${selectId}"]`);
 });
 
 /**
@@ -100,5 +100,5 @@ Cypress.Commands.add('getFormTextareaById', ({ textareaId }) => {
   if (!textareaId) {
     cy.logAndThrowError('textareaId is required');
   }
-  return cy.get(`#main-content .bx--form textarea[id="${textareaId}"]`);
+  return cy.get(`#main-content form textarea[id="${textareaId}"]`);
 });


### PR DESCRIPTION
Haven’t come across a form element without the `.bx-form` class before, removing it to make this more generic.
Forms with `bx-form` class:
<img width="2528" height="1350" alt="image" src="https://github.com/user-attachments/assets/1a274d81-45b4-4f51-850f-84bf5e8eba37" />
Forms without class:
<img width="2954" height="1184" alt="image" src="https://github.com/user-attachments/assets/3735d916-fdb9-4df6-ad1a-5d7a3672dbb9" />

@miq-bot add-label cypress
@miq-bot assign @jrafanie
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
