### PR TITLE
Fix N+1 query when loading Automate classes

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -711,7 +711,7 @@ class MiqAeClassController < ApplicationController
     @edit[:new][:description] = @ae_class.description
     @edit[:new][:namespace] = @ae_class.namespace
     @edit[:new][:inherits] = @ae_class.inherits
-    @edit[:inherits_from] = MiqAeClass.all.collect { |c| [c.fqname, c.fqname] }
+    @edit[:inherits_from] = MiqAeClass.includes(:domain).collect { |c| [c.fqname, c.fqname] }
     @edit[:current] = @edit[:new].dup
     @right_cell_text = if @edit[:rec_id].nil?
                          _("Adding a new Automate Class")


### PR DESCRIPTION
Eager load domain associations when fetching all MiqAeClass records to avoid N+1 queries when calling .fqname on each class.

Affects:
- Automate > Explorer > Add New Class dialog
- Any screen displaying list of Automate classes with their fully qualified names

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
