### PR TITLE
Remove decode-uri-component resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,7 +181,6 @@
     "ansi-regex": "~5.0.1",
     "bootstrap-select": "~1.13.18",
     "cheerio": "1.0.0-rc.12",
-    "decode-uri-component": "^0.4.0",
     "get-intrinsic": "<=1.3.0",
     "lodash": "~4.17.23",
     "lodash-es": "~4.17.23",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7845,10 +7845,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decode-uri-component@npm:^0.4.0":
-  version: 0.4.1
-  resolution: "decode-uri-component@npm:0.4.1"
-  checksum: 10/74eec26f7bec3767164e37d526ef19bc1214cb0bbeeeea1c4f0ceb79299e5c38d3ba734e7243d829842aa140f24e5d020f54cc25b17c7082461c8eead8a72ce3
+"decode-uri-component@npm:^0.2.0":
+  version: 0.2.2
+  resolution: "decode-uri-component@npm:0.2.2"
+  checksum: 10/17a0e5fa400bf9ea84432226e252aa7b5e72793e16bf80b907c99b46a799aeacc139ec20ea57121e50c7bd875a1a4365928f884e92abf02e21a5a13790a0f33e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Remove the decode-uri-component. This PR removes this resolution but causes a downgrade in our version from ^0.4.0 to ^0.2.0.