### PR TITLE
Chain .then() directly to interceptApi for returning zone name

### DIFF
--- a/cypress/e2e/ui/Settings/Application-Settings/zone.cy.js
+++ b/cypress/e2e/ui/Settings/Application-Settings/zone.cy.js
@@ -64,24 +64,25 @@ function addZone() {
   cy.getFormSelectFieldById({
     selectId: 'settings.concurrent_vm_scans',
   }).select(INITIAL_MAX_SCAN_LIMIT);
-  cy.interceptApi({
-    alias: 'createZoneApi',
-    urlPattern: '/api/zones',
-    triggerFn: () =>
-      cy
-        .getFormButtonByTypeWithText({
-          buttonText: ADD_BUTTON_TEXT,
-          buttonType: 'submit',
-        })
-        .should('be.enabled')
-        .click(),
-    onApiResponse: (interception) => {
-      expect(interception.response.statusCode).to.equal(200);
-    },
-  });
-  return cy.then(() => {
-    return `Zone: ${INITIAL_ZONE_DESCRIPTION}`;
-  });
+  return cy
+    .interceptApi({
+      alias: 'createZoneApi',
+      urlPattern: '/api/zones',
+      triggerFn: () =>
+        cy
+          .getFormButtonByTypeWithText({
+            buttonText: ADD_BUTTON_TEXT,
+            buttonType: 'submit',
+          })
+          .should('be.enabled')
+          .click(),
+      onApiResponse: (interception) => {
+        expect(interception.response.statusCode).to.equal(200);
+      },
+    })
+    .then(() => {
+      return `Zone: ${INITIAL_ZONE_DESCRIPTION}`;
+    });
 }
 
 function validateFormElements(isEditForm = false) {


### PR DESCRIPTION
Attempt to fix sporadic failures in the zone form, where the lookup for a newly created zone could start before the create-zone API call completed:
<img width="1280" height="633" alt="image" src="https://github.com/user-attachments/assets/8ade4dad-c922-4ed5-ab92-56e62a221da9" />
By chaining `.then()` directly to `interceptApi` for returning the zone name, it maintains a single, continuous promise chain.

@miq-bot add-label cypress
@miq-bot add-label refactoring
@miq-bot assign @jrafanie

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
