### PR TITLE
Fix N+1 query in MiqEventDefinition report data

### DIFF
--- a/product/views/MiqEventDefinition.yaml
+++ b/product/views/MiqEventDefinition.yaml
@@ -28,6 +28,9 @@ cols:
 
 # Included tables (joined, has_one, has_many) and columns
 include:
+  memberof:
+    columns:
+    - name
 
 # Order of columns (from all tables)
 col_order:


### PR DESCRIPTION
Fixes an N+1 query problem when loading event definitions that was causing
excessive queries for the Control > Events page.

The view includes the event_group_name virtual column which accesses the
memberof association. Without eager loading, each record triggered a
separate query:
  MiqEventDefinitionSet Load ... WHERE member_id = 178
  MiqEventDefinitionSet Load ... WHERE member_id = 177
  ... (repeated for each event definition)

Added preloading of the memberof association, most visible by the endpoint:
POST /miq_event_definition/report_data
