### PR TITLE
Use a shared helper to ensure we open & wait on the enabled accordion

### DIFF
--- a/cypress/e2e/ui/Overview/reports.cy.js
+++ b/cypress/e2e/ui/Overview/reports.cy.js
@@ -27,7 +27,8 @@ describe('Overview > Reports Tests', () => {
     });
 
     it('Can add, edit and delete a report', () => {
-      cy.get('#control_reports_accord > .panel-title > .collapsed').click(); // Navigate to reports section of explorer page
+      // Open the reports accordion and wait for it to load
+      cy.accordion('Reports');
 
       // Click add report
       cy.toolbar('Configuration', 'Add a new Report');
@@ -243,7 +244,8 @@ describe('Overview > Reports Tests', () => {
   });
 
   it('Can add, edit and delete a schedule', () => {
-    cy.get('#control_schedules_accord > .panel-title > .collapsed').click({ force: true });
+    // Open the schedules accordion and wait for it to load
+    cy.accordion('Schedules');
 
     // Click add schedule
     cy.toolbar('Configuration', 'Add a new Schedule');


### PR DESCRIPTION
The hope is to resolve the sporadic failure below where the item is still disabled:

```
1) Overview > Reports Tests
       Can add, edit and delete a schedule:
     CypressError: Timed out retrying after 4050ms: `cy.click()` failed because this element:

          `<li class="list-group-item node-treeview-schedules_tree" data-nodeid="0.0.0">...</li>`

          has CSS `pointer-events: none`, inherited from this element:

`<div class="sidebar-pf sidebar-pf-left scrollable max-height col-sm-4 col-md-3 col-sm-pull-8 col-md-pull-9 sidebar-disabled" id="left_div" style="min-height: 0px;">...</div>`

          `pointer-events: none` prevents user mouse interaction.
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
