### PR TITLE
Fix catalog field tag

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -1075,7 +1075,7 @@ module ApplicationController::MiqRequestMethods
     tags = wf.allowed_tags.map do |cat|
       {
         :values      => cat[:children].map do |tag|
-          {:id => tag.first, :label => tag.second[:label]}
+          {:id => tag.first, :label => tag.second[:description]}
         end,
         :id          => cat[:name],
         :label       => cat[:description],

--- a/spec/controllers/application_controller/miq_request_methods_spec.rb
+++ b/spec/controllers/application_controller/miq_request_methods_spec.rb
@@ -166,4 +166,43 @@ describe MiqRequestController do
       end
     end
   end
+
+  describe '#build_tags_for_provisioning' do
+    let(:wf) { FactoryBot.create(:miq_provision_virt_workflow) }
+    let!(:parent_classification) do
+      FactoryBot.create(:classification,
+                        :name         => 'environment',
+                        :description  => 'Environment',
+                        :single_value => false)
+    end
+    let!(:child_classification) do
+      FactoryBot.create(:classification,
+                        :name        => 'prod',
+                        :description => 'Production',
+                        :parent      => parent_classification)
+    end
+
+    before do
+      stub_user(:features => %w[miq_request_edit])
+      allow(wf).to receive(:allowed_tags).and_return([{:name         => 'environment',
+                                                       :description  => 'Environment',
+                                                       :single_value => false,
+                                                       :children     => [['prod', {:description => 'Production'}]]}])
+    end
+
+    it 'returns tags with :label key for categories and values' do
+      controller.send(:build_tags_for_provisioning, wf, [child_classification.id], false)
+      tags = controller.instance_variable_get(:@tags)
+
+      # Check allowed tags have :label
+      tag_category = tags[:tags].first
+      expect(tag_category[:label]).to eq('Environment')
+      expect(tag_category[:values].first[:label]).to eq('Production')
+
+      # Check assigned tags have :label
+      assigned_tag = tags[:assignedTags].first
+      expect(assigned_tag[:label]).to eq('Environment')
+      expect(assigned_tag[:values].first[:label]).to eq('Production')
+    end
+  end
 end


### PR DESCRIPTION
This was broken in this PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/9910 which was incorrectly fixed in this PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/9959

Fix the catalog provisioning tag field.

Before:
<img width="735" height="353" alt="Screenshot 2026-04-14 at 3 50 17 PM" src="https://github.com/user-attachments/assets/b4482f5e-720d-474e-b7e8-2112dbac1459" />

After:
<img width="832" height="357" alt="Screenshot 2026-04-14 at 3 49 01 PM" src="https://github.com/user-attachments/assets/f7a7d1e3-dfa0-498d-a78e-be3f0243683f" />
