### PR TITLE
Fix feature mismatch in NSX-T security policy and rule flows

### DIFF
--- a/app/helpers/application_helper/toolbar/security_policy_center.rb
+++ b/app/helpers/application_helper/toolbar/security_policy_center.rb
@@ -9,7 +9,7 @@ class ApplicationHelper::Toolbar::SecurityPolicyCenter < ApplicationHelper::Tool
         t,
         :items => [
           button(
-            :security_security_new,
+            :security_policy_new,
             'pficon pficon-add-circle-o fa-lg',
             t = N_('Add a new Security Policy Rule'),
             t,

--- a/app/helpers/application_helper/toolbar/security_policy_rule_center.rb
+++ b/app/helpers/application_helper/toolbar/security_policy_rule_center.rb
@@ -9,7 +9,7 @@ class ApplicationHelper::Toolbar::SecurityPolicyRuleCenter < ApplicationHelper::
         t,
         :items => [
           button(
-            :security_security_rule_new,
+            :security_policy_rule_new,
             'pficon pficon-add-circle-o fa-lg',
             t = N_('Add a new Security Policy Rule'),
             t,


### PR DESCRIPTION
Looks like `security_security_new` & `security_security_rule_new` are not available in [miq_product_features](https://github.com/ManageIQ/manageiq/blob/master/db/fixtures/miq_product_features.yml), which is probably the issue

**NSX-T Security policy:**
### Before:
<img width="2548" height="1890" alt="image" src="https://github.com/user-attachments/assets/316e0205-f7e0-4ce4-b9a9-1cf04778e613" />

### After (along with [providers-nsxt-166](https://github.com/ManageIQ/manageiq-providers-nsxt/pull/166)):
<img width="2586" height="1774" alt="image" src="https://github.com/user-attachments/assets/6d2687e3-1cfa-4bce-886b-b592fae6a501" />

**NSX-T Security policy rule:**
### Before:
<img width="2548" height="1878" alt="image" src="https://github.com/user-attachments/assets/411777ea-64a0-4c5c-9756-820969def938" />

### After:
<img width="2542" height="1892" alt="image" src="https://github.com/user-attachments/assets/3416043e-1853-4034-a728-cfb51c8896bb" />

@miq-bot add-label bug
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
