### PR TITLE
Fix the react forms for catalog items

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -233,6 +233,7 @@ class CatalogController < ApplicationController
 
     # need to check req_id in session since we are using common code for prov requests and atomic ST screens
     id = session[:edit][:req_id] || "new"
+    @checked_id ||= 'new'
     return unless load_edit("prov_edit__#{id}", "replace_cell__explorer")
     get_form_vars
     build_automate_tree(:automate_catalog) if automate_tree_needed?

--- a/app/views/catalog/_st_angular_form.html.haml
+++ b/app/views/catalog/_st_angular_form.html.haml
@@ -1,4 +1,2 @@
 - role_allows = role_allows?(:feature => 'rbac_tenant_view') ? true : false
-- if @checked_id.nil?
-  - @checked_id = 'new'
 = react('AnsiblePlayBookEditCatalogForm', {:initialData => {:catalogFormId => @checked_id, :allCatalogs => @available_catalogs, :zones => @zones, :currentRegion => @current_region, :tenantTree => @tenants_tree, :roleAllows => role_allows}})

--- a/app/views/catalog/_tt_react_form.html.haml
+++ b/app/views/catalog/_tt_react_form.html.haml
@@ -1,4 +1,2 @@
 - role_allows = role_allows?(:feature => 'rbac_tenant_view') ? true : false
-- if @checked_id.nil?
-  - @checked_id = 'new'
 = react('TerraformTemplateCatalogForm', {:initialData => {:catalogFormId => @checked_id, :allCatalogs => @available_catalogs, :zones => @zones, :currentRegion => @current_region, :tenantTree => @tenants_tree, :roleAllows => role_allows}})


### PR DESCRIPTION
Fixes an issue where the React catalog item forms (Ansible playbook and Terraform) were breaking due to not receiving the correct ID value. This was broken due to this pr: #9865.

Before:
When you select an Ansible playbook or Terraform template item from the catalog table checkbox and select Configuration / Edit Item, it hits an error.
<img width="945" height="331" alt="Screenshot 2026-03-12 at 10 24 34 AM" src="https://github.com/user-attachments/assets/63474b93-c426-43e7-8002-34bc8f88ccba" />

After:
<img width="1127" height="450" alt="Screenshot 2026-03-12 at 10 26 07 AM" src="https://github.com/user-attachments/assets/a9a97aa8-f43c-49da-8044-5a4a2cf2f01a" />