### PR TITLE
[WIP] Set FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 to force GHA node 24

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -46,10 +46,11 @@ jobs:
       RUN_CYPRESS: "${{ matrix.cypress-browser == 'chrome' || (matrix.cypress-browser != 'chrome' && github.event_name != 'pull_request') }}"
       PGHOST: localhost
       PGPASSWORD: smartvm
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
     - uses: actions/checkout@v6
     - name: Install Edge
-      uses: browser-actions/setup-edge@v1
+      uses: browser-actions/setup-edge@v1.1.1
       if: "${{ matrix.cypress-browser == 'edge' && env.RUN_CYPRESS == 'true' }}"
     - name: Set up system
       run: bin/before_install


### PR DESCRIPTION
We are seeing the following warning in setup-edge GHA:

cypress (3.3, edge)
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: browser-actions/setup-edge@v1. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Note, setup-edge hasn't yet fixed node24 support yet, see https://www.github.com/browser-actions/setup-edge/pull/549

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
