### PR TITLE
Use Provider specific Service Templates if available

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -991,7 +991,7 @@ class CatalogController < ApplicationController
     elsif prov_type.starts_with?('generic')
       prov_type.gsub(/(generic)(_.*)?/, 'service_template\2').classify.constantize
     else
-      ServiceTemplate
+      "ServiceTemplate#{prov_type.camelize}".safe_constantize || ServiceTemplate
     end
   end
 
@@ -1093,7 +1093,7 @@ class CatalogController < ApplicationController
            end
       common_st_record_vars(st)
       add_orchestration_template_vars(st)  if st.kind_of?(ServiceTemplateOrchestration)
-      add_configuration_script_vars(st)    if st.kind_of?(ServiceTemplateAutomation)
+      add_configuration_script_vars(st)    if st.kind_of?(ServiceTemplateAutomation) && !need_prov_dialogs?(@edit[:new][:st_prov_type])
       add_server_profile_template_vars(st) if @edit[:new][:st_prov_type] == 'cisco_intersight'
       st.service_type = "atomic"
 
@@ -1303,7 +1303,7 @@ class CatalogController < ApplicationController
     @available_catalogs = available_catalogs.sort # Get available catalogs with tenants and ancestors
     @additional_tenants = @edit[:new][:tenant_ids].map(&:to_s) # Get ids of selected Additional Tenants in the Tenants tree
     available_orchestration_templates if @record.kind_of?(ServiceTemplateOrchestration)
-    available_automation_managers     if @record.kind_of?(ServiceTemplateAutomation)
+    available_automation_managers     if @record.kind_of?(ServiceTemplateAutomation) && !need_prov_dialogs?(@record.prov_type)
     available_container_managers      if @record.kind_of?(ServiceTemplateContainerTemplate)
     fetch_zones
     @edit[:new][:zone_id] = @record.zone_id

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1197,20 +1197,33 @@ describe CatalogController do
     end
 
     context "with a ServiceTemplateAnsibleTower" do
-      let!(:ems_ansible_tower)     { FactoryBot.create(:provider_ansible_tower).automation_manager }
-      let(:record)                 { FactoryBot.create(:service_template_ansible_tower) }
+      let!(:ems_ansible_tower) { FactoryBot.create(:provider_ansible_tower).automation_manager }
+      let(:record) { FactoryBot.create(:service_template_ansible_tower, :prov_type => prov_type) }
 
-      it "sets available_managers" do
-        controller.send(:set_form_vars)
-        expect(controller.instance_variable_get(:@edit)[:new][:available_managers]).to eq([[ems_ansible_tower.name, ems_ansible_tower.id]])
-      end
+      context "with a generic_ provision type" do
+        let(:prov_type) { "generic_ansible_tower" }
 
-      context "with other automation managers" do
-        let!(:embedded_ansible) { FactoryBot.create(:provider_embedded_ansible).automation_manager }
-
-        it "doesn't include other automation managers" do
+        it "sets available_managers" do
           controller.send(:set_form_vars)
           expect(controller.instance_variable_get(:@edit)[:new][:available_managers]).to eq([[ems_ansible_tower.name, ems_ansible_tower.id]])
+        end
+
+        context "with other automation managers" do
+          let!(:embedded_ansible) { FactoryBot.create(:provider_embedded_ansible).automation_manager }
+
+          it "doesn't include other automation managers" do
+            controller.send(:set_form_vars)
+            expect(controller.instance_variable_get(:@edit)[:new][:available_managers]).to eq([[ems_ansible_tower.name, ems_ansible_tower.id]])
+          end
+        end
+      end
+
+      context "with a non-generic provision type" do
+        let(:prov_type) { "ansible_tower" }
+
+        it "doesn't set available_managers" do
+          controller.send(:set_form_vars)
+          expect(controller.instance_variable_get(:@edit)[:new].keys).not_to include(:available_managers)
         end
       end
     end


### PR DESCRIPTION
If a provider has a specific service template type use that before falling back on the generic `::ServiceTemplate`

This allows for some of the specific features like seeing Plays and Stdout from AWX/AnsiblePlaybook services in the UI

Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/23741
- [x] https://github.com/ManageIQ/manageiq/pull/23773
- [x] https://github.com/ManageIQ/manageiq-providers-embedded_terraform/pull/120

Awx Service provisioned with workflows provision.asl:
<img width="1111" height="926" alt="image" src="https://github.com/user-attachments/assets/c49d9c5f-ad69-4d4c-82db-4ca1e5afcf34" />

Embedded Terraform Service provisioned with workflows:
<img width="1111" height="926" alt="image" src="https://github.com/user-attachments/assets/32a7e020-a70e-4dea-80e3-b26d4ffa1875" />

Embedded Ansible Service provisioned with workflows:
<img width="1111" height="926" alt="image" src="https://github.com/user-attachments/assets/bcbe6beb-b8ef-4da7-a849-63340c3ae1d9" />

https://github.com/ManageIQ/manageiq/issues/23775
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
