### PR TITLE
Update get-intrinsic

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,6 +191,7 @@
     "cross-spawn": "~7.0.5",
     "decode-uri-component": "^0.2.2",
     "express": "^4.18.2",
+    "get-intrinsic": "<=1.3.0",
     "lodash": "~4.17.21",
     "minimatch": "~5.1.6",
     "moment": "^2.30.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9331,7 +9331,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6, get-intrinsic@npm:^1.2.7, get-intrinsic@npm:^1.3.0":
+"get-intrinsic@npm:<=1.3.0":
   version: 1.3.0
   resolution: "get-intrinsic@npm:1.3.0"
   dependencies:


### PR DESCRIPTION
This locks the get-intrinsic package to version <=1.3.0 to prevent further updates that are causing breaks. Similar to PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/9390, merging this should fix the pr: https://github.com/ManageIQ/manageiq-ui-classic/pull/9641