### PR TITLE
Add explicit status code assertion for Add Zone API

### DIFF
--- a/cypress/e2e/ui/Settings/Application-Settings/zone.cy.js
+++ b/cypress/e2e/ui/Settings/Application-Settings/zone.cy.js
@@ -75,6 +75,9 @@ function addZone() {
         })
         .should('be.enabled')
         .click(),
+    onApiResponse: (interception) => {
+      expect(interception.response.statusCode).to.equal(200);
+    },
   });
   return cy.then(() => {
     return `Zone: ${INITIAL_ZONE_DESCRIPTION}`;


### PR DESCRIPTION
Attempting to fix intermittent failures in the zone form test: caused by querying accordion elements right after the Add Zone API call:
<img width="1280" height="633" alt="image" src="https://github.com/user-attachments/assets/5269096a-5068-4993-8fc0-092fa2a54487" />

@miq-bot add-label cypress
@miq-bot add-label refactoring
@miq-bot assign @jrafanie

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
