### PR TITLE
Delete fonticon picker technical debt

### DIFF
--- a/app/javascript/oldjs/miq_angular_application.js
+++ b/app/javascript/oldjs/miq_angular_application.js
@@ -10,7 +10,6 @@ ManageIQ.angular.app = angular.module('ManageIQ', [
   'miqStaticAssets.common',
   'miqStaticAssets.dialogEditor',
   'miqStaticAssets.dialogUser',
-  'miqStaticAssets.fonticonPicker',
   'miqStaticAssets.miqSelect',
   'miqStaticAssets.treeSelector',
   'miqStaticAssets.treeView',


### PR DESCRIPTION
Delete the fonticon picker technical debt as this was converted to React in this pr: https://github.com/ManageIQ/manageiq-ui-classic/pull/6985