### PR TITLE
Return more appropriate response codes for certain errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -211,9 +211,13 @@ class ApplicationController < ActionController::Base
         case error
         when ::MiqException::RbacPrivilegeException
           redirect_to(:controller => 'dashboard', :action => "auth_error")
+        when ActionController::BadRequest
+          @layout = "exception"
+          response.status = :bad_request # 400
+          render(:template => "layouts/exception", :locals => {:message => msg})
         else
           @layout = "exception"
-          response.status = 500
+          response.status = :internal_server_error # 500
           render(:template => "layouts/exception", :locals => {:message => msg})
         end
       end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -507,6 +507,7 @@ class DashboardController < ApplicationController
 
   # Put out error msg if user's role is not authorized for an action
   def auth_error
+    response.status = :forbidden # 403
     add_flash(_("The user is not authorized for this task or item."), :error)
     add_flash(_("Press your browser's Back button or click a tab to continue"))
   end

--- a/app/controllers/mixins/checked_id_mixin.rb
+++ b/app/controllers/mixins/checked_id_mixin.rb
@@ -69,10 +69,10 @@ module Mixins
     #   either sets flash or raises exception
     #
     def find_records_with_rbac(klass, ids, options = {})
-      raise(ActiveRecord::RecordNotFound, _("Can't access records without an id")) if ids.include?(nil) || ids.empty?
+      raise(ActionController::BadRequest, _("Can't access records without an id")) if ids.include?(nil) || ids.empty?
 
       filtered = Rbac.filtered(klass.where(:id => ids), :named_scope => options[:named_scope])
-      raise(ActiveRecord::RecordNotFound, _("Can't access selected records")) unless ids.length == filtered.length
+      raise(::MiqException::RbacPrivilegeException, _("Can't access selected records")) unless ids.length == filtered.length
 
       filtered
     end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -54,15 +54,19 @@ describe ApplicationController do
       login_as FactoryBot.create(:user, :miq_groups => [group])
     end
 
-    it "Verify Invalid input flash error message when invalid id is passed in" do
-      expect { controller.send(:find_record_with_rbac, ExtManagementSystem, "invalid") }.to raise_error(ActiveRecord::RecordNotFound, "Can't access selected records")
+    it "considers it an bad request when no id is passed in" do
+      expect { controller.send(:find_record_with_rbac, ExtManagementSystem, nil) }.to raise_error(ActionController::BadRequest, "Can't access records without an id")
     end
 
-    it "Verify flash error message when passed in id no longer exists in database" do
-      expect { controller.send(:find_record_with_rbac, ExtManagementSystem, "1") }.to raise_error(ActiveRecord::RecordNotFound, match(/Can't access selected records/))
+    it "considers it an auth error when invalid id is passed in" do
+      expect { controller.send(:find_record_with_rbac, ExtManagementSystem, "invalid") }.to raise_error(MiqException::RbacPrivilegeException, "Can't access selected records")
     end
 
-    it "Verify record gets set when valid id is passed in" do
+    it "considers it an auth error when id no longer exists in database or is RBAC filtered out" do
+      expect { controller.send(:find_record_with_rbac, ExtManagementSystem, "1") }.to raise_error(MiqException::RbacPrivilegeException, "Can't access selected records")
+    end
+
+    it "verify record gets set when valid id is passed in" do
       ems = FactoryBot.create(:ext_management_system)
       expect(controller.send(:find_record_with_rbac, ExtManagementSystem, ems.id)).to eq(ems)
     end

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -103,7 +103,7 @@ describe OpsController do
         end
 
         it "raises error when access is not granted" do
-          expect { controller.send(:rbac_tenant_get_details, other_tenant.id) }.to raise_error(ActiveRecord::RecordNotFound, "Can't access selected records")
+          expect { controller.send(:rbac_tenant_get_details, other_tenant.id) }.to raise_error(MiqException::RbacPrivilegeException, "Can't access selected records")
         end
       end
     end

--- a/spec/routes_spec.rb
+++ b/spec/routes_spec.rb
@@ -61,12 +61,18 @@ describe 'Application routes' do
               allow(subject).to receive(:current_user)
               allow(subject).to receive(:params).and_return({})
               allow(subject).to receive(:request).and_return(request)
+              allow(subject).to receive(:response).and_return(response)
               allow(request).to receive(:xml_http_request?).and_return(false)
             end
 
             let(:check_service) { double(PrivilegeCheckerService) }
 
-            let(:request) { double }
+            let(:request) { double(ActionDispatch::Request) }
+            let(:response) do
+              double(ActionDispatch::Response).tap do |response|
+                allow(response).to receive(:status=)
+              end
+            end
 
             it 'is enforced' do
               # Check if the test is not marked as a false positive


### PR DESCRIPTION
Accessing certain endpoints, such as dashboard/widget_chart_data, without the expected parameters would yield a 500 error, but render the exception page. This commit changes those path to either raise a Bad Request error (400) when the param is not provided, or a Forbidden error (403) when the param either doesn't exist or is not accessible due to RBAC. These are more appropriate response codes that security scanning tools would expect.

CP4AIOPS-444

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
