### PR TITLE
Remove unnecessary ivars

### DIFF
--- a/app/helpers/ops_helper.rb
+++ b/app/helpers/ops_helper.rb
@@ -22,19 +22,19 @@ module OpsHelper
   end
 
   def database_details
-    @database_details = ActiveRecord::Base.configurations.configs_for(:env_name => Rails.env).first.configuration_hash
-    @database_display_name =
-      if @database_details[:host].in?([nil, "", "localhost", "127.0.0.1"])
+    details = ActiveRecord::Base.configurations.configs_for(:env_name => Rails.env).first.configuration_hash
+    display_name =
+      if details[:host].in?([nil, "", "localhost", "127.0.0.1"])
         _("Internal Database")
       else
         _("External Database")
       end
       @data = {:title => _('Basic Information')}
       @data[:rows] = [
-        row_data(_('Name'), @database_display_name),
-        row_data(_('Hostname'), @database_details[:host]),
-        row_data(_('Database name'), @database_details[:database]),
-        row_data(_('Username'), @database_details[:username])
+        row_data(_('Name'), display_name),
+        row_data(_('Hostname'), details[:host]),
+        row_data(_('Database name'), details[:database]),
+        row_data(_('Username'), details[:username])
       ]
   end
 


### PR DESCRIPTION
There's no need for these to be ivars because they are not accessed anywhere else and also they aren't memoized. This commits switches them to be local vars.

@jrafanie Please review.