### PR TITLE
Upgrade lodash & lodash-es to 4.17.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,6 +189,7 @@
     "express": "^4.18.2",
     "get-intrinsic": "<=1.3.0",
     "lodash": "~4.17.23",
+    "lodash-es": "~4.17.23",
     "minimatch": "~5.1.6",
     "moment": "^2.30.1",
     "moment-timezone": "~0.5.40",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12889,10 +12889,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash-es@npm:4.17.21":
-  version: 4.17.21
-  resolution: "lodash-es@npm:4.17.21"
-  checksum: 10/03f39878ea1e42b3199bd3f478150ab723f93cc8730ad86fec1f2804f4a07c6e30deaac73cad53a88e9c3db33348bb8ceeb274552390e7a75d7849021c02df43
+"lodash-es@npm:~4.17.23":
+  version: 4.17.23
+  resolution: "lodash-es@npm:4.17.23"
+  checksum: 10/1feae200df22eb0bd93ca86d485e77784b8a9fb1d13e91b66e9baa7a7e5e04be088c12a7e20c2250fc0bd3db1bc0ef0affc7d9e3810b6af2455a3c6bf6dde59e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Related to https://github.com/ManageIQ/manageiq-ui-classic/pull/9792 & https://github.com/ManageIQ/manageiq-ui-classic/pull/9791:
Upgrade `lodash` & `lodash-es` to resolve Prototype Pollution Vulnerability - [see](https://github.com/ManageIQ/manageiq-ui-classic/actions/runs/21235823857/job/61103547028)

@miq-bot add-label dependencies
@miq-bot add-label security
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
