### PR TITLE
Workflow table remove icon text

### DIFF
--- a/app/stylesheet/miq-data-table.scss
+++ b/app/stylesheet/miq-data-table.scss
@@ -418,3 +418,10 @@ table.miq_preview {
     color: var(--red);
   }
 }
+
+#workflows_table {
+  td.no_text {
+    width: 50px;
+    padding-left: 24px;
+  }
+}

--- a/app/views/workflow/show_list.html.haml
+++ b/app/views/workflow/show_list.html.haml
@@ -1,2 +1,3 @@
 #main_div
-  = render :partial => 'layouts/gtl'
+  #workflows_table
+    = render :partial => 'layouts/gtl'

--- a/lib/gtl_formatter.rb
+++ b/lib/gtl_formatter.rb
@@ -12,6 +12,9 @@ class GtlFormatter
   COLUMN_WITH_ICON = {
     'authentication_status'  => 'authentication_status_image',
     'last_compliance_status' => 'last_compliance_status_image',
+  }.freeze
+
+  COLUMN_WITH_ICON_NO_TEXT = {
     'payload_valid'          => 'payload_valid_image',
   }.freeze
 
@@ -134,6 +137,11 @@ class GtlFormatter
         item = {:title => text,
                 :icon  => icon,
                 :text  => text}.compact
+      elsif COLUMN_WITH_ICON_NO_TEXT.key?(col)
+        icon = send(COLUMN_WITH_ICON_NO_TEXT[col], record)
+        text = format_col_for_display(view, row, col)
+        item = {:title => text,
+                :icon  => icon}.compact
       elsif COLUMN_WITH_TIME.include?(col)
         celltext = format_time_for_display(row, col)
       elsif COLUMN_WITH_OS_TEXT.include?(col)


### PR DESCRIPTION
Follow up to this pr: https://github.com/ManageIQ/manageiq-ui-classic/pull/9632

This PR removes the text and only shows the icon in the payload valid column.

Before:
<img width="1160" height="271" alt="Screenshot 2025-10-28 at 12 37 40 PM" src="https://github.com/user-attachments/assets/73291ca7-4a01-4383-9aa6-7a00c669b632" />

After:
<img width="1163" height="275" alt="Screenshot 2025-10-28 at 12 37 05 PM" src="https://github.com/user-attachments/assets/bacd9ca0-2822-426d-ab3b-ca1aa959d05d" />
