### PR TITLE
Remove @babel/traverse resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,6 @@
     "angular-animate": "~1.8.3",
     "angular-sanitize": "~1.8.3",
     "ansi-regex": "~5.0.1",
-    "@babel/traverse": "~7.29.0",
     "bootstrap-select": "~1.13.18",
     "cheerio": "1.0.0-rc.12",
     "cross-spawn": "~7.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1383,7 +1383,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:~7.29.0":
+"@babel/traverse@npm:^7.1.0, @babel/traverse@npm:^7.27.1, @babel/traverse@npm:^7.28.5, @babel/traverse@npm:^7.28.6, @babel/traverse@npm:^7.29.0, @babel/traverse@npm:^7.4.3":
   version: 7.29.0
   resolution: "@babel/traverse@npm:7.29.0"
   dependencies:


### PR DESCRIPTION
This PR removes the @babel/traverse resolution as it is not needed. Removing the resolution does not change the current version we are using of this package.