### PR TITLE
Fix modal button enable

### DIFF
--- a/app/javascript/forms/miq-button.jsx
+++ b/app/javascript/forms/miq-button.jsx
@@ -37,6 +37,7 @@ function MiqButton(props) {
         onClick={buttonClicked}
         onKeyDown={buttonClicked}
         title={title}
+        disabled={!props.enabled}
       >
         {__(props.name)}
       </Button>
@@ -48,6 +49,7 @@ function MiqButton(props) {
       onClick={buttonClicked}
       onKeyDown={buttonClicked}
       title={title}
+      disabled={!props.enabled}
     >
       {__(props.name)}
     </Button>


### PR DESCRIPTION
Fixes an issue where the modal button is incorrectly enabled when it should be disabled.

Before:
<img width="833" height="463" alt="Screenshot 2026-04-20 at 12 31 43 PM" src="https://github.com/user-attachments/assets/1546566e-421c-417f-b617-49771f192963" />

After:
<img width="820" height="466" alt="Screenshot 2026-04-20 at 12 31 11 PM" src="https://github.com/user-attachments/assets/5d67a021-0628-47cf-8244-f6c9dbe497e1" />



