### PR TITLE
Drop Log Collection validation

### DIFF
--- a/app/controllers/pxe_controller/pxe_servers.rb
+++ b/app/controllers/pxe_controller/pxe_servers.rb
@@ -183,7 +183,7 @@ module PxeController::PxeServers
       render :json => {:status => 'error', :message => _("Error during 'Validate': %{error_message}") % {:error_message => bang.message}}
     end
 
-    render :json => {:status => 'success', :message => _('PXE Credentials successfuly validated')}
+    render :json => {:status => 'success', :message => _('PXE Credentials successfully validated')}
   end
 
   private #######################

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2666,7 +2666,6 @@ Rails.application.routes.draw do
         explorer
         iso_datastore_list
         iso_image_edit
-        log_depot_validate
         pxe_image_edit
         pxe_image_type_edit
         pxe_image_type_list

--- a/spec/config/routes.pending.yml
+++ b/spec/config/routes.pending.yml
@@ -1040,7 +1040,6 @@ PlacementGroupController:
 - sections_field_changed
 PxeController:
 - accordion_select
-- log_depot_validate
 - pxe_server_async_cred_validation
 - reload
 - report_data

--- a/spec/controllers/ops_controller/settings/schedules_spec.rb
+++ b/spec/controllers/ops_controller/settings/schedules_spec.rb
@@ -82,35 +82,6 @@ describe OpsController do
     end
   end
 
-  context "#build_uri_settings" do
-    let(:mocked_filedepot) { double(FileDepotSmb) }
-    it "uses params[:log_password] for validation if one exists" do
-      controller.params = {:log_userid   => "userid",
-                           :log_password => "password2",
-                           :uri_prefix   => "smb",
-                           :uri          => "samba_uri",
-                           :log_protocol => "Samba"}
-      settings = {:username   => "userid",
-                  :password   => "password2",
-                  :uri        => "smb://samba_uri",
-                  :uri_prefix => "smb"}
-      expect(controller.send(:build_uri_settings, mocked_filedepot)).to include(settings)
-    end
-
-    it "uses the stored password for validation if params[:log_password] does not exist" do
-      controller.params = {:log_userid   => "userid",
-                           :uri_prefix   => "smb",
-                           :uri          => "samba_uri",
-                           :log_protocol => "Samba"}
-      expect(mocked_filedepot).to receive(:try).with(:authentication_password).and_return('password')
-      settings = {:username   => "userid",
-                  :password   => "password",
-                  :uri        => "smb://samba_uri",
-                  :uri_prefix => "smb"}
-      expect(controller.send(:build_uri_settings, mocked_filedepot)).to include(settings)
-    end
-  end
-
   context "#schedule_set_record_vars" do
     let(:user) { stub_user(:features => :all) }
     let(:schedule) { FactoryBot.create(:miq_automate_schedule) }

--- a/spec/routing/pxe_routing_spec.rb
+++ b/spec/routing/pxe_routing_spec.rb
@@ -27,12 +27,6 @@ describe PxeController do
     end
   end
 
-  describe "#log_depot_validate" do
-    it "routes with POST" do
-      expect(post("/pxe/log_depot_validate")).to route_to("pxe#log_depot_validate")
-    end
-  end
-
   describe "#pxe_image_edit" do
     it "routes with POST" do
       expect(post("/pxe/pxe_image_edit")).to route_to("pxe#pxe_image_edit")


### PR DESCRIPTION
Follow up to #9704, this drops the log_depot_validate methods. After reviewing it further, these are not used at all. The PxeServer screens were converted to react and call a dedicated validation endpoint under /pxe/pxe_server_async_cred_validation. I also do not see any evidence of scheduled verifications being needed anymore.

@jrafanie  Please review.