### PR TITLE
Fixed test suite name

### DIFF
--- a/cypress/e2e/ui/Services/Catalogs/copy_catalog.cy.js
+++ b/cypress/e2e/ui/Services/Catalogs/copy_catalog.cy.js
@@ -37,7 +37,7 @@ const FLASH_MESSAGE_SAVED = 'saved';
 const ADD_BUTTON_TEXT = 'Add';
 const CANCEL_BUTTON_TEXT = 'Cancel';
 
-describe('Automate Catalog form operations: Services > Catalogs > Catalogs > Configuration > Add a New Catalog', () => {
+describe('Automate Copy Catalog Item form operations: Services > Catalogs > Catalog Items > {Any-created-catalog-item} > Configuration > Copy Selected Item', () => {
   beforeEach(() => {
     cy.appFactories([
       ['create', 'service_template', {name: CATALOG_ITEM_NAME, generic_subtype: 'custom', prov_type: 'generic', display: true}],


### PR DESCRIPTION
Corrected the test suite name, it was referencing add-catalog instead of copy-catalog

@miq-bot add-label cypress
@miq-bot add-label refactoring
@miq-bot assign @jrafanie

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
