### PR TITLE
Fix webpack warnings about end vs flex-end

### DIFF
--- a/app/javascript/components/AeInlineMethod/style.scss
+++ b/app/javascript/components/AeInlineMethod/style.scss
@@ -11,7 +11,7 @@
     .inline-filters {
       display: flex;
       flex-direction: row;
-      align-items: end;
+      align-items: flex-end;
       gap: 10px;
   
       .search-wrapper {

--- a/app/stylesheet/miq-data-table.scss
+++ b/app/stylesheet/miq-data-table.scss
@@ -281,7 +281,7 @@
 
     #pre_prov_form_buttons_div {
       display: flex;
-      justify-content: end;
+      justify-content: flex-end;
     }
   }
 


### PR DESCRIPTION
Removes the following warnings:

```
WARNING in ./app/javascript/components/AeInlineMethod/style.scss (./node_modules/css-loader/dist/cjs.js!./node_modules/postcss-loader/src??ref--9-2!./node_modules/resolve-url-loader!./node_modules/sass-loader/dist/cjs.js??ref--9-4!./app/javascript/components/AeInlineMethod/style.scss)
Module Warning (from ./node_modules/postcss-loader/src/index.js):
Warning

(12:3) end value has mixed support, consider using flex-end instead
 @ ./app/javascript/components/AeInlineMethod/style.scss 2:26-274
 @ ./app/javascript/components/AeInlineMethod/NamespaceSelector.jsx
 @ ./app/javascript/components/AeInlineMethod/index.jsx
 @ ./app/javascript/packs/component-definitions-common.js

WARNING in ./app/stylesheet/application-webpack.scss (./node_modules/css-loader/dist/cjs.js!./node_modules/postcss-loader/src??ref--9-2!./node_modules/resolve-url-loader!./node_modules/sass-loader/dist/cjs.js??ref--9-4!./app/stylesheet/application-webpack.scss)
Module Warning (from ./node_modules/postcss-loader/src/index.js):
Warning

(22744:3) end value has mixed support, consider using flex-end instead
 @ ./app/stylesheet/application-webpack.scss 2:26-264
 @ ./app/javascript/packs/application-common.js
```

@asirvadAbrahamVarghese Please review.