### PR TITLE
Unset fixed width from notification item focus-wrapper div

### DIFF
--- a/app/stylesheet/notifications.scss
+++ b/app/stylesheet/notifications.scss
@@ -141,11 +141,6 @@
         .cds--btn--ghost:active {
           background-color: #e5e5e5;
         }
-       // Target the wrapper div (added in Carbon 1.100.0) that contains __details
-       // This div has no class but is a direct child that wraps the notification content
-        > div:has(> .cds--actionable-notification__details) {
-          width: 100%;
-        }
 
         .cds--actionable-notification__details {
           display: flex;


### PR DESCRIPTION
The wrapper `<div>` for `notification__details` was added solely for the `innerModal` ref in `v1.100.0` but it disrupted the notification component’s alignment:
<img width="3210" height="1650" alt="image" src="https://github.com/user-attachments/assets/106b5b7d-f738-4444-bf4c-8a4490730ec6" />

We had forced it to occupy full width to fix this, but now with latest versions(Fixed in https://github.com/carbon-design-system/carbon/pull/21451), it uses the class `cds--actionable-notification__focus-wrapper` with `display: contents`, which ensures it doesn’t interfere with the layout:
<img width="3456" height="1528" alt="image" src="https://github.com/user-attachments/assets/6a64bcaa-b998-48f9-aa0f-c5b9f47c825b" />

@miq-bot add-label cleanup
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
