### PR TITLE
Preserve white space in the miq structured list component

### DIFF
--- a/app/stylesheet/miq-structured-list.scss
+++ b/app/stylesheet/miq-structured-list.scss
@@ -159,7 +159,7 @@
   .wrap_text {
     width: 100%;
     word-break: break-all;
-    white-space: pre-line;
+    white-space: pre-wrap;
   }
 
   &.bordered-list {


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/7596

Allows the miq-structured-list-component to preserve white space in its values.

Before:
The name value has a leading space, which isn't shown.
<img width="857" height="198" alt="Screenshot 2026-01-26 at 3 25 25 PM" src="https://github.com/user-attachments/assets/9d42911a-9118-4369-89e5-7b018fb4e740" />

After:
The name value does have its leading space shown.
<img width="817" height="199" alt="Screenshot 2026-01-26 at 3 23 44 PM" src="https://github.com/user-attachments/assets/5bf98b3a-63de-4774-8f91-30b69aed03d9" />