### PR TITLE
Fix RJS error when deleting policy action from summary page

### DIFF
--- a/app/helpers/application_helper/toolbar/miq_action_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_action_center.rb
@@ -27,8 +27,7 @@ class ApplicationHelper::Toolbar::MiqActionCenter < ApplicationHelper::Toolbar::
                                          :controller     => 'provider_dialogs',
                                          :display_field  => 'description',
                                          :modal_text     => N_("Are you sure you want to delete this Action?"),
-                                         :modal_title    => N_("Delete Action"),
-                                         :ajax_reload    => true}}),
+                                         :modal_title    => N_("Delete Action")}}),
       ]
     ),
   ])


### PR DESCRIPTION
Fixes #9749 

Issue - The delete button in `miq_action_center.rb` had `:ajax_reload => true`, which attempted to reload the page after deletion. Since the record no longer exists, this caused the RJS error.

@miq-bot add-label bug
@miq-bot add-reviewer @jrafanie 

After fix - 

<img width="1134" height="674" alt="Screenshot 2025-12-08 at 7 11 35 PM" src="https://github.com/user-attachments/assets/e3fad7dc-c47d-4a95-a87f-5f4e2d8cf916" />






<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
<img width="1235" height="453" alt="Screenshot 2025-12-08 at 7 11 56 PM" src="https://github.com/user-attachments/assets/46d81152-4ccb-47ea-818c-41633b9fae2f" />
