### PR TITLE
Fix typo in dashboard reset

### DIFF
--- a/app/javascript/components/dashboard_toolbar.jsx
+++ b/app/javascript/components/dashboard_toolbar.jsx
@@ -22,7 +22,7 @@ const resetButton = () => (
     id="reset-dashboard-button"
     kind="ghost"
     hasIconOnly
-    iconDescription={__('Reset Dashboard Widgets to the default')}
+    iconDescription={__('Reset Dashboard Widgets to the defaults')}
     onClick={resetClick}
     size="md"
     renderIcon={() => <Reply size={18} />}

--- a/app/javascript/spec/toolbar/__snapshots__/dashboard_toolbar.spec.jsx.snap
+++ b/app/javascript/spec/toolbar/__snapshots__/dashboard_toolbar.spec.jsx.snap
@@ -210,7 +210,7 @@ exports[`<DashboardToolbar /> renders ok 1`] = `
       </OverflowMenu>
       <Button
         hasIconOnly={true}
-        iconDescription="Reset Dashboard Widgets to the default"
+        iconDescription="Reset Dashboard Widgets to the defaults"
         id="reset-dashboard-button"
         kind="ghost"
         onClick={[Function]}
@@ -224,7 +224,7 @@ exports[`<DashboardToolbar /> renders ok 1`] = `
           highContrast={true}
           id="reset-dashboard-button"
           kind="ghost"
-          label="Reset Dashboard Widgets to the default"
+          label="Reset Dashboard Widgets to the defaults"
           onClick={[Function]}
           renderIcon={null}
           size="md"
@@ -238,7 +238,7 @@ exports[`<DashboardToolbar /> renders ok 1`] = `
             dropShadow={false}
             enterDelayMs={100}
             highContrast={true}
-            label="Reset Dashboard Widgets to the default"
+            label="Reset Dashboard Widgets to the defaults"
             leaveDelayMs={100}
           >
             <Popover
@@ -338,7 +338,7 @@ exports[`<DashboardToolbar /> renders ok 1`] = `
                     <span
                       className="cds--popover-content cds--tooltip-content"
                     >
-                      Reset Dashboard Widgets to the default
+                      Reset Dashboard Widgets to the defaults
                     </span>
                     <span
                       className="cds--popover-caret"


### PR DESCRIPTION
Fix typo in the dashboard reset button. Should be defaults not default in order to match the old string.