### PR TITLE
Skip yarn for plugins with no dependencies

### DIFF
--- a/lib/tasks/manageiq/ui_tasks.rake
+++ b/lib/tasks/manageiq/ui_tasks.rake
@@ -7,7 +7,16 @@ namespace :update do
           next
         end
         puts "== #{engine.name} =="
-        system("which yarn >/dev/null") || abort("\n== You have to install yarn ==")
+
+        # Check if package.json has any dependencies
+        package_json = JSON.parse(File.read('package.json'))
+        has_deps = package_json.key?('dependencies') || package_json.key?('devDependencies')
+
+        unless has_deps
+          puts "   Skipping: No dependencies in package.json"
+          next
+        end
+
         system("yarn") || abort("\n== yarn failed in #{engine.path} ==") # Add --immutable once s390x doesn't change the checksums.
       end
     end


### PR DESCRIPTION
PR to skip `yarn` step for plugins with no dependencies or devDependencies. In such cases, running Yarn doesn’t serve any purpose. As a follow-up, we can also remove yarn and engines from those plugins, reducing maintenance overhead and avoiding repeated upgrade PRs.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
