### PR TITLE
Ignore sass warnings from dependencies

### DIFF
--- a/config/webpack/loaders.js
+++ b/config/webpack/loaders.js
@@ -96,6 +96,8 @@ module.exports = [
               'node_modules',
             ],
             implementation: require('sass').default,
+            quietDeps: true, // TODO: Ignore patternfly and fontawesome sass warnings; remove this once we've removed those packages
+            silenceDeprecations: ["legacy-js-api"], // TODO: Ignore sass-loader warnings; remove those once we've upgraded sass-loader to v16+
           },
         },
       },


### PR DESCRIPTION
This drops a lot of output from the webpack build, which is not actionable. Specifically, we can't upgrade patternfly, so this removes all of the warnings related to patternfly.

@asirvadAbrahamVarghese Please review.

Before (includes patternfly warnings)
<img width="1459" height="936" alt="__dev_manageiq-ui-classic" src="https://github.com/user-attachments/assets/0a4f4e4f-87c7-4b5c-bc6c-a19c589bb96b" />

After (does not include patternfly warnings)
<img width="1333" height="936" alt="__dev_manageiq-ui-classic" src="https://github.com/user-attachments/assets/ae29e784-610a-4634-bb1d-391c7fd5ed42" />

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
