### PR TITLE
Cypress: Replace UI driven cleanup with db state restore

### DIFF
--- a/cypress/e2e/ui/Services/Catalogs/catalog.cy.js
+++ b/cypress/e2e/ui/Services/Catalogs/catalog.cy.js
@@ -7,9 +7,6 @@ import {
   DUAL_LIST_ACTION_TYPE,
 } from '../../../../support/commands/constants/command_constants.js';
 
-// Component route url
-const COMPONENT_ROUTE_URL = '/catalog/explorer';
-
 // Menu options
 const SERVICES_MENU_OPTION = 'Services';
 const CATALOGS_MENU_OPTION = 'Catalogs';
@@ -21,7 +18,6 @@ const DESCRIPTION_FIELD_LABEL = 'Description';
 const CATALOG_ITEMS_HEADER = 'Catalog Items';
 const DUAL_LIST_AVAILABLE_ITEMS_HEADER = 'Unassigned';
 const DUAL_LIST_SELECTED_ITEMS_HEADER = 'Selected';
-const REMOVE_CATALOG_MODAL_HEADER_TEXT = 'Delete';
 
 // Field values
 const CATALOG_ITEM_NAME_1 = 'Test-Catalog-Item-1';
@@ -35,14 +31,12 @@ const ADD_CATALOG_ITEM_CONFIG_OPTION = 'Add a New Catalog Item';
 const ADD_CATALOG_CONFIG_OPTION = 'Add a New Catalog';
 const EDIT_CATALOG_CONFIG_OPTION = 'Edit this Item';
 const REMOVE_CATALOG_CONFIG_OPTION = 'Remove Catalog';
-const DELETE_CATALOG_ITEMS_CONFIG_OPTION = 'Delete Catalog Items';
 
 // Buttons
 const ADD_BUTTON_TEXT = 'Add';
 const SAVE_BUTTON_TEXT = 'Save';
 const CANCEL_BUTTON_TEXT = 'Cancel';
 const RESET_BUTTON_TEXT = 'Reset';
-const DELETE_BUTTON_TEXT = 'Delete';
 
 // Flash message text snippets
 const FLASH_MESSAGE_ADDED = 'added';
@@ -147,6 +141,10 @@ describe('Automate Catalog form operations: Services > Catalogs > Catalogs > Con
 
     cy.accordion(CATALOGS_ACCORDION_ITEM);
     cy.selectAccordionItem([ALL_CATALOGS_ACCORDION_ITEM]);
+  });
+
+  afterEach(() => {
+    cy.appDbState('restore');
   });
 
   describe('Validate add form fields and verify add, edit, and delete operations', () => {
@@ -254,59 +252,5 @@ describe('Automate Catalog form operations: Services > Catalogs > Catalogs > Con
       );
       cy.expect_inline_field_errors({ containsText: 'taken' });
     });
-
-    afterEach(() => {
-      // TODO: Replace with better cleanup approach
-      cy.url()
-        .then((url) => {
-          // Ensures navigation to Services -> Catalogs in the UI
-          if (!url.endsWith(COMPONENT_ROUTE_URL)) {
-            cy.visit(COMPONENT_ROUTE_URL);
-          }
-          cy.accordion(CATALOGS_ACCORDION_ITEM);
-        })
-        .then(() => {
-          cy.selectAccordionItem([
-            ALL_CATALOGS_ACCORDION_ITEM,
-            TEST_CATALOG_NAME,
-          ]);
-          cy.expect_browser_confirm_with_text({
-            confirmTriggerFn: () =>
-              cy.toolbar(CONFIG_TOOLBAR_BUTTON, REMOVE_CATALOG_CONFIG_OPTION),
-            containsText: BROWSER_ALERT_REMOVE_CONFIRM_TEXT,
-          });
-        });
-    });
-  });
-
-  afterEach(() => {
-    // TODO: Replace with better cleanup approach
-    cy.url()
-      .then((url) => {
-        // Ensures navigation to Services -> Catalogs in the UI
-        if (!url.endsWith(COMPONENT_ROUTE_URL)) {
-          cy.visit(COMPONENT_ROUTE_URL);
-        }
-        cy.accordion(CATALOG_ITEMS_ACCORDION_ITEM);
-      })
-      .then(() => {
-        cy.selectAccordionItem([
-          ALL_CATALOG_ITEMS_ACCORDION_ITEM,
-          UNASSIGNED_ACCORDION_ITEM,
-        ]);
-        cy.selectTableRowsByText({
-          textArray: [CATALOG_ITEM_NAME_1, CATALOG_ITEM_NAME_2],
-        });
-        cy.toolbar(CONFIG_TOOLBAR_BUTTON, DELETE_CATALOG_ITEMS_CONFIG_OPTION);
-        cy.expect_modal({
-          modalHeaderText: REMOVE_CATALOG_MODAL_HEADER_TEXT,
-          modalContentExpectedTexts: [
-            'delete',
-            CATALOG_ITEM_NAME_1,
-            CATALOG_ITEM_NAME_2,
-          ],
-          targetFooterButtonText: DELETE_BUTTON_TEXT,
-        });
-      });
   });
 });

