### PR TITLE
Fix image path resolution for packs

### DIFF
--- a/config/webpack/loaders.js
+++ b/config/webpack/loaders.js
@@ -65,6 +65,11 @@ module.exports = [
             if (url.startsWith('/upload/')) {
               return false;
             }
+            // Don't process absolute paths starting with /packs/ in production
+            // These will be resolved at runtime
+            if (url.startsWith('/packs/')) {
+              return false;
+            }
             return true;
           },
         },


### PR DESCRIPTION
Follow up to https://github.com/ManageIQ/manageiq-ui-classic/pull/9989

PR to fix `/packs/` path resolution when `NODE_ENV` is production

`NODE_ENV=production bin/webpack` will throw:
```
ERROR in ./app/stylesheet/legacy/main.scss (./node_modules/css-loader/dist/cjs.js??ref--9-1!./node_modules/postcss-loader/dist/cjs.js??ref--9-2!./node_modules/sass-loader/dist/cjs.js??ref--9-3!./app/stylesheet/legacy/main.scss)
Module build failed (from ./node_modules/css-loader/dist/cjs.js):
Error: Can't resolve '/packs/bg-login.png' in 'path/to/manageiq-ui-classic/app/stylesheet/legacy'
```

```
ERROR in ./app/stylesheet/legacy/main.scss (./node_modules/css-loader/dist/cjs.js??ref--9-1!./node_modules/postcss-loader/dist/cjs.js??ref--9-2!./node_modules/sass-loader/dist/cjs.js??ref--9-3!./app/stylesheet/legacy/main.scss)
Module build failed (from ./node_modules/css-loader/dist/cjs.js):
Error: Can't resolve '/packs/bg-modal-about-pf.png' in 'path/to/manageiq-ui-classic/app/stylesheet/legacy'
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
