### PR TITLE
Fix N+1 queries in dashboard widget loading

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -210,7 +210,15 @@ class DashboardController < ApplicationController
     widget_list = []
     prev_type   = nil
     @available_widgets = []
-    MiqWidget.available_for_user(current_user).sort_by { |a| a.content_type + a.title.downcase }.each do |w|
+
+    # Eager load widget contents for current user's group to avoid N+1 queries
+    widgets = MiqWidget.available_for_user(current_user)
+    eager_loaded_widgets = MiqWidget.where(:id => widgets.map(&:id)).includes(:miq_widget_contents).sort_by { |a| a.content_type + a.title.downcase }
+
+    # Pass widgets to view as hash for fast lookup instead of using find_by_id
+    @widgets_by_id = eager_loaded_widgets.index_by(&:id)
+
+    eager_loaded_widgets.each do |w|
       @available_widgets.push(w.id) # Keep track of widgets available to this user
       next if col_widgets.include?(w.id) || !w.enabled
 

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -210,7 +210,16 @@ class DashboardController < ApplicationController
     widget_list = []
     prev_type   = nil
     @available_widgets = []
-    MiqWidget.available_for_user(current_user).sort_by { |a| a.content_type + a.title.downcase }.each do |w|
+
+    # Preload widget contents to reduce N+1 queries
+    widgets = MiqWidget.available_for_user(current_user)
+    MiqPreloader.preload(widgets, :miq_widget_contents)
+    eager_loaded_widgets = widgets.sort_by { |a| a.content_type + a.title.downcase }
+
+    # View will access the preloaded widgets indexed by id to avoid N+1 finds
+    @widgets_by_id = eager_loaded_widgets.index_by(&:id)
+
+    eager_loaded_widgets.each do |w|
       @available_widgets.push(w.id) # Keep track of widgets available to this user
       next if col_widgets.include?(w.id) || !w.enabled
 

--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -3,11 +3,11 @@
   %div{:class => 'row dashboard', :id => @tabs[0][1].split[0], 'role' => 'tabpanel', 'aria-labelledby' => "#{@tabs[0][1].split[0]}_tab"}
     .col-md-6.col-lg-6.columns#col1
       - @sb[:dashboards][@sb[:active_db]][:col1].each do |w|
-        - widget = MiqWidget.find_by_id(w)
+        - widget = @widgets_by_id[w]
         - if widget && widget.enabled && @available_widgets.include?(widget.id)
           = WidgetPresenter.new(self, controller, widget).render_partial
     .col-md-6.col-lg-6.columns#col2
       - @sb[:dashboards][@sb[:active_db]][:col2].each do |w|
-        - widget = MiqWidget.find_by_id(w)
+        - widget = @widgets_by_id[w]
         - if widget && widget.enabled && @available_widgets.include?(widget.id)
           = WidgetPresenter.new(self, controller, widget).render_partial


### PR DESCRIPTION
Reduces N+1 queries by eager loading widget contents and passing
widgets to view via an ivar hash instead of using find_by_id.

The view was calling MiqWidget.find_by_id for each widget, bypassing
any eager loading done in the controller. This caused individual queries
for each widget plus their contents.

View was making individual widget queries:
```
  MiqWidget Load (0.8ms) WHERE "miq_widgets"."id" = $1 (widget 4)
  MiqWidget Load (0.5ms) WHERE "miq_widgets"."id" = $1 (widget 3)
  MiqWidget Load (0.4ms) WHERE "miq_widgets"."id" = $1 (widget 9)
  MiqWidget Load (0.3ms) WHERE "miq_widgets"."id" = $1 (widget 24)
  MiqWidget Load (0.4ms) WHERE "miq_widgets"."id" = $1 (widget 22)
  MiqWidget Load (0.4ms) WHERE "miq_widgets"."id" = $1 (widget 1)
  MiqWidget Load (4.5ms) WHERE "miq_widgets"."id" = $1 (widget 6)
  MiqWidget Load (2.4ms) WHERE "miq_widgets"."id" = $1 (widget 21)
  MiqWidget Load (0.1ms) WHERE "miq_widgets"."id" = $1 (widget 10)
```
Plus individual MiqWidgetContent queries for each widget.

Result: Completed 200 OK in 299ms (49 queries, 9 cached)

Single bulk load with eager loading:
```
  MiqWidgetContent Load (4.1ms) WHERE "miq_widget_contents"."miq_widget_id" IN ($1, $2, ..., $27)
```