--- a/cypress/e2e/ui/Services/Catalogs/copy_catalog.cy.js
+++ b/cypress/e2e/ui/Services/Catalogs/copy_catalog.cy.js
@@ -6,9 +6,6 @@ import {
   BUTTON_CONFIG_KEYS,
 } from '../../../../support/commands/constants/command_constants';
 
-// Component route url
-const COMPONENT_ROUTE_URL = '/catalog/explorer';
-
 // Menu options
 const SERVICES_MENU_OPTION = 'Services';
 const CATALOGS_MENU_OPTION = 'Catalogs';
@@ -22,13 +19,11 @@ const UNASSIGNED_ACCORDION_ITEM = 'Unassigned';
 const CONFIG_TOOLBAR_BUTTON = 'Configuration';
 const ADD_CATALOG_ITEM_CONFIG_OPTION = 'Add a New Catalog Item';
 const COPY_CONFIG_OPTION = 'Copy Selected Item';
-const DELETE_CATALOG_ITEMS_CONFIG_OPTION = 'Delete Catalog Items';
 
 // Field labels
 const FORM_HEADER = 'Catalog';
 const NAME_FIELD_LABEL = 'Name';
 const COPY_TAGS_FIELD_LABEL = 'Copy Tags';
-const REMOVE_CATALOG_MODAL_HEADER_TEXT = 'Delete';
 
 // Field values
 const CATALOG_ITEM_NAME = 'Test-Catalog-Item';
@@ -43,33 +38,6 @@ const FLASH_MESSAGE_SAVED = 'saved';
 // Buttons
 const ADD_BUTTON_TEXT = 'Add';
 const CANCEL_BUTTON_TEXT = 'Cancel';
-const DELETE_BUTTON_TEXT = 'Delete';
-
-function cleanUp(catalogItemToDelete) {
-  cy.url()
-    .then((url) => {
-      // Ensures navigation to Services -> Catalogs in the UI
-      if (!url.endsWith(COMPONENT_ROUTE_URL)) {
-        cy.visit(COMPONENT_ROUTE_URL);
-      }
-      cy.accordion(CATALOG_ITEMS_ACCORDION_ITEM);
-    })
-    .then(() => {
-      cy.selectAccordionItem([
-        ALL_CATALOG_ITEMS_ACCORDION_ITEM,
-        UNASSIGNED_ACCORDION_ITEM,
-      ]);
-      cy.selectTableRowsByText({
-        textArray: [catalogItemToDelete],
-      });
-      cy.toolbar(CONFIG_TOOLBAR_BUTTON, DELETE_CATALOG_ITEMS_CONFIG_OPTION);
-      cy.expect_modal({
-        modalHeaderText: REMOVE_CATALOG_MODAL_HEADER_TEXT,
-        modalContentExpectedTexts: ['delete', catalogItemToDelete],
-        targetFooterButtonText: DELETE_BUTTON_TEXT,
-      });
-    });
-}
 
 describe('Automate Catalog form operations: Services > Catalogs > Catalogs > Configuration > Add a New Catalog', () => {
   beforeEach(() => {
@@ -96,6 +64,10 @@ describe('Automate Catalog form operations: Services > Catalogs > Catalogs > Con
       CATALOG_ITEM_NAME,
     ]);
     cy.toolbar(CONFIG_TOOLBAR_BUTTON, COPY_CONFIG_OPTION);
+  });
+
+  afterEach(() => {
+    cy.appDbState('restore');
   });
 
   describe('Verify form elements, validate cancel button and validate name related error messages', () => {
@@ -162,15 +134,5 @@ describe('Automate Catalog form operations: Services > Catalogs > Catalogs > Con
       }).click();
       cy.expect_flash(flashClassMap.success, FLASH_MESSAGE_SAVED);
     });
-
-    afterEach(() => {
-      // TODO: Replace with better cleanup approach
-      cleanUp(COPIED_CATALOG_ITEM_NAME);
-    });
-  });
-
-  afterEach(() => {
-    // TODO: Replace with better cleanup approach
-    cleanUp(CATALOG_ITEM_NAME);
   });
 });


### PR DESCRIPTION
This is step 1.

We'll replace the setup side, if possible, with factories next, see https://github.com/ManageIQ/manageiq-ui-classic/pull/9699

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
