### PR TITLE
Add credential_type and credential_id fields to provision form

### DIFF
--- a/app/views/miq_request/_prov_configuration_script_dialog.html.haml
+++ b/app/views/miq_request/_prov_configuration_script_dialog.html.haml
@@ -38,8 +38,14 @@
     = render(:partial => "prov_dialog_fieldset",
              :locals  => {:workflow => wf,
                :dialog => dialog,
-               :label  => _("Provision"),
+               :label  => _("Runner Options"),
                :keys   => keys})
+    - keys = [:credential_type, :credential_id]
+    = render(:partial => "prov_dialog_fieldset",
+            :locals  => {:workflow => wf,
+              :dialog => dialog,
+              :label  => _("Credentials"),
+              :keys   => keys})
     - keys = [:root_password]
     = render(:partial => "prov_dialog_fieldset",
              :locals => {:workflow => wf,

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -287,8 +287,9 @@
                :placement_cluster_name, :placement_dc_name, :placement_ds_name,
                :placement_ems_name, :placement_host_name, :placement_rp_name,
                :pxe_image_id, :windows_image_id, :src_configured_system_ids,
-               :src_host_ids, :src_vm_id, :src_configuration_script_id, :sysprep_custom_spec,
-               :customization_template_id].include?(field)
+               :src_host_ids, :src_vm_id, :src_configuration_script_id,
+               :sysprep_custom_spec, :customization_template_id,
+               :credential_id, :credential_type].include?(field)
         -# Pull Down fields that need to be sorted on description
         .col-md-8
           - if @edit && field_hash[:display] == :edit && !@edit[:stamp_typ]


### PR DESCRIPTION
Depends on:
- [x] https://github.com/ManageIQ/manageiq-ui-classic/pull/9949

Required for:
* https://github.com/ManageIQ/manageiq-providers-embedded_terraform/pull/122

<img width="1029" height="670" alt="image" src="https://github.com/user-attachments/assets/5e028c00-c842-4049-aa31-fd84c6406ef3" />

<img width="888" height="203" alt="image" src="https://github.com/user-attachments/assets/d1dae619-b99f-40fa-badd-7b8044c62037" />

Alternative to https://github.com/ManageIQ/manageiq-ui-classic/pull/9930
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
