### PR TITLE
Enhance select accordion item

### DIFF
--- a/cypress/support/commands/explorer.js
+++ b/cypress/support/commands/explorer.js
@@ -104,6 +104,50 @@ Cypress.Commands.add('selectAccordionItem', (accordionPath) => {
             return;
           }
 
+          // TODO: Once interceptApi is enhanced to handle mutiple aliases, instead of
+          // depending on the spinner or angle-down spans, wait for tree_autoload to complete
+          /* ===================================================================================== */
+          const isStillLoading =
+            currentLiElement.find('span.fa-spinner').length > 0;
+          if (isStillLoading) {
+            Cypress.log({
+              name: '⚠️ selectAccordionItem',
+              message: `Node "${liText}" is still loading - waiting for fa-angle-down to appear`,
+            });
+
+            // Wait for fa-angle-down to appear (indicates loading is complete)
+            cy.wrap(currentLiElement)
+              .find('span.fa-angle-down')
+              .should('exist')
+              .then(() => {
+                Cypress.log({
+                  name: '🟢 selectAccordionItem',
+                  message: `Node "${liText}" loading completed (fa-angle-down found)`,
+                });
+                cy.get('div.panel-collapse.collapse.in')
+                  .then((latestAccordionJqueryObject) => {
+                    // Update the expanded accordion reference to the latest one
+                    expandedAccordion = latestAccordionJqueryObject;
+                    const updatedListItems = [
+                      ...expandedAccordion.find('li.list-group-item'),
+                    ];
+                    Cypress.log({
+                      name: '🟢 selectAccordionItem',
+                      message: `Re-queried accordion - new list items count: ${updatedListItems.length}`,
+                    });
+                    // Update list items
+                    listItems = [...updatedListItems];
+                  })
+                  .then(() => {
+                    // Recurse to the next label in the given path array and
+                    // start iteration from the current index
+                    expandAndClickPath(accordionPathIndex + 1, i + 1);
+                  });
+              });
+            return;
+          }
+          /* ===================================================================================== */
+
           const expandButton = currentLiElement.find('span.fa-angle-right');
           const isExpandable = expandButton.length > 0;
 


### PR DESCRIPTION
An interim fix to the issue mentioned in https://github.com/ManageIQ/manageiq-ui-classic/pull/9705#issuecomment-3482003117:
Temporarily, we can do this: watch for the `spinner` being replaced by the `angle-down` icon as a sign that loading is done and then like we did with `tree_autoload` after clicking the expand icon, update the accordion reference and the list items
<img width="2400" height="1518" alt="image" src="https://github.com/user-attachments/assets/33357261-309d-4d48-a2f6-09d484041e1b" />

@miq-bot add-label cypress
@miq-bot add-label refactoring
@miq-bot assign @jrafanie

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
