### PR TITLE
Enhanced selectAccordionItem to wait for items to load before proceeding

### DIFF
--- a/cypress/support/commands/explorer.js
+++ b/cypress/support/commands/explorer.js
@@ -210,8 +210,32 @@ Cypress.Commands.add('selectAccordionItem', (accordionPath) => {
       cy.logAndThrowError(errorMessage);
     };
 
-    // Start the recursive call from the first label in the given path
+    // If no list items are found initially - wait for them to load and
+    // then start the recursive call from the first label in the given path
     // and from the beginning of the accordion items in the panel
-    expandAndClickPath(0, 0);
+    if (listItems.length) {
+      expandAndClickPath(0, 0);
+    } else {
+      Cypress.log({
+        name: '⚠️ selectAccordionItem',
+        message: 'No list items found initially - waiting for them to load',
+      });
+
+      cy.get('div.panel-collapse.collapse.in').then((freshAccordion) => {
+        cy.wrap(freshAccordion)
+          .find('li.list-group-item')
+          .should('have.length.greaterThan', 0)
+          .then((loadedListItems) => {
+            // Update references with the loaded data
+            expandedAccordion = freshAccordion;
+            listItems = [...loadedListItems];
+            Cypress.log({
+              name: '🟢 selectAccordionItem',
+              message: `List items loaded - found ${listItems.length} items`,
+            });
+            expandAndClickPath(0, 0);
+          });
+      });
+    }
   });
 });


### PR DESCRIPTION
Enhanced the `selectAccordionItem` command to wait for list items to load prior to initiating the lookup
This issue was noticed as part of https://github.com/ManageIQ/manageiq-ui-classic/pull/8916 where it failed to find `li` nodes when there is a delay:
<img width="3066" height="1492" alt="image" src="https://github.com/user-attachments/assets/393c48be-b774-4219-a632-1696fb4e041b" />
Fix: re-query the dom when no `li` nodes are found initially:
<img width="2850" height="1480" alt="image" src="https://github.com/user-attachments/assets/5e63440f-412c-43e0-9660-0a0823cf1ac8" />

@miq-bot add-label cypress
@miq-bot add-label refactoring
@miq-bot assign @jrafanie

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
