### PR TITLE
Menu loading of settings must wait on async GET

### DIFF
--- a/cypress/e2e/ui/settings.cy.js
+++ b/cypress/e2e/ui/settings.cy.js
@@ -1,13 +1,17 @@
 /* eslint-disable no-undef */
 describe('Settings > My Settings', () => {
-  beforeEach(() => {
-    cy.login();
+  const interceptUserSettingsLoad = (alias = 'userSettingsLoad') => {
     cy.interceptApi({
       method: 'GET',
-      alias: 'userSettingsLoad',
+      alias,
       urlPattern: '/api/users/*',
       triggerFn: () => cy.menu('Settings', 'My Settings'),
     });
+  };
+
+  beforeEach(() => {
+    cy.login();
+    interceptUserSettingsLoad();
   });
 
   it('Saves the start page setting', () => {
@@ -30,12 +34,7 @@ describe('Settings > My Settings', () => {
     cy.login();
     cy.url().should('include', '/dashboard');
 
-    cy.interceptApi({
-      method: 'GET',
-      alias: 'userSettingsReload',
-      urlPattern: '/api/users/*',
-      triggerFn: () => cy.menu('Settings', 'My Settings'),
-    });
+    interceptUserSettingsLoad('userSettingsReload');
     cy.getFormInputFieldByIdAndType({ inputId: 'display.startpage' }).should(
       'have.value',
       'Overview / Dashboard'


### PR DESCRIPTION
After switching the menu to MySettings, we now explicitly wait for the GET that loads the user settings before we check field values.

Hopefully, this fixes the following sporadic timing error:

```
Settings > My Settings
    ✖(Attempt 1 of 4) Saves the start page setting
    ✖(Attempt 2 of 4) Saves the start page setting
    ✖(Attempt 3 of 4) Saves the start page setting
    ✖(Attempt 4 of 4) Saves the start page setting
    ✖ Saves the start page setting (2218ms)

  0 passing (16s)
  1 failing

  1) Settings > My Settings
       Saves the start page setting:

      AssertionError: expected 'Overview / Dashboard' to be one of [ '', 'Overview / Utilization' ]
      + expected - actual

      -'Overview / Dashboard'
      +[ '', 'Overview / Utilization' ]

```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
