### PR TITLE
Modernize the miqbrowserdetect function

### DIFF
--- a/app/javascript/components/miq-about-modal/helper.js
+++ b/app/javascript/components/miq-about-modal/helper.js
@@ -1,0 +1,135 @@
+const searchString = (data) => {
+  for (let i = 0; i < data.length; i += 1) {
+    const dataString = data[i].string;
+    const dataProp = data[i].prop;
+    const versionSearchString = data[i].versionSearch || data[i].identity;
+
+    if (dataString) {
+      if (dataString.indexOf(data[i].subString) !== -1) {
+        return { identity: data[i].identity, versionSearchString };
+      }
+    } else if (dataProp) {
+      return { identity: data[i].identity, versionSearchString };
+    }
+  }
+  return null;
+};
+
+const searchVersion = (dataString, versionSearchString) => {
+  const index = dataString.indexOf(versionSearchString);
+  if (index === -1) {
+    return null;
+  }
+  return parseFloat(dataString.substring(index + versionSearchString.length + 1));
+};
+
+const dataBrowser = [
+  {
+    string: navigator.userAgent,
+    subString: 'OmniWeb',
+    versionSearch: 'OmniWeb/',
+    identity: 'OmniWeb',
+  },
+  {
+    string: navigator.vendor,
+    subString: 'Apple',
+    identity: 'Safari',
+  },
+  {
+    prop: window.opera,
+    identity: 'Opera',
+  },
+  {
+    string: navigator.vendor,
+    subString: 'iCab',
+    identity: 'iCab',
+  },
+  {
+    string: navigator.vendor,
+    subString: 'KDE',
+    identity: 'Konqueror',
+  },
+  {
+    string: navigator.userAgent,
+    subString: 'Firefox',
+    identity: 'Firefox',
+  },
+  {
+    string: navigator.vendor,
+    subString: 'Camino',
+    identity: 'Camino',
+  },
+  {
+    string: navigator.userAgent,
+    subString: 'Netscape',
+    identity: 'Netscape',
+  },
+  {
+    string: navigator.userAgent,
+    subString: 'MSIE',
+    identity: 'Explorer',
+    versionSearch: 'MSIE',
+  },
+  {
+    string: navigator.userAgent,
+    subString: 'Trident',
+    identity: 'Explorer',
+    versionSearch: 'rv',
+  },
+  {
+    string: navigator.vendor,
+    subString: 'Google Inc.',
+    identity: 'Chrome',
+    versionSearch: 'Chrome',
+  },
+  {
+    string: navigator.userAgent,
+    subString: 'Gecko',
+    identity: 'Mozilla',
+    versionSearch: 'rv',
+  },
+  {
+    string: navigator.userAgent,
+    subString: 'Mozilla',
+    identity: 'Netscape',
+    versionSearch: 'Mozilla',
+  },
+];
+
+const dataOS = [
+  {
+    string: navigator.platform,
+    subString: 'Win',
+    identity: 'Windows',
+  },
+  {
+    string: navigator.platform,
+    subString: 'Mac',
+    identity: 'Mac',
+  },
+  {
+    string: navigator.platform,
+    subString: 'Linux',
+    identity: 'Linux',
+  },
+];
+
+export const detectBrowser = () => {
+  const browserResult = searchString(dataBrowser);
+  const browser = browserResult ? browserResult.identity : __('An unknown browser');
+
+  const version = browserResult
+    ? searchVersion(navigator.userAgent, browserResult.versionSearchString)
+      || searchVersion(navigator.appVersion, browserResult.versionSearchString)
+      || __('An unknown version')
+    : __('An unknown version');
+
+  const osResult = searchString(dataOS);
+  const OS = osResult ? osResult.identity : __('An unknown OS');
+
+  return {
+    browser,
+    version,
+    OS,
+  };
+};

--- a/app/javascript/components/miq-about-modal/miq-about-modal.jsx
+++ b/app/javascript/components/miq-about-modal/miq-about-modal.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { Modal, ModalBody, Button } from 'carbon-components-react';
 import ModalItem from './modal-item';
+import { detectBrowser } from './helper';
 
 const SHOW_ABOUT_MODAL = '@@aboutModal/show';
 const HIDE_ABOUT_MODAL = '@@aboutModal/hide';
@@ -77,7 +78,7 @@ class MiqAboutModal extends React.Component {
       return null;
     }
 
-    const browser = window.miqBrowserDetect();
+    const browser = detectBrowser();
     const plugins = Object.keys(data.server_info.plugins).map((key) => {
       const val = data.server_info.plugins[key];
       return (


### PR DESCRIPTION
Moves code from this file: https://github.com/ManageIQ/manageiq-ui-classic/blob/3f99d1cdcb916fdfe4f71bc4057fd522282be498/app/javascript/oldjs/miq_browser_detect.js to new react code.

This pr modernizes the miqBrowserDetect function and places it in a helper file along with the file that uses it. This will allow us to use this in other future react conversions too without requiring the oldjs file. Once the login page is converted to React we can delete the miq_browser_detect.js file as it is no longer needed.