### PR TITLE
Trigger a yarn lock update when the source files change

### DIFF
--- a/.github/workflows/yarn_lock.yaml
+++ b/.github/workflows/yarn_lock.yaml
@@ -1,5 +1,11 @@
 name: Update yarn.lock
 on:
+  push:
+    branches:
+    - master
+    paths:
+    - package.json
+    - yarn.lock
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch:


### PR DESCRIPTION
Frequently, we will merge PRs from renovate, dependabot, or developers that need to make specific changes for specific packages. This causes the bot's PR to become unmergeable, and so we have to either manually trigger it, or wait until the next cron.

This commit changes the update_yarn_lock to trigger when a change is merged to either yarn.lock or package.json. As changes to either of these will generally cause a conflict, this will allow the bot to "automatically" correct it's PR.

@jrafanie Please review. cc @ManageIQ/committers-ui .

Note that I never changed this PR to use the shared workflow at https://github.com/ManageIQ/.github/blob/master/.github/workflows/update_yarn_lock.yaml, so I will do that in a follow up PR.  Regardless, the "on" has to live in this repo, so that part can't be shared. Once I confirm this works as expected, I will blast this out to ui-service and the other repos that do yarn lock updates.