### PR TITLE
Fix: Improve policy summary page layout for created/updated fields

### DIFF
--- a/app/helpers/miq_policy_helper.rb
+++ b/app/helpers/miq_policy_helper.rb
@@ -10,10 +10,10 @@ module MiqPolicyHelper
     rows = []
     data = {:title => _('Basic Information'), :mode => "miq_policy_basic_information"}
     rows.push({:cells => {:label => _('Active'), :value => record.active ? _("Yes") : _("No")}})
-    rows.push({:cells => {:label => _('Created By'), :value => record.created_by || _("N/A")}})
+    rows.push({:cells => {:label => _('Created By'), :value => record.created_by || ""}})
     rows.push({:cells => {:label => _('Created On'), :value => format_timezone(record.created_on, session[:user_tz], "gtl")}})
     if @record.created_on != @record.updated_on
-      rows.push({:cells => {:label => _("Last Updated By"), :value => record.updated_by || _("N/A")}})
+      rows.push({:cells => {:label => _("Last Updated By"), :value => record.updated_by || ""}})
       rows.push({:cells => {:label => _("Last Updated On"), :value => format_timezone(record.updated_on, session[:user_tz], "gtl")}})
     end
     data[:rows] = rows


### PR DESCRIPTION
Separates the "Created" and "Last Updated" fields for better readability. Also changes missing usernames from "N/A" to blank to be consistent with other summary pages in the application.

Fixes #9743 

Previously - after adding a new policy

<img width="655" height="122" alt="add-policy-before" src="https://github.com/user-attachments/assets/79cebb11-dedf-4713-a217-7d6d55931f79" />

With the fix - after adding new policy

<img width="507" height="155" alt="add-policy-after" src="https://github.com/user-attachments/assets/297f7e4a-4a45-4bc1-a99b-84647fdc9e5e" />

Previously - after updating a policy

<img width="675" height="155" alt="policy-update-before" src="https://github.com/user-attachments/assets/649dde0d-aed4-4cb4-bf7f-e2278fd46857" />

With the fix - after updating a policy

<img width="573" height="221" alt="policy-update-after" src="https://github.com/user-attachments/assets/8b3cd0c3-e5c6-421b-949e-ab7371210485" />

Before, when user was nil,

<img width="518" height="162" alt="no-user-before" src="https://github.com/user-attachments/assets/a08dd857-eb00-4cdb-a2e3-dc78425b546e" />

WIth the fix, user field will be blank if not present

<img width="498" height="193" alt="no-user-after" src="https://github.com/user-attachments/assets/fc6d7594-212d-4d94-a2e5-e070d1ec8eec" />



@miq-bot add-label bug
@miq-bot add-reviewer @jrafanie
@miq-bot add-reviewer @Fryguy  

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
