### PR TITLE
Orchestration stack template summary page converted to react

### DIFF
--- a/app/helpers/orchestration_stack_helper.rb
+++ b/app/helpers/orchestration_stack_helper.rb
@@ -1,3 +1,37 @@
 module OrchestrationStackHelper
   include TextualSummary
+
+  def stack_orchestration_template_basic_info(template)
+    rows = [
+      row_data(_('Name'), template.name),
+      row_data(_('Description'), template.description),
+      row_data(_('Draft'), template.draft ? _("True") : _("False")),
+      row_data(_('Read Only'), template.in_use? ? _("True") : _("False")),
+      row_data(_('Orderable'), template.supports?(:order) ? _("True") : _("False")),
+      row_data(_('Created On'), template.created_at),
+      row_data(_('Updated On'), template.updated_at),
+    ]
+    miq_structured_list({
+                          :title => _('Details'),
+                          :mode  => "stack_orchestration_template_details",
+                          :rows  => rows
+                        })
+  end
+
+  def template_content(template)
+    rows = [
+      row_data('', {:input => 'code_mirror', :props => {:mode => 'ruby', :payload => template}})
+    ]
+    miq_structured_list({
+                          :title => _('Content'),
+                          :mode  => "template_data",
+                          :rows  => rows
+                        })
+  end
+
+  private
+
+  def row_data(label, value)
+    {:cells => {:label => label, :value => value}}
+  end
 end

--- a/app/views/orchestration_stack/_stack_orchestration_template.html.haml
+++ b/app/views/orchestration_stack/_stack_orchestration_template.html.haml
@@ -1,40 +1,6 @@
 #form_div
   #basic_info_div
   = render :partial => "layouts/flash_msg"
-  %table.table.table-bordered.table-striped.table-summary-screen
-    %thead
-      %tr
-        %th{:colspan => "2"}= _('Details')
-    %tbody
-      - {:name        => _("Name"),
-         :description => _("Description"),
-         :draft       => _("Draft"),
-         :read_only   => _("Read Only"),
-         :orderable?  => _("Orderable"),
-         :created_at  => _("Created On"),
-         :updated_at  => _("Updated On")}.each do |sym, label|
-        %tr
-          %td.label
-            = label
-          %td
-            - case sym
-            - when :draft
-              = @record.orchestration_template.draft ? _("True") : _("False")
-            - when :orderable?
-              = @record.orchestration_template.supports?(:order) ? _("True") : _("False")
-            - when :read_only
-              = @record.orchestration_template.in_use? ? _("True") : _("False")
-            - else
-              = @record.orchestration_template.send(sym)
-
+  = stack_orchestration_template_basic_info(@record.orchestration_template)
   - if @record.orchestration_template.content
-    %hr
-    #form_div
-      = text_area_tag("template_content", @record.orchestration_template.content, :style => "display:none;")
-      = render :partial => "/layouts/my_code_mirror",
-        :locals => {:text_area_id => "template_content",
-                    :mode         => "yaml",
-                    :line_numbers => true,
-                    :read_only    => true}
-      :javascript
-        ManageIQ.editor.refresh();
+    = template_content(@record.orchestration_template.content)


### PR DESCRIPTION
Converted the orchestration stack template summary page to react

Before:
<img width="1185" height="461" alt="Screenshot 2026-01-19 at 10 21 57 AM" src="https://github.com/user-attachments/assets/889a36b3-3156-4189-be0d-6d48767e53f6" />


After:
<img width="1177" height="519" alt="Screenshot 2026-01-19 at 10 19 35 AM" src="https://github.com/user-attachments/assets/3350db10-f396-4f29-af14-210d7a2c27c9" />
