### PR TITLE
Remove ansi regex resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,6 @@
     "angular": "~1.8.3",
     "angular-animate": "~1.8.3",
     "angular-sanitize": "~1.8.3",
-    "ansi-regex": "~5.0.1",
     "bootstrap-select": "~1.13.18",
     "cheerio": "1.0.0-rc.12",
     "decode-uri-component": "^0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4633,7 +4633,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-regex@npm:~5.0.1":
+"ansi-regex@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "ansi-regex@npm:2.1.1"
+  checksum: 10/190abd03e4ff86794f338a31795d262c1dfe8c91f7e01d04f13f646f1dcb16c5800818f886047876f1272f065570ab86b24b99089f8b68a0e11ff19aed4ca8f1
+  languageName: node
+  linkType: hard
+
+"ansi-regex@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "ansi-regex@npm:3.0.1"
+  checksum: 10/09daf180c5f59af9850c7ac1bd7fda85ba596cc8cbeb210826e90755f06c818af86d9fa1e6e8322fab2c3b9e9b03f56c537b42241139f824dd75066a1e7257cc
+  languageName: node
+  linkType: hard
+
+"ansi-regex@npm:^4.0.0, ansi-regex@npm:^4.1.0":
+  version: 4.1.1
+  resolution: "ansi-regex@npm:4.1.1"
+  checksum: 10/b1a6ee44cb6ecdabaa770b2ed500542714d4395d71c7e5c25baa631f680fb2ad322eb9ba697548d498a6fd366949fc8b5bfcf48d49a32803611f648005b01888
+  languageName: node
+  linkType: hard
+
+"ansi-regex@npm:^5.0.0, ansi-regex@npm:^5.0.1":
   version: 5.0.1
   resolution: "ansi-regex@npm:5.0.1"
   checksum: 10/2aa4bb54caf2d622f1afdad09441695af2a83aa3fe8b8afa581d205e57ed4261c183c4d3877cee25794443fde5876417d859c108078ab788d6af7e4fe52eb66b


### PR DESCRIPTION
This pr removes the resolution for ansi-regex. This pulls in older versions of ansi-regex but no open vulnerabilities exist in these versions.