### PR TITLE
Upgrade to cypress 15.10.x, use expose, disallow env

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -9,6 +9,7 @@ module.exports = defineConfig({
     viewportWidth: 1800,
     numTestsKeptInMemory: 5,
     videoCompression: false,
+    allowCypressEnv: false,
 
     // See: https://docs.cypress.io/app/references/experiments#Experimental-Flake-Detection-Features
     retries: {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "core-js": "~3.48.0",
     "core-js-compat": "~3.48.0",
     "css-loader": "~3.6.0",
-    "cypress": "~15.9.0",
+    "cypress": "~15.10.0",
     "duplicate-package-checker-webpack-plugin": "~3.0.0",
     "enhanced-resolve": "~4.5.0",
     "enzyme": "^3.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7162,9 +7162,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:~15.9.0":
-  version: 15.9.0
-  resolution: "cypress@npm:15.9.0"
+"cypress@npm:~15.10.0":
+  version: 15.10.0
+  resolution: "cypress@npm:15.10.0"
   dependencies:
     "@cypress/request": "npm:^3.0.10"
     "@cypress/xvfb": "npm:^1.2.4"
@@ -7194,7 +7194,7 @@ __metadata:
     hasha: "npm:5.2.2"
     is-installed-globally: "npm:~0.4.0"
     listr2: "npm:^3.8.3"
-    lodash: "npm:^4.17.21"
+    lodash: "npm:^4.17.23"
     log-symbols: "npm:^4.0.0"
     minimist: "npm:^1.2.8"
     ospath: "npm:^1.2.2"
@@ -7210,7 +7210,7 @@ __metadata:
     yauzl: "npm:^2.10.0"
   bin:
     cypress: bin/cypress
-  checksum: 10/f561e7f9f8956e26a1eeb1dc98614b83abb63c1f83d008ffd26a03d96c15c25037980868f57e07f9821be4c41ace6886f8edf4de6d86a3b5de5f3c059b586ecd
+  checksum: 10/d32e501737f48580ba28072b680b8ad53fd1da3bcfca101c6c6fffcc8e5692a280bd01b792dffdc4e1e37407883bb1979669ea11bc8f2f49c59c118c72d8acce
   languageName: node
   linkType: hard
 
@@ -13618,7 +13618,7 @@ __metadata:
     core-js-compat: "npm:~3.48.0"
     create-react-context: "npm:~0.3.0"
     css-loader: "npm:~3.6.0"
-    cypress: "npm:~15.9.0"
+    cypress: "npm:~15.10.0"
     d3: "npm:^7.8.2"
     dompurify: "npm:^3.2.4"
     duplicate-package-checker-webpack-plugin: "npm:~3.0.0"


### PR DESCRIPTION
Replaces https://github.com/ManageIQ/manageiq-ui-classic/pull/9835

https://docs.cypress.io/app/references/changelog#15-10-0

The details around expose vs. env can be found here: https://docs.cypress.io/app/references/migration-guide#Via-runtime

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
