### PR TITLE
Upgrade @carbon/react to latest

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -20,5 +20,6 @@ module.exports = {
     require('@babel/plugin-transform-class-properties').default,
     require('@babel/plugin-transform-optional-chaining').default,
     require('@babel/plugin-transform-nullish-coalescing-operator').default,
+    require('@babel/plugin-transform-numeric-separator').default,
   ],
 };

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "@babel/eslint-parser": "~7.28.0",
     "@babel/plugin-transform-class-properties": "~7.28.0",
     "@babel/plugin-transform-nullish-coalescing-operator": "~7.28.6",
+    "@babel/plugin-transform-numeric-separator": "~7.28.6",
     "@babel/plugin-transform-optional-chaining": "~7.28.6",
     "@babel/preset-env": "~7.29.0",
     "@babel/preset-react": "~7.28.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -929,7 +929,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-numeric-separator@npm:^7.28.6":
+"@babel/plugin-transform-numeric-separator@npm:^7.28.6, @babel/plugin-transform-numeric-separator@npm:~7.28.6":
   version: 7.28.6
   resolution: "@babel/plugin-transform-numeric-separator@npm:7.28.6"
   dependencies:
@@ -13686,6 +13686,7 @@ __metadata:
     "@babel/eslint-parser": "npm:~7.28.0"
     "@babel/plugin-transform-class-properties": "npm:~7.28.0"
     "@babel/plugin-transform-nullish-coalescing-operator": "npm:~7.28.6"
+    "@babel/plugin-transform-numeric-separator": "npm:~7.28.6"
     "@babel/plugin-transform-optional-chaining": "npm:~7.28.6"
     "@babel/preset-env": "npm:~7.29.0"
     "@babel/preset-react": "npm:~7.28.0"


### PR DESCRIPTION
Replaces https://github.com/ManageIQ/manageiq-ui-classic/pull/9924

PR to bump `@carbon/react` to `v1.104.0`

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
