### PR TITLE
Log a warning and continue on for invalid dev VMs

### DIFF
--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -68,7 +68,8 @@ class ApplicationHelper::ToolbarChooser
       when ManageIQ::Providers::InfraManager::Template
         'x_miq_template_center_tb'
       else
-        raise 'FIXME: this would return "x_# {@button_group}_center_tb' # FIXME: remove this branch
+        Rails.logger.warn("An unknown object type [#{@record.class.name}] was found when selecting a toolbar. Continuing without a toolbar selection.")
+        nil
       end
     else
       case x_active_tree


### PR DESCRIPTION
If a "hacked" dev VM isn't a normal VM or Template, it will trigger this else condition which raises a strange error to the UI. However, we can continue on and just not show the toolbar instead. This PR does that and logs a warning about the VM state and the missing toolbar.

Before:
<img width="2251" height="575" alt="ManageIQ__Workloads" src="https://github.com/user-attachments/assets/956835d0-a533-4989-9356-416fdf1fbbfb" />

After:
<img width="1338" height="575" alt="ManageIQ__Workloads" src="https://github.com/user-attachments/assets/424a3b1f-d41a-41b6-88f6-e5a37a190891" />
<img width="2534" height="204" alt="ManageIQ__Workloads__Log" src="https://github.com/user-attachments/assets/349b9b09-e23c-4663-8fbf-f627a6e7c9da" />
