### PR TITLE
Preserve whitespace with treeview names

### DIFF
--- a/app/stylesheet/ddf_override.scss
+++ b/app/stylesheet/ddf_override.scss
@@ -526,3 +526,11 @@
     margin-right: 5%;
   }
 }
+
+#listnav_div {
+  .list-group {
+    .list-group-item {
+      white-space: pre;
+    }
+  }
+}


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/7012

This pr will preserve the white space in the tree view names.

Before:
The first name is `test  1` with 2 spaces, and the second is `test 1` with 1 space, but they both show up as `test 1` with 1 space.
<img width="299" height="53" alt="Screenshot 2026-01-26 at 1 46 41 PM" src="https://github.com/user-attachments/assets/400e068e-eb05-49f4-8407-16721d2344ea" />

After:
Correctly shows `test  1` with 2 spaces and `test 1` with 1 space using this pr.
<img width="304" height="47" alt="Screenshot 2026-01-26 at 2 09 42 PM" src="https://github.com/user-attachments/assets/d1b7bdbe-962d-4750-ad75-de42499a72f6" />