### PR TITLE
Remove core-js-compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "babel-loader": "~8.4.0",
     "compression-webpack-plugin": "^6.1.1",
     "core-js": "~3.49.0",
-    "core-js-compat": "~3.48.0",
     "css-loader": "~3.6.0",
     "cypress": "~15.11.0",
     "duplicate-package-checker-webpack-plugin": "~3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7163,15 +7163,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js-compat@npm:~3.48.0":
-  version: 3.48.0
-  resolution: "core-js-compat@npm:3.48.0"
-  dependencies:
-    browserslist: "npm:^4.28.1"
-  checksum: 10/83c326dcfef5e174fd3f8f33c892c66e06d567ce27f323a1197a6c280c0178fe18d3e9c5fb95b00c18b98d6c53fba5c646def5fedaa77310a4297d16dfbe2029
-  languageName: node
-  linkType: hard
-
 "core-js-pure@npm:^3.48.0":
   version: 3.49.0
   resolution: "core-js-pure@npm:3.49.0"
@@ -13953,7 +13944,6 @@ __metadata:
     compression-webpack-plugin: "npm:^6.1.1"
     connected-react-router: "npm:~6.9.0"
     core-js: "npm:~3.49.0"
-    core-js-compat: "npm:~3.48.0"
     create-react-context: "npm:~0.3.0"
     css-loader: "npm:~3.6.0"
     cypress: "npm:~15.11.0"


### PR DESCRIPTION
Replaces https://github.com/ManageIQ/manageiq-ui-classic/pull/9935

PR to remove `core-js-compat` as a direct dependency since packages that require it already declare it themselves:
<img width="722" height="312" alt="image" src="https://github.com/user-attachments/assets/b5b38e84-c73f-4ef5-aa83-f64a5d6f9683" />

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
