### PR TITLE
Remove the provision button from the services/workload page

### DIFF
--- a/app/helpers/application_helper/toolbar/vms_center.rb
+++ b/app/helpers/application_helper/toolbar/vms_center.rb
@@ -108,21 +108,4 @@ class ApplicationHelper::Toolbar::VmsCenter < ApplicationHelper::Toolbar::Basic
       ]
     ),
   ])
-  button_group('vm_lifecycle', [
-    select(
-      :vm_lifecycle_choice,
-      nil,
-      N_('Lifecycle'),
-      :items => [
-        button(
-          :vm_miq_request_new,
-          'pficon pficon-add-circle-o fa-lg',
-          N_('Request to Provision'),
-          N_('Provision'),
-          :url_parms    => "main_div",
-          :send_checked => true,
-          :klass        => ApplicationHelper::Button::ButtonNewDiscover),
-      ]
-    ),
-  ])
 end


### PR DESCRIPTION
We have decided the provision feature shouldn't exist on this page, and this PR removes the lifecycle button and its sub-option of provision.

Before:
<img width="794" height="136" alt="Screenshot 2026-02-18 at 3 49 10 PM" src="https://github.com/user-attachments/assets/3b398f74-0307-4b81-a974-7f3058db3d4d" />

After:
<img width="795" height="142" alt="Screenshot 2026-02-18 at 3 48 39 PM" src="https://github.com/user-attachments/assets/14951a1d-84c2-4fdb-8b64-99743dc5c5dd" />