### PR TITLE
Fixes the dependent field to initialize to Yes

### DIFF
--- a/app/javascript/components/reconfigure-vm-form/disk-form-fields.js
+++ b/app/javascript/components/reconfigure-vm-form/disk-form-fields.js
@@ -92,7 +92,7 @@ const dependentField = (data, roles) => ({
   offText: __('No'),
   hideField: !roles.isVmwareInfra,
   disabled: data.form.action === TYPES.RESIZE,
-  initialValue: data.form.action === TYPES.RESIZE ? getSwitchData(data.editingRow, 'dependent') : '',
+  initialValue: data.form.action === TYPES.RESIZE ? getSwitchData(data.editingRow, 'dependent') : 'Yes',
 });
 
 const bootableField = (data, roles) => ({

--- a/app/javascript/spec/reconfigure-vm-form/__snapshots__/reconfigure-vm-form.spec.js.snap
+++ b/app/javascript/spec/reconfigure-vm-form/__snapshots__/reconfigure-vm-form.spec.js.snap
@@ -17596,7 +17596,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                     "disabled": false,
                     "hideField": false,
                     "id": "dependent",
-                    "initialValue": "",
+                    "initialValue": "Yes",
                     "label": "Dependent",
                     "name": "dependent",
                     "offText": "No",
@@ -17823,7 +17823,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                       "disabled": false,
                       "hideField": false,
                       "id": "dependent",
-                      "initialValue": "",
+                      "initialValue": "Yes",
                       "label": "Dependent",
                       "name": "dependent",
                       "offText": "No",
@@ -18043,7 +18043,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                         "disabled": false,
                         "hideField": false,
                         "id": "dependent",
-                        "initialValue": "",
+                        "initialValue": "Yes",
                         "label": "Dependent",
                         "name": "dependent",
                         "offText": "No",
@@ -18259,7 +18259,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                             "disabled": false,
                             "hideField": false,
                             "id": "dependent",
-                            "initialValue": "",
+                            "initialValue": "Yes",
                             "label": "Dependent",
                             "name": "dependent",
                             "offText": "No",
@@ -18422,7 +18422,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                             "disabled": false,
                             "hideField": false,
                             "id": "dependent",
-                            "initialValue": "",
+                            "initialValue": "Yes",
                             "label": "Dependent",
                             "name": "dependent",
                             "offText": "No",
@@ -18589,7 +18589,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                               "disabled": false,
                               "hideField": false,
                               "id": "dependent",
-                              "initialValue": "",
+                              "initialValue": "Yes",
                               "label": "Dependent",
                               "name": "dependent",
                               "offText": "No",
@@ -18753,7 +18753,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                               "disabled": false,
                               "hideField": false,
                               "id": "dependent",
-                              "initialValue": "",
+                              "initialValue": "Yes",
                               "label": "Dependent",
                               "name": "dependent",
                               "offText": "No",
@@ -18920,7 +18920,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                             "disabled": false,
                             "hideField": false,
                             "id": "dependent",
-                            "initialValue": "",
+                            "initialValue": "Yes",
                             "label": "Dependent",
                             "name": "dependent",
                             "offText": "No",
@@ -19077,7 +19077,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                                 "disabled": false,
                                 "hideField": false,
                                 "id": "dependent",
-                                "initialValue": "",
+                                "initialValue": "Yes",
                                 "label": "Dependent",
                                 "name": "dependent",
                                 "offText": "No",
@@ -19238,7 +19238,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                                   "disabled": false,
                                   "hideField": false,
                                   "id": "dependent",
-                                  "initialValue": "",
+                                  "initialValue": "Yes",
                                   "label": "Dependent",
                                   "name": "dependent",
                                   "offText": "No",
@@ -20823,7 +20823,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                               disabled={false}
                               hideField={false}
                               id="dependent"
-                              initialValue=""
+                              initialValue="Yes"
                               key="dependent"
                               label="Dependent"
                               name="dependent"
@@ -20836,7 +20836,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                                     "component": "switch",
                                     "disabled": false,
                                     "id": "dependent",
-                                    "initialValue": "",
+                                    "initialValue": "Yes",
                                     "label": "Dependent",
                                     "name": "dependent",
                                     "offText": "No",
@@ -20851,7 +20851,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                                     component="switch"
                                     disabled={false}
                                     id="dependent"
-                                    initialValue=""
+                                    initialValue="Yes"
                                     label="Dependent"
                                     name="dependent"
                                     offText="No"
@@ -20869,7 +20869,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                                         onBlur={[Function]}
                                         onChange={[Function]}
                                         onFocus={[Function]}
-                                        toggled={false}
+                                        toggled={true}
                                         type="checkbox"
                                       >
                                         <Toggle
@@ -20885,7 +20885,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                                           onChange={[Function]}
                                           onFocus={[Function]}
                                           onToggle={[Function]}
-                                          toggled={false}
+                                          toggled={true}
                                           type="checkbox"
                                         >
                                           <div
@@ -20893,7 +20893,7 @@ exports[`Reconfigure VM form component should render reconfigure form and show d
                                           >
                                             <input
                                               aria-label={null}
-                                              checked={false}
+                                              checked={true}
                                               className="bx--toggle-input"
                                               disabled={false}
                                               id="dependent"


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/9815

Before:
<img width="1180" height="711" alt="Screenshot 2026-02-02 at 9 53 41 AM" src="https://github.com/user-attachments/assets/da174d00-ce94-4d37-9e30-3f583efd7524" />

After:
<img width="1181" height="720" alt="Screenshot 2026-02-02 at 9 52 43 AM" src="https://github.com/user-attachments/assets/d42d7f64-b850-45fa-9b47-824af58fca71" />

