### PR TITLE
Quiet the noisy cypress output in the beginning of the run

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -37,11 +37,9 @@ module.exports = defineConfig({
       });
       on('before:browser:launch', (browser = {}, launchOptions) => {
         console.log('Launching browser:', browser.name);
-        console.log('Input args:', launchOptions.args);
         if (browser.name === 'chrome') {
           launchOptions.args.push('--disable-features=AutofillServerCommunication');
         }
-        console.log('Actual args:', launchOptions.args);
         return launchOptions;
       });
     },


### PR DESCRIPTION
It was added in 58775b56e13 for debugging cypress configured launchoptions to verify we were disabling some of them.

I don't think it's helpful normally and it can be added again locally while debugging.

## Before

<img width="931" height="879" alt="image" src="https://github.com/user-attachments/assets/dc1c7b56-2e05-429c-90ab-e298e836547a" />

## After

<img width="901" height="864" alt="image" src="https://github.com/user-attachments/assets/06858ae7-1f85-4908-a87c-33d2dfb8fdbc" />
