### PR TITLE
Remove ansible credentials tech debt

### DIFF
--- a/app/javascript/oldjs/directives/ansible_credentials/adjust_on_reset.js
+++ b/app/javascript/oldjs/directives/ansible_credentials/adjust_on_reset.js
@@ -1,9 +1,0 @@
-ManageIQ.angular.app.directive('adjustOnReset', function() {
-  return {
-    link: function(scope, _elem, attr) {
-      scope.$watch('vm.reset', function() {
-        scope.vm.cancelPassword(attr.adjustOnReset);
-      });
-    },
-  };
-});

--- a/app/javascript/oldjs/directives/index.js
+++ b/app/javascript/oldjs/directives/index.js
@@ -1,4 +1,3 @@
-require('./ansible_credentials/adjust_on_reset.js');
 require('./autofocus.js');
 require('./checkchange.js');
 require('./detect_spaces.js');


### PR DESCRIPTION
The ansible credentials form was converted to React in this pr: https://github.com/ManageIQ/manageiq-ui-classic/pull/7324

So this code is no longer needed and can be deleted.