### PR TITLE
Replication tab fix - Handle update and delete of saved subscriptions

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -187,7 +187,7 @@ module OpsController::Settings::Common
     to_remove = []
     params[:subscriptions]&.each do |_k, subscription_params|
       subscription = find_or_new_subscription(subscription_params['id'])
-      if subscription.id && subscription_params['remove'] == "true"
+      if subscription.id && subscription_params['remove']
         to_remove << subscription
       else
         set_subscription_attributes(subscription, subscription_params)

--- a/app/javascript/components/settings-replication-form/helper.js
+++ b/app/javascript/components/settings-replication-form/helper.js
@@ -4,8 +4,11 @@ export const createRows = (subscriptions) => {
 
   if (Array.isArray(subscriptions) && subscriptions.length > 0) {
     subscriptions.forEach((value, index) => {
+      const isMarkedForDeletion = value.remove === true;
+
       rows.push({
         id: index.toString(),
+        disabled: isMarkedForDeletion,
         dbname: { text: value.dbname },
         host: { text: value.host },
         user: { text: value.user },
@@ -20,6 +23,7 @@ export const createRows = (subscriptions) => {
           kind: 'tertiary',
           size: 'md',
           callback: 'editSubscription',
+          disabled: isMarkedForDeletion,
         },
         validate: {
           is_button: true,
@@ -27,8 +31,15 @@ export const createRows = (subscriptions) => {
           kind: 'tertiary',
           size: 'md',
           callback: 'validateSubscription',
+          disabled: isMarkedForDeletion,
         },
-        delete: {
+        delete: isMarkedForDeletion ? {
+          is_button: true,
+          text: __('Cancel Delete'),
+          kind: 'tertiary',
+          size: 'md',
+          callback: 'cancelDelete',
+        } : {
           is_button: true,
           text: __('Delete'),
           kind: 'danger',

--- a/app/javascript/components/settings-replication-form/index.jsx
+++ b/app/javascript/components/settings-replication-form/index.jsx
@@ -6,6 +6,7 @@ import { Modal } from '@carbon/react';
 import createSchema from './settings-replication-form.schema';
 import createSubscriptionSchema from './modal-form.schema';
 import { SubscriptionsTableComponent } from './subscriptions-table';
+import MiqConfirmActionModal, { modalCallbackTypes } from '../miq-confirm-action-modal';
 import mapper from '../../forms/mappers/componentMapper';
 import { http } from '../../http_api';
 import miqFlash from '../../helpers/miq-flash';
@@ -30,12 +31,41 @@ const SettingsReplicationForm = ({ pglogicalReplicationFormId }) => {
   );
 
   const [isModalOpen, setModalOpen] = useState(false);
+  const [confirmModal, setConfirmModal] = useState(null);
   const modalRef = useRef(null);
   const formApiRef = useRef(null);
 
   const handleModalClose = () => {
     setModalOpen(false);
     setState((state) => ({ ...state, selectedSubscription: {} }));
+  };
+
+  const handleConfirmCallback = (type) => {
+    if (type === modalCallbackTypes.OK && confirmModal) {
+      if (confirmModal.type === 'delete') {
+        // Mark for deletion (keep in UI but flag as removed)
+        setState((prev) => ({
+          ...prev,
+          subscriptions: prev.subscriptions.map((sub, i) => (i === confirmModal.rowId ? { ...sub, remove: true } : sub)),
+          selectedRowId: confirmModal.rowId,
+          selectedSubscription: { ...subscriptions[confirmModal.rowId], remove: true },
+        }));
+      } else if (confirmModal.type === 'edit') {
+        // Open edit modal
+        setModalOpen(true);
+        setState((state) => ({
+          ...state,
+          selectedRowId: confirmModal.rowId,
+          form: {
+            type: 'replication',
+            className: 'replication_form',
+            action: 'edit',
+          },
+          selectedSubscription: subscriptions[confirmModal.rowId],
+        }));
+      }
+    }
+    setConfirmModal(null);
   };
 
   useEffect(() => {
@@ -56,15 +86,18 @@ const SettingsReplicationForm = ({ pglogicalReplicationFormId }) => {
   useEffect(() => {
     if (pglogicalReplicationFormId) {
       http.get(`/ops/pglogical_subscriptions_form_fields/${pglogicalReplicationFormId}`).then((response) => {
+        const helperText = response.replication_type === 'none' ? __('No replication role has been set') : null;
         setState({
           subscriptions: response.subscriptions,
           savedSubscriptions: response.subscriptions,
+          replicationType: response.replication_type,
+          savedReplicationType: response.replication_type,
           form: {
             type: 'replication',
             className: 'replication_form',
             action: 'add',
           },
-          replicationHelperText: __('No replication role has been set'),
+          replicationHelperText: helperText,
           helperTextType: 'warning',
           isLoading: false,
         });
@@ -105,6 +138,7 @@ const SettingsReplicationForm = ({ pglogicalReplicationFormId }) => {
           user: values.user,
           password: values.password,
           port: values.port,
+          newRecord: true,
         };
 
         setState((state) => ({
@@ -112,7 +146,9 @@ const SettingsReplicationForm = ({ pglogicalReplicationFormId }) => {
           subscriptions: [...state.subscriptions, newSubscription],
         }));
       } else if (form.action === 'edit') {
+        const currentSubscription = subscriptions[selectedRowId];
         const editedSub = {
+          ...currentSubscription,
           dbname: values.dbname,
           host: values.host,
           password: values.password,
@@ -132,23 +168,34 @@ const SettingsReplicationForm = ({ pglogicalReplicationFormId }) => {
   };
 
   const handleSaveResponse = (message) => {
+    const updatedSubscriptions = subscriptions
+      .filter((sub) => !sub.remove)
+      .map((sub) => {
+        // Remove newRecord flag using destructuring
+        // eslint-disable-next-line no-unused-vars
+        const { newRecord, ...subscriptionWithoutNewRecordFlag } = sub;
+        return subscriptionWithoutNewRecordFlag;
+      });
+
     setState((state) => ({
       ...state,
       replicationHelperText: message,
       helperTextType: 'success',
       savedReplicationType: state.replicationType,
-      subscriptions: (state.replicationType !== 'global') ? [] : state.subscriptions,
-      savedSubscriptions: (state.replicationType !== 'global') ? [] : state.subscriptions,
+      subscriptions: (state.replicationType !== 'global') ? [] : updatedSubscriptions,
+      savedSubscriptions: (state.replicationType !== 'global') ? [] : updatedSubscriptions,
     }));
   };
 
   const onSave = (values) => {
     let data;
     if (replicationType === 'global') {
-      if (subscriptions.length === 0) {
+      const activeSubscriptions = subscriptions.filter((sub) => !sub.remove);
+      if (activeSubscriptions.length === 0) {
         miqFlash('error', __('At least 1 subscription must be added to save server replication type'));
         return;
       }
+      // Send all subscriptions including those marked for deletion
       const subscriptionData = subscriptions.reduce((acc, item, index) => {
         acc[index] = item;
         return acc;
@@ -183,7 +230,7 @@ const SettingsReplicationForm = ({ pglogicalReplicationFormId }) => {
   return !isLoading && (
     <div>
       <MiqFormRenderer
-        schema={createSchema(subscriptions, setState, setModalOpen, replicationType, isSubscriptionModified)}
+        schema={createSchema(subscriptions, setState, setModalOpen, replicationType, isSubscriptionModified, setConfirmModal)}
         componentMapper={componentMapper}
         initialValues={{
           replication_type: savedReplicationType,
@@ -219,12 +266,23 @@ const SettingsReplicationForm = ({ pglogicalReplicationFormId }) => {
           onCancel={handleModalClose}
           canReset
           buttonsLabels={{
-            submitLabel: __('Add'),
+            submitLabel: selectedSubscription && Object.keys(selectedSubscription).length
+              ? __('Update')
+              : __('Add'),
           }}
         />
       </Modal>
-    </div>
 
+      {confirmModal && (
+        <MiqConfirmActionModal
+          modalData={{
+            label: confirmModal.label,
+            confirm: confirmModal.message,
+            callback: handleConfirmCallback,
+          }}
+        />
+      )}
+    </div>
   );
 };
 

--- a/app/javascript/components/settings-replication-form/settings-replication-form.schema.js
+++ b/app/javascript/components/settings-replication-form/settings-replication-form.schema.js
@@ -3,31 +3,79 @@ import { componentTypes } from '@@ddf';
 import { createRows } from './helper';
 import miqFlash from '../../helpers/miq-flash';
 
-const createSchema = (subscriptions, setState, setModalOpen, replicationType, isSubscriptionModified) => {
+const createSchema = (subscriptions, setState, setModalOpen, replicationType, isSubscriptionModified, setConfirmModal) => {
   const deleteSubscription = (selectedRow) => {
     const rowId = parseInt(selectedRow.id, 10);
+    const subscription = subscriptions[rowId];
 
+    const isNewRecord = subscription.newRecord === true;
+
+    if (isNewRecord) {
+      // New records: remove immediately from UI
+      setState((prev) => ({
+        ...prev,
+        subscriptions: prev.subscriptions.filter((_, i) => i !== rowId),
+        selectedRowId: rowId,
+        selectedSubscription: subscriptions[rowId],
+      }));
+    } else {
+      // Existing records: show confirmation dialog
+      setConfirmModal({
+        type: 'delete',
+        rowId,
+        label: __('Confirm Delete'),
+        message: __(
+          'Deleting a subscription will remove all replicated data which originated in the selected region. Do you want to continue?'
+        ),
+      });
+    }
+  };
+
+  const cancelDelete = (selectedRow) => {
+    const rowId = parseInt(selectedRow.id, 10);
     setState((prev) => ({
       ...prev,
-      subscriptions: prev.subscriptions.filter((_, i) => i !== rowId),
-      selectedRowId: rowId,
-      selectedSubscription: subscriptions[rowId],
+      subscriptions: prev.subscriptions.map((sub, i) => {
+        if (i === rowId) {
+          // eslint-disable-next-line no-unused-vars
+          const { remove, ...rest } = sub;
+          return rest;
+        }
+        return sub;
+      }),
     }));
   };
 
   const editSubscription = (selectedRow) => {
     const rowId = parseInt(selectedRow.id, 10);
-    setModalOpen(true);
-    setState((state) => ({
-      ...state,
-      selectedRowId: rowId,
-      form: {
-        type: 'replication',
-        className: 'replication_form',
-        action: 'edit',
-      },
-      selectedSubscription: subscriptions[rowId],
-    }));
+    const subscription = subscriptions[rowId];
+    const isNewRecord = subscription.newRecord === true;
+
+    // Show confirmation dialog for existing subscriptions
+    if (!isNewRecord) {
+      setConfirmModal({
+        type: 'edit',
+        rowId,
+        label: __('Confirm Edit'),
+        message: __(
+          'An updated subscription must point to the same database with which it was originally created. '
+          + 'Failure to do so will result in undefined behavior. Do you want to continue?'
+        ),
+      });
+    } else {
+      // New records: open edit modal directly
+      setModalOpen(true);
+      setState((state) => ({
+        ...state,
+        selectedRowId: rowId,
+        form: {
+          type: 'replication',
+          className: 'replication_form',
+          action: 'edit',
+        },
+        selectedSubscription: subscriptions[rowId],
+      }));
+    }
   };
 
   const validateSubscription = (selectedRow) => {
@@ -46,7 +94,7 @@ const createSchema = (subscriptions, setState, setModalOpen, replicationType, is
       skipErrors: [400],
     }).then((response) => {
       if (response.status === 'success') {
-        miqFlash('success', __('Validation successful'));
+        miqFlash('success', response.message);
       } else {
         miqFlash('error', response.message);
       }
@@ -105,6 +153,7 @@ const createSchema = (subscriptions, setState, setModalOpen, replicationType, is
       {
         component: componentTypes.TEXT_FIELD,
         name: 'subscriptions_changed',
+        label: __('Subscriptions Changed'),
         hideField: true,
       },
       {
@@ -129,6 +178,9 @@ const createSchema = (subscriptions, setState, setModalOpen, replicationType, is
                 break;
               case 'deleteSubscription':
                 deleteSubscription(selectedRow);
+                break;
+              case 'cancelDelete':
+                cancelDelete(selectedRow);
                 break;
               case 'validateSubscription':
                 validateSubscription(selectedRow);

--- a/app/javascript/components/settings-replication-form/styles.scss
+++ b/app/javascript/components/settings-replication-form/styles.scss
@@ -2,3 +2,13 @@
   display: flex;
   justify-content: flex-end;
 }
+
+/* For subscriptions marked for deletion */
+.subscriptions-table .disabled-row {
+  background-color: #fff1f1;
+  opacity: 0.8;
+}
+
+.subscriptions-table .disabled-row:hover {
+  background-color: #ffe0e0;
+}

--- a/cypress/e2e/ui/Settings/Application-Settings/settings_replication_tab.cy.js
+++ b/cypress/e2e/ui/Settings/Application-Settings/settings_replication_tab.cy.js
@@ -35,7 +35,7 @@ const TEST_PORT = '8888';
 const SAVE_BUTTON_TEXT = 'Save';
 const RESET_BUTTON_TEXT = 'Reset';
 const CANCEL_BUTTON_TEXT = 'Cancel';
-const ACCEPT_BUTTON_TEXT = 'Add';
+const ADD_BUTTON_TEXT = 'Add';
 const ADD_SUBSCRIPTION_BUTTON_TEXT = 'Add Subscription';
 const UPDATE_BUTTON_TEXT = 'Update';
 const VALIDATE_BUTTON_TEXT = 'Validate';
@@ -44,6 +44,8 @@ const DELETE_BUTTON_TEXT = 'Delete';
 // Modal headings
 const ADD_SUBSCRIPTION_MODAL_HEADING = 'Add Subscription';
 const EDIT_SUBSCRIPTION_MODAL_HEADING_PREFIX = 'Edit';
+const CONFIRM_DELETE_MODAL_HEADING = 'Confirm Delete';
+const CONFIRM_EDIT_MODAL_HEADING = 'Confirm Edit';
 
 // Flash message text snippets
 const FLASH_MESSAGE_SAVE_INITIATED = 'save initiated';
@@ -58,26 +60,53 @@ const MODAL_SELECTOR = '.cds--modal';
 const MODAL_HEADER_SELECTOR = '.cds--modal-header__heading';
 const SUBSCRIPTIONS_TABLE_SELECTOR = '.subscriptions-table';
 const MIQ_DATA_TABLE_BUTTON_SELECTOR = '.miq-data-table .miq-data-table-button';
+const CANCEL_DELETE_BUTTON_TEXT = 'Cancel Delete';
+const DISABLED_ROW_SELECTOR = '.disabled-row';
 
-function saveReplicationForm() {
-  cy.interceptApi({
-    alias: 'saveReplication',
-    method: 'POST',
-    urlPattern: /\/ops\/pglogical_save_subscriptions\/.*\?button=save/,
-    triggerFn: () => cy.contains('button', SAVE_BUTTON_TEXT).click(),
-  });
+const CONFIRM_OK_BUTTON_TEXT = 'Ok';
+
+function navigateToReplicationTab() {
+  cy.login();
+  cy.menu(SETTINGS_MENU_OPTION, APP_SETTINGS_MENU_OPTION);
+  cy.accordion(SETTINGS_ACCORDION_ITEM);
+  cy.selectAccordionItem([MANAGEIQ_REGION_ACCORDION_ITEM]);
+  cy.expect_explorer_title('ManageIQ Region');
+  cy.tabs({ tabLabel: REPLICATION_TAB });
 }
 
-function addSubscription() {
-  cy.getFormSelectFieldById({ selectId: REPLICATION_TYPE_SELECT_NAME }).select(REPLICATION_TYPE_GLOBAL, { force: true });
-  
-  cy.contains('button', ADD_SUBSCRIPTION_BUTTON_TEXT).should('be.visible');
+// Mock the replication form fields API with custom response
+function mockReplicationFormFieldsApi(replicationType, subscriptions = [], aliasName = 'getReplicationFormFields') {
+  cy.intercept('GET', '/ops/pglogical_subscriptions_form_fields/new', {
+    statusCode: 200,
+    body: {
+      replication_type: replicationType,
+      subscriptions,
+    },
+  }).as(aliasName);
+}
 
-  cy.contains('button', ADD_SUBSCRIPTION_BUTTON_TEXT).click();
+// Prepare previously saved subscription(s) for global type
+function setupSavedSubscription(subscription) {
+  mockReplicationFormFieldsApi('global', [subscription], 'getSubscriptions');
+
+  navigateToReplicationTab();
+  cy.wait('@getSubscriptions');
+  cy.getFormSelectFieldById({ selectId: REPLICATION_TYPE_SELECT_NAME }).select(REPLICATION_TYPE_GLOBAL);
+}
+
+// Add a new subscription for global type
+function addSubscription() {
+  cy.getFormSelectFieldById({ selectId: REPLICATION_TYPE_SELECT_NAME })
+    .select(REPLICATION_TYPE_GLOBAL, { force: true });
+  
+  cy.contains('button', ADD_SUBSCRIPTION_BUTTON_TEXT)
+    .should('be.visible')
+    .click();
+
   cy.get(MODAL_SELECTOR).should('be.visible');
   cy.get(MODAL_HEADER_SELECTOR).should('have.text', ADD_SUBSCRIPTION_MODAL_HEADING);
 
-  cy.get('body').click(0, 0);
+  cy.get('body').click(0, 0); // Click outside to close modal
   cy.get(MODAL_SELECTOR).should('not.be.visible');
 
   cy.contains('button', ADD_SUBSCRIPTION_BUTTON_TEXT).click();
@@ -89,216 +118,376 @@ function addSubscription() {
   cy.getFormInputFieldByIdAndType({ inputId: PASSWORD_INPUT_NAME, inputType: 'password' }).should('be.visible');
   cy.getFormInputFieldByIdAndType({ inputId: PORT_INPUT_NAME }).should('be.visible');
 
-  cy.contains(`${MODAL_SELECTOR} button`, ACCEPT_BUTTON_TEXT).should('be.disabled');
+  cy.contains(`${MODAL_SELECTOR} button`, ADD_BUTTON_TEXT).should('be.disabled');
 
   cy.getFormInputFieldByIdAndType({ inputId: DBNAME_INPUT_NAME })
     .clear({ force: true })
     .type(TEST_DB_NAME, { force: true, delay: 100 })
-    .should('have.value', TEST_DB_NAME);
   cy.getFormInputFieldByIdAndType({ inputId: HOST_INPUT_NAME }).type(TEST_HOST);
   cy.getFormInputFieldByIdAndType({ inputId: USER_INPUT_NAME }).type(TEST_USER_1);
   cy.getFormInputFieldByIdAndType({ inputId: PASSWORD_INPUT_NAME, inputType: 'password' }).type(TEST_PASSWORD);
   cy.getFormInputFieldByIdAndType({ inputId: PORT_INPUT_NAME }).type(TEST_PORT);
 
-  cy.contains(`${MODAL_SELECTOR} button`, ACCEPT_BUTTON_TEXT).should('not.be.disabled').click();
+  cy.contains(`${MODAL_SELECTOR} button`, ADD_BUTTON_TEXT).should('not.be.disabled').click();
 
   cy.get(SUBSCRIPTIONS_TABLE_SELECTOR).should('be.visible');
 }
 
-describe('Automate Replication form operations: Settings > Application Settings > Replication', () => {
-  beforeEach(() => {
-    cy.login();
-    cy.menu(SETTINGS_MENU_OPTION, APP_SETTINGS_MENU_OPTION);
-    cy.accordion(SETTINGS_ACCORDION_ITEM);
-    cy.selectAccordionItem([MANAGEIQ_REGION_ACCORDION_ITEM]);
-    cy.expect_explorer_title('ManageIQ Region');
-    
-    cy.tabs({ tabLabel: REPLICATION_TAB });
+function saveReplicationForm() {
+  cy.interceptApi({
+    alias: 'saveReplication',
+    method: 'POST',
+    urlPattern: /\/ops\/pglogical_save_subscriptions\/.*\?button=save/,
+    triggerFn: () => cy.contains('button', SAVE_BUTTON_TEXT).click(),
+  });
+}
 
+function handleConfirmationModal(heading, buttonText) {
+  cy.get(MODAL_SELECTOR).should('be.visible');
+  cy.contains(MODAL_HEADER_SELECTOR, heading).should('be.visible');
+  
+  cy.contains('button', buttonText).click({force: true});
+  
+  cy.contains(MODAL_HEADER_SELECTOR, heading).should('not.exist');
+}
+
+describe('Settings > Application Settings > Replication form', () => {
+  beforeEach(() => {
+    navigateToReplicationTab();
     cy.getFormSelectFieldById({ selectId: REPLICATION_TYPE_SELECT_NAME }).should('be.visible');
   });
 
-  describe('Validate Replication Type Operations', () => {
-    it('Validate replication type dropdown and options', () => {
-    cy.getFormSelectFieldById({ selectId: REPLICATION_TYPE_SELECT_NAME }).should('exist').and('be.visible');
+  describe('Verify Operations on Replication Type Dropdown', () => {
+    it('Verify replication type dropdown and its options', () => {
+      cy.getFormSelectFieldById({ selectId: REPLICATION_TYPE_SELECT_NAME })
+        .find('option').should('have.length', 3);
+      cy.getFormSelectFieldById({ selectId: REPLICATION_TYPE_SELECT_NAME })
+        .find(`option[value="${REPLICATION_TYPE_NONE}"]`).should('exist');
+      cy.getFormSelectFieldById({ selectId: REPLICATION_TYPE_SELECT_NAME })
+        .find(`option[value="${REPLICATION_TYPE_GLOBAL}"]`).should('exist');
+      cy.getFormSelectFieldById({ selectId: REPLICATION_TYPE_SELECT_NAME })
+        .find(`option[value="${REPLICATION_TYPE_REMOTE}"]`).should('exist');
+    });
 
-    cy.getFormSelectFieldById({ selectId: REPLICATION_TYPE_SELECT_NAME }).find('option').should('have.length', 3);
-    cy.getFormSelectFieldById({ selectId: REPLICATION_TYPE_SELECT_NAME }).find(`option[value="${REPLICATION_TYPE_NONE}"]`).should('exist');
-    cy.getFormSelectFieldById({ selectId: REPLICATION_TYPE_SELECT_NAME }).find(`option[value="${REPLICATION_TYPE_GLOBAL}"]`).should('exist');
-    cy.getFormSelectFieldById({ selectId: REPLICATION_TYPE_SELECT_NAME }).find(`option[value="${REPLICATION_TYPE_REMOTE}"]`).should('exist');
-  });
+    it('Verify dropdown reflects API response for global type', () => {
+      mockReplicationFormFieldsApi('global', [], 'getGlobalReplication');
 
-  it('Validate save remote type', () => {
-    cy.getFormSelectFieldById({ selectId: REPLICATION_TYPE_SELECT_NAME }).select(REPLICATION_TYPE_REMOTE);
+      cy.reload();
+      cy.wait('@getGlobalReplication');
 
-    saveReplicationForm();
+      cy.getFormSelectFieldById({ selectId: REPLICATION_TYPE_SELECT_NAME })
+        .should('have.value', REPLICATION_TYPE_GLOBAL);
+    });
 
-    cy.expect_flash(flashClassMap.success, FLASH_MESSAGE_SAVE_INITIATED);
-  });
+    it('Verify dropdown reflects API response for remote type', () => {
+      mockReplicationFormFieldsApi('remote', [], 'getRemoteReplication');
 
-  it('Validate save none type', () => {
-    cy.expect_flash(flashClassMap.warning, FLASH_MESSAGE_NO_REPLICATION_ROLE);
+      cy.reload();
+      cy.wait('@getRemoteReplication');
 
-    cy.getFormSelectFieldById({ selectId: REPLICATION_TYPE_SELECT_NAME }).select(REPLICATION_TYPE_REMOTE);
-    saveReplicationForm();
+      cy.getFormSelectFieldById({ selectId: REPLICATION_TYPE_SELECT_NAME })
+        .should('have.value', REPLICATION_TYPE_REMOTE);
+    });
 
-    cy.getFormSelectFieldById({ selectId: REPLICATION_TYPE_SELECT_NAME }).select(REPLICATION_TYPE_NONE);
+    it('Verify saving remote type', () => {
+      // Mock API to return 'none' so selecting 'remote' is a change
+      mockReplicationFormFieldsApi('none', [], 'getInitialState');
 
-    cy.expect_flash(flashClassMap.warning, FLASH_MESSAGE_REPLICATION_DISABLED);
+      cy.reload();
+      cy.wait('@getInitialState');
 
-    saveReplicationForm();
+      cy.expect_flash(flashClassMap.warning, FLASH_MESSAGE_NO_REPLICATION_ROLE);
 
-    cy.expect_flash(flashClassMap.success, FLASH_MESSAGE_SAVE_INITIATED);
-  });
+      cy.getFormSelectFieldById({ selectId: REPLICATION_TYPE_SELECT_NAME }).select(REPLICATION_TYPE_REMOTE);
 
-  it('Validate reset functionality', () => {
-    cy.getFormSelectFieldById({ selectId: REPLICATION_TYPE_SELECT_NAME }).select(REPLICATION_TYPE_REMOTE);
-    cy.contains('button', RESET_BUTTON_TEXT).click();
+      saveReplicationForm();
 
-    cy.expect_flash(flashClassMap.warning, FLASH_MESSAGE_RESET);
+      cy.expect_flash(flashClassMap.success, FLASH_MESSAGE_SAVE_INITIATED);
+    });
+
+    it('Verify saving none type', () => {
+      // Mock API to return 'remote' as initial state
+      mockReplicationFormFieldsApi('remote', [], 'getInitialRemoteState');
+
+      cy.reload();
+      cy.wait('@getInitialRemoteState');
+
+      cy.getFormSelectFieldById({ selectId: REPLICATION_TYPE_SELECT_NAME }).select(REPLICATION_TYPE_NONE);
+
+      cy.expect_flash(flashClassMap.warning, FLASH_MESSAGE_REPLICATION_DISABLED);
+
+      saveReplicationForm();
+
+      cy.expect_flash(flashClassMap.success, FLASH_MESSAGE_SAVE_INITIATED);
+    });
+
+    it('Verify form resets to initial state', () => {
+      // Mock API to return 'none' as initial state
+      mockReplicationFormFieldsApi('none', [], 'getInitialNoneState');
+
+      cy.reload();
+      cy.wait('@getInitialNoneState');
+
+      // Make a change by selecting remote
+      cy.getFormSelectFieldById({ selectId: REPLICATION_TYPE_SELECT_NAME }).select(REPLICATION_TYPE_REMOTE);
+
+      cy.contains('button', RESET_BUTTON_TEXT).click();
+
+      cy.getFormSelectFieldById({ selectId: REPLICATION_TYPE_SELECT_NAME })
+        .should('have.value', REPLICATION_TYPE_NONE);
     });
   });
 
-  describe('Validate Subscription CRUD Operations', () => {
+  describe('Global Type: Verify Subscription CRUD Operations', () => {
     afterEach(() => {
       cy.appDbState('restore');
     });
 
-    it('Validate create subscription for global type', () => {
-    addSubscription();
+    it('Verify adding a new subscription', () => {
+      addSubscription();
 
-    cy.get(SUBSCRIPTIONS_TABLE_SELECTOR)
-      .find('table')
-      .find('tbody')
-      .find('tr')
-      .should('have.length', 1);
-  });
+      cy.get(SUBSCRIPTIONS_TABLE_SELECTOR)
+        .find('table')
+        .find('tbody')
+        .find('tr')
+        .should('have.length', 1);
+    });
 
-  it('Validate update subscription', () => {
-    addSubscription();
-
-    cy.contains(MIQ_DATA_TABLE_BUTTON_SELECTOR, UPDATE_BUTTON_TEXT)
-      .should('be.visible')
-      .click();
-
-    cy.get(MODAL_SELECTOR).should('be.visible');
-    cy.get(MODAL_HEADER_SELECTOR).should('have.text', `${EDIT_SUBSCRIPTION_MODAL_HEADING_PREFIX} ${TEST_DB_NAME}`);
-
-    cy.getFormInputFieldByIdAndType({ inputId: USER_INPUT_NAME })
-      .clear({ force: true })
-      .type(TEST_USER_2, { force: true, delay: 100 })
-      .should('have.value', TEST_USER_2);
-
-    cy.contains(`${MODAL_SELECTOR} button`, ACCEPT_BUTTON_TEXT)
-      .should('be.visible')
-      .click();
-
-    cy.get(SUBSCRIPTIONS_TABLE_SELECTOR)
-      .find('table')
-      .find('tbody')
-      .find('tr')
-      .find('td')
-      .eq(2)
-      .should('have.text', TEST_USER_2);
-  });
-
-  it('Validate subscription validation', () => {
-    addSubscription();
-
-    cy.interceptApi({
-      alias: 'validateSubscriptionApi',
-      method: 'POST',
-      urlPattern: /\/ops\/pglogical_validate_subscription/,
-      triggerFn: () => cy.contains(MIQ_DATA_TABLE_BUTTON_SELECTOR, VALIDATE_BUTTON_TEXT)
+    it('Verify Cancel and Reset operations in the subscription modal', () => {
+      cy.getFormSelectFieldById({ selectId: REPLICATION_TYPE_SELECT_NAME })
+        .select(REPLICATION_TYPE_GLOBAL, { force: true });
+      
+      cy.contains('button', ADD_SUBSCRIPTION_BUTTON_TEXT)
         .should('be.visible')
-        .click(),
-    });
-
-    cy.expect_flash(flashClassMap.error, FLASH_MESSAGE_VALIDATION_FAILED);
-  });
-
-  it('Validate save subscriptions to database', () => {
-    addSubscription();
-
-    saveReplicationForm();
-
-    cy.expect_flash(flashClassMap.success, FLASH_MESSAGE_SAVE_INITIATED);
-  });
-
-  it('Validate delete subscription from UI', () => {
-    addSubscription();
-
-    cy.contains(MIQ_DATA_TABLE_BUTTON_SELECTOR, DELETE_BUTTON_TEXT)
-      .scrollIntoView()
-      .should('be.visible')
-      .click();
-
-    cy.get(SUBSCRIPTIONS_TABLE_SELECTOR)
-      .find('table')
-      .find('tbody')
-      .find('tr')
-      .should('have.length', 0);
-    });
-  });
-
-  describe('Validate Replication Type Switching', () => {
-    afterEach(() => {
-      cy.appDbState('restore');
-    });
-
-    it('Validate subscriptions removed when switching replication type', () => {
-    addSubscription();
-
-    cy.get(SUBSCRIPTIONS_TABLE_SELECTOR)
-      .find('table')
-      .find('tbody')
-      .find('tr')
-      .should('have.length', 1);
-
-    saveReplicationForm();
-
-    cy.getFormSelectFieldById({ selectId: REPLICATION_TYPE_SELECT_NAME }).select(REPLICATION_TYPE_REMOTE);
-
-    cy.expect_flash(flashClassMap.warning, FLASH_MESSAGE_SUBSCRIPTIONS_REMOVED);
-
-    saveReplicationForm();
-
-    cy.getFormSelectFieldById({ selectId: REPLICATION_TYPE_SELECT_NAME }).select(REPLICATION_TYPE_GLOBAL);
-
-    cy.get(SUBSCRIPTIONS_TABLE_SELECTOR)
-      .find('table')
-      .find('tbody')
-      .find('tr')
-      .should('have.length', 0);
-    });
-  });
-
-  describe('Validate Modal Interactions', () => {
-    it('Validate reset fields in subscription modal', () => {
-    addSubscription();
-
-    cy.contains('button', ADD_SUBSCRIPTION_BUTTON_TEXT).click();
-    cy.get(MODAL_SELECTOR).should('be.visible');
-
-    cy.getFormInputFieldByIdAndType({ inputId: DBNAME_INPUT_NAME }).type('test_reset');
-
-    cy.contains(`${MODAL_SELECTOR} button`, RESET_BUTTON_TEXT)
-      .should('be.visible')
-      .click();
-
-    cy.getFormInputFieldByIdAndType({ inputId: DBNAME_INPUT_NAME }).should('have.value', '');
-    cy.getFormInputFieldByIdAndType({ inputId: HOST_INPUT_NAME }).should('have.value', '');
-
-    cy.expect_flash(flashClassMap.warning, FLASH_MESSAGE_RESET);
-    });
-
-    it('Validate modal closes when cancel button clicked', () => {
-      cy.getFormSelectFieldById({ selectId: REPLICATION_TYPE_SELECT_NAME }).select(REPLICATION_TYPE_GLOBAL);
-      cy.contains('button', ADD_SUBSCRIPTION_BUTTON_TEXT).click();
+        .click();
+        
       cy.get(MODAL_SELECTOR).should('be.visible');
 
-      cy.contains(`${MODAL_SELECTOR} button`, CANCEL_BUTTON_TEXT).click();
+      cy.contains(`${MODAL_SELECTOR} button`, CANCEL_BUTTON_TEXT)
+        .should('be.visible')
+        .click();
+
       cy.get(MODAL_SELECTOR).should('not.be.visible');
+
+      cy.contains('button', ADD_SUBSCRIPTION_BUTTON_TEXT)
+        .should('be.visible')
+        .click();
+        
+      cy.get(MODAL_SELECTOR).should('be.visible');
+      
+      cy.getFormInputFieldByIdAndType({ inputId: DBNAME_INPUT_NAME })
+        .scrollIntoView()
+        .type('test_reset', { force: true });
+
+      cy.contains(`${MODAL_SELECTOR} button`, RESET_BUTTON_TEXT)
+        .should('be.visible')
+        .click();
+      cy.getFormInputFieldByIdAndType({ inputId: DBNAME_INPUT_NAME }).should('have.value', '');
+      cy.expect_flash(flashClassMap.warning, FLASH_MESSAGE_RESET);
     });
+
+    it('Verify subscription validation', () => {
+      addSubscription();
+
+      cy.interceptApi({
+        alias: 'validateSubscriptionApi',
+        method: 'POST',
+        urlPattern: /\/ops\/pglogical_validate_subscription/,
+        triggerFn: () => cy.contains(MIQ_DATA_TABLE_BUTTON_SELECTOR, VALIDATE_BUTTON_TEXT)
+          .should('be.visible')
+          .click(),
+      });
+
+      cy.expect_flash(flashClassMap.error, FLASH_MESSAGE_VALIDATION_FAILED);
+    });
+
+    it('Verify editing a newly added subscription', () => {
+      addSubscription();
+
+      cy.contains(MIQ_DATA_TABLE_BUTTON_SELECTOR, UPDATE_BUTTON_TEXT)
+        .should('be.visible')
+        .click();
+
+      cy.get(MODAL_SELECTOR).should('be.visible');
+      cy.get(MODAL_HEADER_SELECTOR)
+        .should('have.text', `${EDIT_SUBSCRIPTION_MODAL_HEADING_PREFIX} ${TEST_DB_NAME}`);
+
+      cy.getFormInputFieldByIdAndType({ inputId: USER_INPUT_NAME })
+        .clear({ force: true })
+        .type(TEST_USER_2, { force: true, delay: 100 })
+        .should('have.value', TEST_USER_2);
+
+      cy.contains(`${MODAL_SELECTOR} button`, UPDATE_BUTTON_TEXT)
+        .should('be.visible')
+        .click();
+
+      cy.get(SUBSCRIPTIONS_TABLE_SELECTOR)
+        .find('table').find('tbody').find('tr').find('td').eq(2)
+        .should('have.text', TEST_USER_2);
+    });
+
+    it('Verify editing a previously saved subscription', () => {
+      const MOCK_SAVED_SUBSCRIPTION = {
+        id: 888,
+        dbname: 'test_db',
+        host: 'localhost',
+        user: 'testuser',
+        password: 'testpass',
+        port: 5432,
+      };
+
+      setupSavedSubscription(MOCK_SAVED_SUBSCRIPTION);
+
+      // Click update button - should show confirmation modal
+      cy.contains(MIQ_DATA_TABLE_BUTTON_SELECTOR, UPDATE_BUTTON_TEXT)
+        .should('be.visible')
+        .click();
+
+      cy.contains('An updated subscription must point to the same database').should('be.visible');
+      
+      // Confirm the edit operation - this will close the confirmation modal and open the edit modal
+      handleConfirmationModal(CONFIRM_EDIT_MODAL_HEADING, CONFIRM_OK_BUTTON_TEXT);
+      
+      // Verify the edit modal is now open
+      cy.contains(MODAL_HEADER_SELECTOR, `${EDIT_SUBSCRIPTION_MODAL_HEADING_PREFIX} ${MOCK_SAVED_SUBSCRIPTION.dbname}`)
+        .should('be.visible');
+
+      cy.getFormInputFieldByIdAndType({ inputId: USER_INPUT_NAME })
+        .clear({ force: true })
+        .type(TEST_USER_2, { force: true, delay: 100 })
+        .should('have.value', TEST_USER_2);
+
+      cy.contains(`${MODAL_SELECTOR} button`, UPDATE_BUTTON_TEXT).click();
+
+      cy.get(SUBSCRIPTIONS_TABLE_SELECTOR)
+        .find('table').find('tbody').find('tr').find('td').eq(2)
+        .should('have.text', TEST_USER_2);
+    });
+
+    it('Verify deleting a newly added subscription', () => {
+      addSubscription();
+
+      cy.contains(MIQ_DATA_TABLE_BUTTON_SELECTOR, DELETE_BUTTON_TEXT)
+        .scrollIntoView()
+        .should('be.visible')
+        .click();
+
+      cy.get(SUBSCRIPTIONS_TABLE_SELECTOR)
+        .find('table').find('tbody').find('tr')
+        .should('have.length', 0);
+    });
+
+    it('Verify deleting a previously saved subscription', () => {      
+      const MOCK_SAVED_SUBSCRIPTION = {
+        id: 888,
+        dbname: 'test_db',
+        host: 'localhost',
+        user: 'testuser',
+        password: 'testpass',
+        port: 5432,
+      };
+
+      setupSavedSubscription(MOCK_SAVED_SUBSCRIPTION);
+
+      cy.contains(MOCK_SAVED_SUBSCRIPTION.dbname).should('be.visible');
+
+      // Click delete button - should show confirmation modal
+      cy.contains(MIQ_DATA_TABLE_BUTTON_SELECTOR, DELETE_BUTTON_TEXT)
+        .scrollIntoView()
+        .should('be.visible')
+        .click();
+
+      cy.get(MODAL_SELECTOR).should('be.visible');
+      cy.contains(MODAL_HEADER_SELECTOR, CONFIRM_DELETE_MODAL_HEADING).should('be.visible');
+      cy.contains('Deleting a subscription will remove all replicated data').should('be.visible');
+
+      handleConfirmationModal(CONFIRM_DELETE_MODAL_HEADING, CONFIRM_OK_BUTTON_TEXT);
+
+      // Verify subscription is marked for deletion (disabled row with Cancel Delete button)
+      cy.contains('button', CANCEL_DELETE_BUTTON_TEXT).scrollIntoView().should('be.visible');
+      cy.get(DISABLED_ROW_SELECTOR).should('exist');
+
+      // Undo delete
+      cy.contains('button', CANCEL_DELETE_BUTTON_TEXT).scrollIntoView().click();
+
+      // Verify subscription is restored (no longer disabled)
+      cy.get(DISABLED_ROW_SELECTOR).should('not.exist');
+      cy.get(SUBSCRIPTIONS_TABLE_SELECTOR)
+        .find('tbody tr')
+        .should('have.length', 1)
+        .within(() => {
+          cy.contains(MOCK_SAVED_SUBSCRIPTION.dbname).should('exist');
+          cy.contains(DELETE_BUTTON_TEXT).should('exist');
+        });
+      
+      // Now delete again
+      cy.contains(MIQ_DATA_TABLE_BUTTON_SELECTOR, DELETE_BUTTON_TEXT)
+        .scrollIntoView()
+        .click();
+      
+      handleConfirmationModal(CONFIRM_DELETE_MODAL_HEADING, CONFIRM_OK_BUTTON_TEXT);
+            
+      // Try to save after deleting all subscriptions - an error should be displayed
+      cy.contains('button', SAVE_BUTTON_TEXT).click();
+      cy.expect_flash(flashClassMap.error, 'At least 1 subscription must be added to save server replication type');
+      
+      addSubscription();
+
+      // Verify both subscriptions exist: one marked for deletion, one active
+      cy.get(SUBSCRIPTIONS_TABLE_SELECTOR).find('tbody tr').should('have.length', 2);
+      cy.get(DISABLED_ROW_SELECTOR).should('have.length', 1);
+
+      // Mock the save API to verify request body
+      cy.intercept('POST', '/ops/pglogical_save_subscriptions/new?button=save', {
+        statusCode: 200,
+        body: { message: 'Replication settings save initiated' },
+      }).as('saveSubscriptions');
+
+      cy.contains('button', SAVE_BUTTON_TEXT).click();
+
+      // Verify the request body contains both subscriptions with correct flags
+      cy.wait('@saveSubscriptions').its('request.body').should((body) => {
+        expect(body.subscriptions).to.exist;
+        // First subscription (original) should be marked for removal
+        expect(body.subscriptions['0']).to.have.property('remove', true);
+        expect(body.subscriptions['0'].dbname).to.equal(MOCK_SAVED_SUBSCRIPTION.dbname);
+        // Second subscription (newly added) should not have remove flag
+        expect(body.subscriptions['1']).to.not.have.property('remove');
+        expect(body.subscriptions['1'].dbname).to.equal(TEST_DB_NAME);
+      });
+
+      cy.expect_flash(flashClassMap.success, FLASH_MESSAGE_SAVE_INITIATED);
+    });
+
+    it('Verify saving subscriptions to database', () => {
+      addSubscription();
+      saveReplicationForm();
+      cy.expect_flash(flashClassMap.success, FLASH_MESSAGE_SAVE_INITIATED);
+    });
+  });
+
+  describe('Verify Switching Replication Type', () => {
+    afterEach(() => {
+      cy.appDbState('restore');
+    });
+
+    it('Verify subscriptions are removed when switching replication type from global', () => {
+      addSubscription();
+      
+      cy.get(SUBSCRIPTIONS_TABLE_SELECTOR)
+        .find('table').find('tbody').find('tr')
+        .should('have.length', 1);
+
+      saveReplicationForm();
+
+      cy.getFormSelectFieldById({ selectId: REPLICATION_TYPE_SELECT_NAME }).select(REPLICATION_TYPE_REMOTE);
+      cy.expect_flash(flashClassMap.warning, FLASH_MESSAGE_SUBSCRIPTIONS_REMOVED);
+      saveReplicationForm();
+      cy.getFormSelectFieldById({ selectId: REPLICATION_TYPE_SELECT_NAME }).select(REPLICATION_TYPE_GLOBAL);
+
+      cy.get(SUBSCRIPTIONS_TABLE_SELECTOR)
+        .find('table').find('tbody').find('tr')
+        .should('have.length', 0);
+      });
   });
 });


### PR DESCRIPTION
- Change the Save button text in the subscription modal based on the action (add/update)
- Adds confirmation dialog for updating and deleting existing subscriptions
- Allows restoring subscriptions via “Cancel Delete” (after a delete action)
- Highlights subscriptions marked for deletion with a light red background

Missed including these in [this PR](https://github.com/ManageIQ/manageiq-ui-classic/pull/9388)

Previously (while deleting saved subscription)- 

<img width="1031" height="560" alt="Screenshot 2026-04-16 at 4 52 19 PM" src="https://github.com/user-attachments/assets/ecc96d6f-9fe5-452b-be30-80cb844f1bbd" />

<img width="939" height="459" alt="del old" src="https://github.com/user-attachments/assets/d418565f-1105-4aec-b6d7-292ef5b7a9ff" />

Now (while deleting saved subscription)- 

<img width="1318" height="564" alt="Screenshot 2026-04-23 at 5 05 06 PM" src="https://github.com/user-attachments/assets/cbbe3e36-2962-4bf3-ad2c-8df5d8aadf3f" />

<img width="991" height="404" alt="Screenshot 2026-04-20 at 6 44 48 PM" src="https://github.com/user-attachments/assets/a161817b-38ca-4d8c-882f-ece34f06af63" />


Previously (while updating saved subscription)- 

<img width="998" height="428" alt="Screenshot 2026-04-22 at 11 58 00 AM" src="https://github.com/user-attachments/assets/a205f502-8988-408a-aa6d-c86412ad3487" />

Now (while updating saved subscription)- 

<img width="1315" height="539" alt="Screenshot 2026-04-23 at 5 04 47 PM" src="https://github.com/user-attachments/assets/f2e5f7cb-4b9a-46da-8116-e520a655535a" />


<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
