### PR TITLE
Drop unused method sanitize_output

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -138,20 +138,6 @@ class ServiceController < ApplicationController
     Service
   end
 
-  def sanitize_output(stdout)
-    htm = stdout.gsub('"', '\"')
-
-    regex_map = {
-      /\\'/ => "'",
-      /'/   => "\\\\'",
-      /{{/  => '\{\{',
-      /}}/  => '\}\}'
-    }
-    regex_map.each_pair { |f, t| htm.gsub!(f, t) }
-    htm
-  end
-  helper_method :sanitize_output
-
   def textual_group_list
     if @item && @item.kind_of?(GenericObject)
       [%i[go_properties attribute_details_list methods go_relationships]]

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -133,13 +133,6 @@ describe ServiceController do
     end
   end
 
-  describe "#sanitize_output" do
-    it "escapes characters in the output string" do
-      output = controller.send(:sanitize_output, "I'm \"\\'Fred\\'\" {{Flintstone}}")
-      expect(output).to eq("I\\'m \\\"\\'Fred\\'\\\" \\{\\{Flintstone\\}\\}")
-    end
-  end
-
   context "Generic Object instances in Textual Summary" do
     it "displays Generic Objects in Ansible Playbook Service Textual Summary" do
       record = FactoryBot.create(:service_ansible_playbook)


### PR DESCRIPTION
This method was last used in #2708. Originally added in #1369 to deal with angular/ansible incompatibility.

@elsamaryv Please review.