### PR TITLE
Set row_data as private method

### DIFF
--- a/app/helpers/pxe_helper.rb
+++ b/app/helpers/pxe_helper.rb
@@ -13,6 +13,8 @@ module PxeHelper
                         })
   end
 
+  private
+
   def row_data(label, value)
     {:cells => {:label => label, :value => value}}
   end


### PR DESCRIPTION
Made the method `row_data` private, which was missed in this  [PR](https://github.com/ManageIQ/manageiq-ui-classic/pull/9785)

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
