### PR TITLE
Delete angular-ui-codemirror

### DIFF
--- a/app/javascript/oldjs/miq_angular_application.js
+++ b/app/javascript/oldjs/miq_angular_application.js
@@ -19,7 +19,6 @@ ManageIQ.angular.app = angular.module('ManageIQ', [
   'patternfly.charts',
   'patternfly.views',
   'ui.bootstrap',
-  'ui.codemirror',
 ]);
 miqHttpInject(ManageIQ.angular.app);
 

--- a/app/javascript/packs/globals.js
+++ b/app/javascript/packs/globals.js
@@ -39,7 +39,6 @@ require('angular-ui-bootstrap');
 require('angular-gettext');
 require('angular-sanitize');
 require('angular.validators');
-require('ng-annotate-loader!angular-ui-codemirror');
 require('angular-dragdrop'); // ngDragDrop, used by ui-components
 require('angular-ui-sortable'); // ui.sortable, used by ui-components
 require('angular-patternfly');

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "angular-patternfly": "~3.26.0",
     "angular-sanitize": "~1.8.3",
     "angular-ui-bootstrap": "~2.5.6",
-    "angular-ui-codemirror": "~0.3.0",
     "angular-ui-sortable": "~0.19.0",
     "angular.validators": "~4.4.3",
     "array-includes": "^3.1.9",

--- a/spec/javascripts/globals_pack_spec.js
+++ b/spec/javascripts/globals_pack_spec.js
@@ -41,10 +41,6 @@ describe('packs/global.js', function() {
     it('loads angular-ui-bootstrap', function() {
       expect(angular.module('ui.bootstrap')).toBeDefined();
     });
-
-    it('loads codemirror', function() {
-      expect(angular.module('ui.codemirror')).toBeDefined();
-    });
   });
 
   context('codemirror', function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4605,13 +4605,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"angular-ui-codemirror@npm:~0.3.0":
-  version: 0.3.0
-  resolution: "angular-ui-codemirror@npm:0.3.0"
-  checksum: 10/ba33a81fae6879c40c706dc0f0b2c3fe263f68cd88c62963fc0bffa9c2eb6941749c62ba4716550b80245985ebb27e06a38d82ed244ccfa297eb6235c43120df
-  languageName: node
-  linkType: hard
-
 "angular-ui-sortable@npm:^0.16.1":
   version: 0.16.1
   resolution: "angular-ui-sortable@npm:0.16.1"
@@ -13642,7 +13635,6 @@ __metadata:
     angular-patternfly: "npm:~3.26.0"
     angular-sanitize: "npm:~1.8.3"
     angular-ui-bootstrap: "npm:~2.5.6"
-    angular-ui-codemirror: "npm:~0.3.0"
     angular-ui-sortable: "npm:~0.19.0"
     angular.validators: "npm:~4.4.3"
     array-includes: "npm:^3.1.9"


### PR DESCRIPTION
Deleting angular-ui-codemirror as it is no longer used. The only forms that still use the non-React codemirror are the method form and advanced settings form. Both of these use the JS (non-Angular) codemirror and still function as expected after this pr.