### PR TITLE
Enhanced validateFormFields to assert checkbox state

### DIFF
--- a/cypress/support/commands/constants/command_constants.js
+++ b/cypress/support/commands/constants/command_constants.js
@@ -15,6 +15,7 @@ export const FIELD_CONFIG_KEYS = {
   FIELD_TYPE: 'fieldType',
   INPUT_FIELD_TYPE: 'inputFieldType',
   SHOULD_BE_DISABLED: 'shouldBeDisabled',
+  SHOULD_BE_CHECKED: 'shouldBeChecked',
   EXPECTED_VALUE: 'expectedValue',
 };
 

--- a/cypress/support/commands/form_elements_validation_commands.js
+++ b/cypress/support/commands/form_elements_validation_commands.js
@@ -152,6 +152,16 @@ Cypress.Commands.add('validateFormFields', (fieldConfigs) => {
             if (expectedValue) {
               cy.wrap(field).should('have.value', expectedValue);
             }
+
+            if (inputFieldType === 'checkbox') {
+              const shouldBeChecked =
+                config[FIELD_CONFIG_KEYS.SHOULD_BE_CHECKED] || false;
+              if (shouldBeChecked) {
+                expect(field).to.be.checked;
+              } else {
+                expect(field).to.not.be.checked;
+              }
+            }
           });
         break;
       case FIELD_TYPES.SELECT:


### PR DESCRIPTION
PR to enhance `validateFormFields` to assert checkbox state when `inputFieldType` is 'checkbox'

@miq-bot add-label cypress
@miq-bot add-label enhancement
@miq-bot assign @jrafanie

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
