### PR TITLE
Cleanup useless regular-expression character escape

### DIFF
--- a/app/javascript/components/fonticon-picker/icon-list.jsx
+++ b/app/javascript/components/fonticon-picker/icon-list.jsx
@@ -7,7 +7,7 @@ const isFontIcon = (value, family) => value.selectorText && value.selectorText.i
 
 const clearRule = (rule, family) => {
   // eslint-disable-next-line no-useless-escape
-  const re = new RegExp(`.*(${family}\-[a-z0-9\-\_]+).*`);
+  const re = new RegExp(`.*(${family}-[a-z0-9_-]+).*`);
   return rule.replace(re, '$1');
 };
 


### PR DESCRIPTION
@asirvadAbrahamVarghese These are triggering some low sev CodeQL issues because they are unnecessary.

Basically the same PR as https://github.com/ManageIQ/ui-components/pull/580, but on the ui-classic side (not sure why it's duplicated)