### PR TITLE
Fix: Capture Metrics button is disabled for an Openshift provider

### DIFF
--- a/app/controllers/mixins/ems_common/metrics.rb
+++ b/app/controllers/mixins/ems_common/metrics.rb
@@ -72,13 +72,7 @@ module Mixins
         if task == "refresh_ems"
           model.refresh_ems(emss, true)
         elsif task == "capture_ems"
-          emss.each do |ems|
-            unless ems.zone.role_active?("ems_metrics_coordinator")
-              add_flash(_("Capacity & Utilization Coordinator role is off for %{name}") % {:name => ems.name}, :error)
-            else
-              ems.queue_metrics_capture
-            end
-          end
+          emss.each(&:queue_metrics_capture)
         end
 
         add_task_flash(emss, action_name)


### PR DESCRIPTION
Fixes an issue where the "Capture Metrics" button remained disabled for OpenShift providers. The button was incorrectly disabled because the `check_role` method only verified whether the "ems_metrics_coordinator" role was active in the current server’s zone, instead of checking the provider’s own zone. 

The fix updates the logic to - 

~~`(@record ? @record.zone.role_active?("ems_metrics_coordinator") : MiqServer.my_server.zone.role_active?("ems_metrics_coordinator"))`~~

~~This ensures the role is checked against the provider’s zone first when a provider (@record) is present, enabling the button correctly.~~

check for role "ems_metrics_coordinator " only if there is a provider `@record` object

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
