### PR TITLE
Remove owner_load_ldap from dialogs

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -64,13 +64,6 @@ module ApplicationController::MiqRequestMethods
           page << "ManageIQ.calendar.calDateFrom = new Date(#{@timezone_offset});"
           page << "miqBuildCalendar();"
         end
-        if @edit.fetch_path(:new, :owner_email).blank?
-          page << javascript_hide("lookup_button_on")
-          page << javascript_show("lookup_button_off")
-        else
-          page << javascript_hide("lookup_button_off")
-          page << javascript_show("lookup_button_on")
-        end
         if changed != session[:changed]
           session[:changed] = changed
           page << javascript_for_miq_button_visibility(changed)

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -300,28 +300,6 @@ class MiqRequestController < ApplicationController
     end
   end
 
-  WORKFLOW_METHOD_WHITELIST = {'retrieve_ldap' => :retrieve_ldap}.freeze
-
-  def retrieve_email
-    assert_privileges("miq_request_edit")
-    @edit = session[:edit]
-    begin
-      method = WORKFLOW_METHOD_WHITELIST[params[:field]]
-      @edit[:wf].send(method, @edit[:new]) unless method.nil?
-    rescue StandardError => bang
-      add_flash(_("Error retrieving LDAP info: %{error_message}") % {:error_message => bang.message}, :error)
-      javascript_flash
-    else
-      render :update do |page|
-        page << javascript_prologue
-        page.replace_html(:requester, :partial => "shared/views/prov_dialog",
-                                      :locals  => {:wf => @edit[:wf], :dialog => :requester})
-        page.replace("flash_msg_div", :partial => "layouts/flash_msg")
-        page << "miqScrollTop();" if @flash_array.present?
-      end
-    end
-  end
-
   def post_install_callback
     MiqRequestTask.post_install_callback(params["task_id"]) if params["task_id"]
     head :ok

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -124,21 +124,6 @@
           - unless field_hash[:notes_display] == :hide || field_hash[:notes].blank?
             -# Display notes if available
             = field_hash[:notes]
-        .col-md-2
-          - if field == :owner_email
-            - fh = wf.get_field(:owner_load_ldap, dialog)
-            - if @edit && field_hash[:display] == :edit && fh[:display] == :show && !@edit[:stamp_typ]
-              #lookup_button_off{:style => "#{options[field].blank? ? '' : 'display:none'}"}
-                = button_tag(_("Lookup"), :class => "btn btn-default disabled")
-              #lookup_button_on{:style => "#{options[field].blank? ? 'display:none' : ''}"}
-                = button_tag(_('Lookup'),
-                             :class   => "btn btn-primary",
-                             :alt     => t = _("LDAP Group Lookup"),
-                             :title   => t,
-                             :onclick => "miqAjaxButton('#{url_for_only_path(:controller => 'miq_request',
-                                                                   :action     => 'retrieve_email',
-                                                                   :field      => fh[:pressed][:method],
-                                                                   :button     => 'submit')}');")
       - elsif [:vm_prefix].include?(field)
         -# text field for vm prefix/suffix
         .col-md-8

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2223,7 +2223,6 @@ Rails.application.routes.draw do
         prov_load_tab
         request_copy
         request_edit
-        retrieve_email
         show_list
         sort_configured_system_grid
         sort_configuration_script_grid

--- a/spec/config/routes.pending.yml
+++ b/spec/config/routes.pending.yml
@@ -832,7 +832,6 @@ MiqRequestController:
 - report_data
 - request_copy
 - request_edit
-- retrieve_email
 - show
 - show_list
 - sort_configuration_script_grid

--- a/spec/controllers/miq_request_controller_spec.rb
+++ b/spec/controllers/miq_request_controller_spec.rb
@@ -488,22 +488,6 @@ describe MiqRequestController do
     end
   end
 
-  describe '#retrieve_email' do
-    let(:wf) { FactoryBot.create(:miq_provision_virt_workflow) }
-
-    before do
-      allow(controller).to receive(:session).and_return(:edit => {:wf => wf})
-      controller.params = {:field => 'retrieve_ldap'}
-      stub_user(:features => %w[miq_request_edit])
-    end
-
-    it 'calls render method and sets @edit according to the session' do
-      expect(controller).to receive(:render).with(:update)
-      controller.send(:retrieve_email)
-      expect(controller.instance_variable_get(:@edit)).to eq(:wf => wf)
-    end
-  end
-
   private
 
   def create_user_in_other_region(userid)

--- a/spec/routing/miq_request_routing_spec.rb
+++ b/spec/routing/miq_request_routing_spec.rb
@@ -78,12 +78,6 @@ describe 'routes for MiqRequestController' do
     end
   end
 
-  describe '#retrieve_email' do
-    it 'routes with POST' do
-      expect(post("/#{controller_name}/retrieve_email")).to route_to("#{controller_name}#retrieve_email")
-    end
-  end
-
   describe '#show' do
     it 'routes with GET' do
       expect(get("/#{controller_name}/show")).to route_to("#{controller_name}#show")


### PR DESCRIPTION
owner_load_ldap depends on MiqLdap which is no longer supported. Additionally drop retrieve_email, as that function's purpose is to implement the call to retrieve_ldap for owner_load_ldap.

Part of ManageIQ/manageiq#21127

Co-depends on
- [x] https://github.com/ManageIQ/manageiq/pull/23763

Depends on
- [x] https://github.com/ManageIQ/manageiq-providers-azure/pull/580
- [x] https://github.com/ManageIQ/manageiq-providers-ibm_cic/pull/68
- [x] https://github.com/ManageIQ/manageiq-providers-ibm_power_vc/pull/149
- [x] https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/322
- [x] https://github.com/ManageIQ/manageiq-providers-openshift/pull/299
- [x] https://github.com/ManageIQ/manageiq-providers-openstack/pull/938
- [x] https://github.com/ManageIQ/manageiq-providers-oracle_cloud/pull/124
- [x] https://github.com/ManageIQ/manageiq-providers-ovirt/pull/705
- [x] https://github.com/ManageIQ/manageiq-providers-vmware/pull/965
