### PR TITLE
Expect each cypress test to pass 1 out of 4 attempts

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -14,7 +14,7 @@ module.exports = defineConfig({
     retries: {
       experimentalStrategy: 'detect-flake-and-pass-on-threshold',
       experimentalOptions: {
-        maxRetries: 9,
+        maxRetries: 3,
         passesRequired: 1,
       },
 


### PR DESCRIPTION
We've stabilized a lot of our tests so the last few cypress builds on master don't need more than 4 total attempts.  10 total attempt is painfully slow when running locally and if we have a problematic page or cypress test in CI, it takes a long time and we probably aren't fixing the minor timing issues regarding waiting for elements or API requests, etc.  We can always change this if this number is too high or low in the future.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
