### PR TITLE
Remove unused angular code

### DIFF
--- a/app/views/ems_infra/_show_dashboard.html.haml
+++ b/app/views/ems_infra/_show_dashboard.html.haml
@@ -15,6 +15,3 @@
     .col-xs-12.col-sm-12.col-md-6
       = react('RecentVmGraph', :providerId => @record.id.to_s, :title => _('Recent VMs and Templates'), :config => 'recentVmsConfig',
        :apiUrl => 'ems_infra_dashboard/recent_vms_data', :dataPoint => 'recentResources')
-
-  :javascript
-    ManageIQ.angular.app.value('providerId', '#{@record.id}');

--- a/app/views/ems_storage/_show_block_storage_dashboard.html.haml
+++ b/app/views/ems_storage/_show_block_storage_dashboard.html.haml
@@ -9,6 +9,3 @@
     .col-xs-12.col-sm-12.col-md-6
       = react('EventChart', :providerId => @record.id.to_s, :apiUrl => 'ems_storage_dashboard/aggregate_event_data',
                 :title => 'Fixed vs Not-Fixed Events By Storage-System')
-
-  :javascript
-    ManageIQ.angular.app.value('providerId', '#{@record.id}');

--- a/app/views/ems_storage/_show_object_storage_dashboard.html.haml
+++ b/app/views/ems_storage/_show_object_storage_dashboard.html.haml
@@ -2,6 +2,3 @@
 .container-fluid.container-tiles-pf.ems-storage-dashboard
   .row.row-tile-pf
     = react 'AggregateStatusCard', {:providerId => @record.id.to_s, :providerType => 'ems_storage'}
-
-  :javascript
-    ManageIQ.angular.app.value('providerId', '#{@record.id}');


### PR DESCRIPTION
The ems_infra dashboard was converted to React in this PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/7658 and the ems_storage dashboards were converted to React in this PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/8073.

Since these are now using React they no longer need the angular code and this can be deleted.