### PR TITLE
Additional options for ConfigurationScript Provisioning

### DIFF
--- a/app/views/miq_request/_prov_configuration_script_dialog.html.haml
+++ b/app/views/miq_request/_prov_configuration_script_dialog.html.haml
@@ -34,6 +34,12 @@
                :label  => _("Configuration Scripts"),
                :keys   => keys})
   - when :customize
+    - keys = [:verbosity, :execution_ttl, :log_output]
+    = render(:partial => "prov_dialog_fieldset",
+             :locals  => {:workflow => wf,
+               :dialog => dialog,
+               :label  => _("Provision"),
+               :keys   => keys})
     - keys = [:root_password]
     = render(:partial => "prov_dialog_fieldset",
              :locals => {:workflow => wf,

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -80,7 +80,7 @@
             :owner_office, :owner_manager, :owner_manager_mail,
             :owner_manager_phone, :owner_phone, :owner_phone_mobile,
             :owner_state, :owner_title, :owner_zip, :request_notes,
-            :subnet_mask, :memory_limit, :memory_reserve,
+            :subnet_mask, :memory_limit, :memory_reserve, :execution_ttl,
             :root_username, :root_password, :ssh_public_key, :sysprep_password, :sysprep_domain_admin,
             :sysprep_domain_password, :sysprep_workgroup_name,
             :sysprep_full_name, :sysprep_organization,
@@ -226,7 +226,7 @@
                :floating_ip_address, :resource_group, :load_balancer,
                :sysprep_auto_logon_count, :sysprep_domain_name, :sysprep_server_license_mode,
                :vlan, :cloud_tenant, :src_configuration_profile_id, :vm_minimum_memory,
-               :vm_maximum_memory, :boot_disk_size, :subnet, :placement_group, :shared_processor_pool].include?(field)
+               :vm_maximum_memory, :boot_disk_size, :subnet, :placement_group, :shared_processor_pool, :verbosity, :log_output].include?(field)
         -# Pull Down fields
         -# Multiple select Pull Down fields
         - multiple = %i[security_groups cloud_volumes].include?(field)


### PR DESCRIPTION
Add execution_ttl, verbosity, and log_output options for ConfigurationScript provisioning.

Required for:
* https://github.com/ManageIQ/manageiq-providers-embedded_terraform/pull/122
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
