### PR TITLE
Removes dead code

### DIFF
--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -330,7 +330,6 @@ class InfraNetworkingController < ApplicationController
       partial_locals = {:controller =>'infra_networking'}
       if partial == 'layouts/x_gtl'
         partial_locals[:action_url] = @lastaction
-        presenter[:parent_class] = params[:controller] # Set parent class for URL also
       end
       presenter.update(:main_div, r[:partial => partial, :locals => partial_locals])
     else


### PR DESCRIPTION
Remove unused `parent_class` assignment in InfraNetworkingController as the value is never consumed by the frontend JavaScript code.

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->

@miq-bot add-label technical debt
@miq-bot add-reviewer @Fryguy
@miq-bot add-reviewer @jrafanie 
