### PR TITLE
Update Cypress README with CYPRESS env variable info

### DIFF
--- a/cypress/README.md
+++ b/cypress/README.md
@@ -2,9 +2,19 @@
 
 #### Run
 
-Please note that the rails server has to be running first:
+**Prerequisites:**
 
-    bin/rails s
+Before running Cypress tests, ensure the following:
+
+1. **Build webpack with CYPRESS flag** - This disables debug notifications that would block Cypress from accessing UI elements:
+
+       CYPRESS=true bin/webpack
+
+   If you skip this step, Cypress will show an error and refuse to start.
+
+2. **Start the Rails server**:
+
+       bin/rails s
 
 
 Run without interaction:


### PR DESCRIPTION
Follow-up to https://github.com/ManageIQ/manageiq-ui-classic/pull/9896
 
PR to add documentation for `CYPRESS` environment variable prerequisite to Cypress README
### Before:
<img width="2774" height="1460" alt="image" src="https://github.com/user-attachments/assets/c1f9a479-bbb5-41a3-bd38-86c18cc0cd35" />

### After:
<img width="2726" height="1462" alt="image" src="https://github.com/user-attachments/assets/4022acac-2dcb-4c8b-91e1-7a0140f055fb" />

@miq-bot add-reviewer @jrafanie 
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
