### PR TITLE
Remove nwsapi resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,7 +191,6 @@
     "minimatch": "~10.2.1",
     "moment": "~2.30.1",
     "moment-timezone": "~0.6.0",
-    "nwsapi": "^2.2.1",
     "path-to-regexp": "~8.3.0",
     "patternfly": "~3.59.5",
     "request": "npm:@cypress/request@^3.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14675,7 +14675,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nwsapi@npm:^2.2.1":
+"nwsapi@npm:^2.0.7, nwsapi@npm:^2.2.0":
   version: 2.2.23
   resolution: "nwsapi@npm:2.2.23"
   checksum: 10/aa4a570039c33d70b51436d1bb533f3e2c33c488ccbe9b09285c46a6cee5ef266fd60103461085c6954ba52460786a8138f042958328c7c1b4763898eb3dadfa


### PR DESCRIPTION
Removing the resolution for nwsapi as it is not needed. Even without the resolution our package version remains unchanged at 2.2.23 as the only version so we can delete this resolution.