### PR TITLE
Add intercept & wait for async widget page updates

### DIFF
--- a/cypress/e2e/ui/Overview/dashboard.cy.js
+++ b/cypress/e2e/ui/Overview/dashboard.cy.js
@@ -108,15 +108,23 @@ describe('Overview > Dashboard Tests', () => {
   it('Zoom a widget', () => {
     cy.get('.card-pf').then((cards) => {
       cy.get(cards[0]).then((card) => {
-        cy.get(card.children()[0].children[0].children[0]).click().then(() => {
-          cy.get('.cds--overflow-menu-options').then((menuItems) => {
-            cy.get(menuItems.children()[4]).click();
-          });
+        const widgetId = cards[0].children[1].id.split('_')[1].replace('w', '');
+        cy.interceptApi({
+          alias: 'zoomChartData',
+          method: 'GET',
+          urlPattern: `/dashboard/widget_chart_data/${widgetId}`,
+          triggerFn: () => {
+            cy.get(card.children()[0].children[0].children[0]).click().then(() => {
+              cy.get('.cds--overflow-menu-options').then((menuItems) => {
+                cy.get(menuItems.children()[4]).click();
+              });
+            });
+          }
         });
       });
     });
     cy.get('#lightbox-panel').should('have.css', 'display', 'block');
-    cy.get('#zoomed_chart_div', { timeout: 10000 }).should('contain', defaultCards[0]);
+    cy.get('#zoomed_chart_div').should('contain', defaultCards[0]);
   });
 
   it('Refresh a widget', () => {


### PR DESCRIPTION
1. "Add and remove a widget" 
Added 3 intercepts at start: widget_add, dashboardReload, widget_close
The first two are fired from the add button and the latter is fired later
Moved waits outside .then() callbacks

2. "Zoom a widget" 
Moved assertions outside nested callbacks
Used .should() with automatic retry

3. "Reset dashboard back to default widgets"
Added intercepts for widget additions
Used interceptApi for the reset button click - clean single API call
Waits moved outside callbacks

Hopefully fixes the following sporadic failures:

```
  Overview > Dashboard Tests
    ✓ Dashboard loads correctly (7985ms)
    ✓ Default dashboard widgets loaded (1824ms)
    ✖(Attempt 1 of 4) Add and remove a widget
    ✖(Attempt 2 of 4) Add and remove a widget
    ✖(Attempt 3 of 4) Add and remove a widget
    ✖(Attempt 4 of 4) Add and remove a widget
    ✖ Add and remove a widget (7208ms)
    ✓ Minimize a widget (1992ms)
    ✖(Attempt 1 of 4) Zoom a widget
    ✖(Attempt 2 of 4) Zoom a widget
    ✖(Attempt 3 of 4) Zoom a widget
    ✖(Attempt 4 of 4) Zoom a widget
    ✖ Zoom a widget (6540ms)
    ✓ Refresh a widget (1973ms)
    ✖(Attempt 1 of 4) Reset dashboard back to default widgets
    ✖(Attempt 2 of 4) Reset dashboard back to default widgets
    ✖(Attempt 3 of 4) Reset dashboard back to default widgets
    ✖(Attempt 4 of 4) Reset dashboard back to default widgets
    ✖ Reset dashboard back to default widgets (9544ms)

  4 passing (2m)
  3 failing

  1) Overview > Dashboard Tests
       Add and remove a widget:

      Timed out retrying after 4000ms
      + expected - actual

      -9
      +6

      at Context.eval (webpack://manageiq-ui-classic/./cypress/e2e/ui/Overview/dashboard.cy.js:37:39)
      at getRet (http://localhost:3000/__cypress/runner/cypress_runner.js:122690:20)
      at tryCatcher (http://localhost:3000/__cypress/runner/cypress_runner.js:1777:23)
      at Promise.attempt.Promise.try (http://localhost:3000/__cypress/runner/cypress_runner.js:4285:29)
      at Context.thenFn (http://localhost:3000/__cypress/runner/cypress_runner.js:122701:66)
      at Context.then (http://localhost:3000/__cypress/runner/cypress_runner.js:122952:21)
      at wrapped (http://localhost:3000/__cypress/runner/cypress_runner.js:146050:19)

  2) Overview > Dashboard Tests
       Zoom a widget:
     AssertionError: Timed out retrying after 4000ms: Expected to find content: 'Vendor and Guest OS Chart' within the element: <div#zoomed_chart_div> but never did.
      at Context.eval (webpack://manageiq-ui-classic/./cypress/e2e/ui/Overview/dashboard.cy.js:106:42)
      at getRet (http://localhost:3000/__cypress/runner/cypress_runner.js:122690:20)
      at tryCatcher (http://localhost:3000/__cypress/runner/cypress_runner.js:1777:23)
      at Promise.attempt.Promise.try (http://localhost:3000/__cypress/runner/cypress_runner.js:4285:29)
      at Context.thenFn (http://localhost:3000/__cypress/runner/cypress_runner.js:122701:66)
      at Context.then (http://localhost:3000/__cypress/runner/cypress_runner.js:122952:21)
      at wrapped (http://localhost:3000/__cypress/runner/cypress_runner.js:146050:19)

  3) Overview > Dashboard Tests
       Reset dashboard back to default widgets:

      Timed out retrying after 4000ms
      + expected - actual

      -17
      +7

      at Context.eval (webpack://manageiq-ui-classic/./cypress/e2e/ui/Overview/dashboard.cy.js:149:37)
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
