### PR TITLE
Fix sass warnings

### DIFF
--- a/app/stylesheet/legacy/login.scss
+++ b/app/stylesheet/legacy/login.scss
@@ -84,7 +84,7 @@ div#saml-login {
 
     .details {
       p:first-child {
-        border-top: 1px solid rgba($color-pf-white, (30 * 0.01));
+        border-top: 1px solid rgba($color-pf-white, 0.3);
         padding-top: 25px;
         margin-top: 25px;
       }
@@ -96,7 +96,7 @@ div#saml-login {
           margin-top: 0;
         }
 
-        border-left: 1px solid rgba($color-pf-white, (30 * 0.01));
+        border-left: 1px solid rgba($color-pf-white, 0.3);
         padding-left: 40px;
       }
 

--- a/app/stylesheet/legacy/login.scss
+++ b/app/stylesheet/legacy/login.scss
@@ -82,7 +82,7 @@ div#saml-login {
 
     .details {
       p:first-child {
-        border-top: 1px solid rgba($color-pf-white, (30/100));
+        border-top: 1px solid rgba($color-pf-white, (30 * 0.01));
         padding-top: 25px;
         margin-top: 25px;
       }
@@ -94,7 +94,7 @@ div#saml-login {
           margin-top: 0;
         }
 
-        border-left: 1px solid rgba($color-pf-white, (30/100));
+        border-left: 1px solid rgba($color-pf-white, (30 * 0.01));
         padding-left: 40px;
       }
 

--- a/app/stylesheet/legacy/login.scss
+++ b/app/stylesheet/legacy/login.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .login-pf body {
   padding-bottom: 0 !important;
   padding-top: 0 !important;
@@ -183,7 +185,7 @@ div#saml-login {
   }
 
   .form-control {
-    height: ceil(($input-height-base + 10px ));
+    height: math.ceil($input-height-base + 10px);
   }
 
   .checkbox-label {
@@ -246,7 +248,7 @@ div#saml-login {
 
   .login-pf-signup {
     margin: $login-pf-signup-margin-top 0 0;
-    font-size: ceil(($font-size-base * 1.25));
+    font-size: math.ceil($font-size-base * 1.25);
     text-align: center;
 
     a {
@@ -352,7 +354,7 @@ div#saml-login {
       }
 
       &:last-of-type {
-        padding-left: ceil(($login-pf-accounts-section-heading-desktop-padding-left - 1px));
+        padding-left: math.ceil($login-pf-accounts-section-heading-desktop-padding-left - 1px);
         border-left: 1px solid $color-pf-black-300;
       }
     }

--- a/app/stylesheet/legacy/patternfly_overrides.scss
+++ b/app/stylesheet/legacy/patternfly_overrides.scss
@@ -102,7 +102,7 @@ body#dashboard .blank-slate-pf {
       margin-right: 0;
       min-width: ($font-size-base * 2 + 2); // 26px
       position: absolute;
-      left: ($grid-gutter-width / 2);
+      left: ($grid-gutter-width * 0.5);
       text-align: center;
       top: 15px;
     }

--- a/app/stylesheet/legacy/piecharts.scss
+++ b/app/stylesheet/legacy/piecharts.scss
@@ -26,7 +26,7 @@
 
   @for $i from 0 through 10 {
     &.fill-#{$i}::before {
-      transform: rotate(#{$i / 20}turn);
+      transform: rotate(#{$i * 0.05}turn);
     }
   }
 
@@ -34,7 +34,7 @@
     &.fill-#{$i} {
       &::before {
         background: $chart-fill;
-        transform: rotate(#{($i - 10) / 20}turn);
+        transform: rotate(#{($i - 10) * 0.05}turn);
       }
 
       &.invert::before {

--- a/app/stylesheet/legacy/variables.scss
+++ b/app/stylesheet/legacy/variables.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 //bootstrap variables
 
 //
@@ -9,13 +11,13 @@
 //## Gray and brand colors for use across Bootstrap.
 
 $gray-base:              #000;
-$gray-darker:            lighten($gray-base, 13.5%); // #222
-$gray-dark:              lighten($gray-base, 20%);   // #333
-$gray:                   lighten($gray-base, 33.5%); // #555
-$gray-light:             lighten($gray-base, 46.7%); // #777
-$gray-lighter:           lighten($gray-base, 93.5%); // #eee
+$gray-darker:            color.adjust($gray-base, $lightness: 13.5%, $space: hsl); // #222
+$gray-dark:              color.adjust($gray-base, $lightness: 20%, $space: hsl);   // #333
+$gray:                   color.adjust($gray-base, $lightness: 33.5%, $space: hsl); // #555
+$gray-light:             color.adjust($gray-base, $lightness: 46.7%, $space: hsl); // #777
+$gray-lighter:           color.adjust($gray-base, $lightness: 93.5%, $space: hsl); // #eee
 
-$brand-primary:         darken(#428bca, 6.5%); // #337ab7
+$brand-primary:         color.adjust(#428bca, $lightness: -6.5%, $space: hsl); // #337ab7
 $brand-success:         #5cb85c;
 $brand-info:            #5bc0de;
 $brand-warning:         #f0ad4e;
@@ -33,7 +35,7 @@ $text-color:            $gray-dark;
 //** Global textual link color.
 $link-color:            $brand-primary;
 //** Link hover color set via `darken()` function.
-$link-hover-color:      darken($link-color, 15%);
+$link-hover-color:      color.adjust($link-color, $lightness: -15%, $space: hsl);
 //** Link hover decoration.
 $link-hover-decoration: underline;
 
@@ -153,23 +155,23 @@ $btn-default-border:             #ccc;
 
 $btn-primary-color:              #fff;
 $btn-primary-bg:                 $brand-primary;
-$btn-primary-border:             darken($btn-primary-bg, 5%);
+$btn-primary-border:             color.adjust($btn-primary-bg, $lightness: -5%, $space: hsl);
 
 $btn-success-color:              #fff;
 $btn-success-bg:                 $brand-success;
-$btn-success-border:             darken($btn-success-bg, 5%);
+$btn-success-border:             color.adjust($btn-success-bg, $lightness: -5%, $space: hsl);
 
 $btn-info-color:                 #fff;
 $btn-info-bg:                    $brand-info;
-$btn-info-border:                darken($btn-info-bg, 5%);
+$btn-info-border:                color.adjust($btn-info-bg, $lightness: -5%, $space: hsl);
 
 $btn-warning-color:              #fff;
 $btn-warning-bg:                 $brand-warning;
-$btn-warning-border:             darken($btn-warning-bg, 5%);
+$btn-warning-border:             color.adjust($btn-warning-bg, $lightness: -5%, $space: hsl);
 
 $btn-danger-color:               #fff;
 $btn-danger-bg:                  $brand-danger;
-$btn-danger-border:              darken($btn-danger-bg, 5%);
+$btn-danger-border:              color.adjust($btn-danger-bg, $lightness: -5%, $space: hsl);
 
 $btn-link-disabled-color:        $gray-light;
 
@@ -244,7 +246,7 @@ $dropdown-divider-bg:            #e5e5e5;
 //** Dropdown link text color.
 $dropdown-link-color:            $gray-dark;
 //** Hover color for dropdown links.
-$dropdown-link-hover-color:      darken($gray-dark, 5%);
+$dropdown-link-hover-color:      color.adjust($gray-dark, $lightness: -5%, $space: hsl);
 //** Hover background for dropdown links.
 $dropdown-link-hover-bg:         #f5f5f5;
 
@@ -362,20 +364,20 @@ $navbar-collapse-max-height:       340px;
 
 $navbar-default-color:             #777;
 $navbar-default-bg:                #f8f8f8;
-$navbar-default-border:            darken($navbar-default-bg, 6.5%);
+$navbar-default-border:            color.adjust($navbar-default-bg, $lightness: -6.5%, $space: hsl);
 
 // Navbar links
 $navbar-default-link-color:                #777;
 $navbar-default-link-hover-color:          #333;
 $navbar-default-link-hover-bg:             transparent;
 $navbar-default-link-active-color:         #555;
-$navbar-default-link-active-bg:            darken($navbar-default-bg, 6.5%);
+$navbar-default-link-active-bg:            color.adjust($navbar-default-bg, $lightness: -6.5%, $space: hsl);
 $navbar-default-link-disabled-color:       #ccc;
 $navbar-default-link-disabled-bg:          transparent;
 
 // Navbar brand label
 $navbar-default-brand-color:               $navbar-default-link-color;
-$navbar-default-brand-hover-color:         darken($navbar-default-brand-color, 10%);
+$navbar-default-brand-hover-color:         color.adjust($navbar-default-brand-color, $lightness: -10%, $space: hsl);
 $navbar-default-brand-hover-bg:            transparent;
 
 // Navbar toggle
@@ -385,16 +387,16 @@ $navbar-default-toggle-border-color:       #ddd;
 
 //=== Inverted navbar
 // Reset inverted navbar basics
-$navbar-inverse-color:                      lighten($gray-light, 15%);
+$navbar-inverse-color:                      color.adjust($gray-light, $lightness: 15%, $space: hsl);
 $navbar-inverse-bg:                         #222;
-$navbar-inverse-border:                     darken($navbar-inverse-bg, 10%);
+$navbar-inverse-border:                     color.adjust($navbar-inverse-bg, $lightness: -10%, $space: hsl);
 
 // Inverted navbar links
-$navbar-inverse-link-color:                 lighten($gray-light, 15%);
+$navbar-inverse-link-color:                 color.adjust($gray-light, $lightness: 15%, $space: hsl);
 $navbar-inverse-link-hover-color:           #fff;
 $navbar-inverse-link-hover-bg:              transparent;
 $navbar-inverse-link-active-color:          $navbar-inverse-link-hover-color;
-$navbar-inverse-link-active-bg:             darken($navbar-inverse-bg, 10%);
+$navbar-inverse-link-active-bg:             color.adjust($navbar-inverse-bg, $lightness: -10%, $space: hsl);
 $navbar-inverse-link-disabled-color:        #444;
 $navbar-inverse-link-disabled-bg:           transparent;
 
@@ -533,7 +535,7 @@ $popover-border-color:                rgba(0, 0, 0, 0.2);
 $popover-fallback-border-color:       #ccc;
 
 //** Popover title background color
-$popover-title-bg:                    darken($popover-bg, 3%);
+$popover-title-bg:                    color.adjust($popover-bg, $lightness: -3%, $space: hsl);
 
 //** Popover arrow width
 $popover-arrow-width:                 10px;
@@ -545,7 +547,7 @@ $popover-arrow-outer-width:           ($popover-arrow-width + 1);
 //** Popover outer arrow color
 $popover-arrow-outer-color:           fadein($popover-border-color, 5%);
 //** Popover outer arrow fallback color
-$popover-arrow-outer-fallback-color:  darken($popover-fallback-border-color, 20%);
+$popover-arrow-outer-fallback-color:  color.adjust($popover-fallback-border-color, $lightness: -20%, $space: hsl);
 
 //== Labels
 //
@@ -667,7 +669,7 @@ $list-group-active-bg:          $component-active-bg;
 //** Border color of active list elements
 $list-group-active-border:      $list-group-active-bg;
 //** Text color for content within active list items
-$list-group-active-text-color:  lighten($list-group-active-bg, 40%);
+$list-group-active-text-color:  color.adjust($list-group-active-bg, $lightness: 40%, $space: hsl);
 
 //** Text color of disabled list items
 $list-group-disabled-color:      $gray-light;
@@ -741,7 +743,7 @@ $thumbnail-caption-padding:   9px;
 //##
 
 $well-bg:                     #f5f5f5;
-$well-border:                 darken($well-bg, 7%);
+$well-border:                 color.adjust($well-bg, $lightness: -7%, $space: hsl);
 
 //== Badges
 //

--- a/app/stylesheet/legacy/variables.scss
+++ b/app/stylesheet/legacy/variables.scss
@@ -356,8 +356,8 @@ $container-lg:                 $container-large-desktop;
 $navbar-height:                    50px;
 $navbar-margin-bottom:             $line-height-computed;
 $navbar-border-radius:             $border-radius-base;
-$navbar-padding-horizontal:        floor(($grid-gutter-width / 2));
-$navbar-padding-vertical:          (($navbar-height - $line-height-computed) / 2);
+$navbar-padding-horizontal:        floor(($grid-gutter-width * 0.5));
+$navbar-padding-vertical:          (($navbar-height - $line-height-computed) * 0.5);
 $navbar-collapse-max-height:       340px;
 
 $navbar-default-color:             #777;

--- a/app/stylesheet/legacy/variables.scss
+++ b/app/stylesheet/legacy/variables.scss
@@ -1,4 +1,5 @@
 @use "sass:color";
+@use "sass:math";
 
 //bootstrap variables
 
@@ -50,20 +51,20 @@ $font-family-monospace:   menlo, monaco, consolas, "Courier New", monospace;
 $font-family-base:        $font-family-sans-serif;
 
 $font-size-base:          14px;
-$font-size-large:         ceil(($font-size-base * 1.25)); // ~18px
-$font-size-small:         ceil(($font-size-base * 0.85)); // ~12px
+$font-size-large:         math.ceil($font-size-base * 1.25); // ~18px
+$font-size-small:         math.ceil($font-size-base * 0.85); // ~12px
 
-$font-size-h1:            floor(($font-size-base * 2.6)); // ~36px
-$font-size-h2:            floor(($font-size-base * 2.15)); // ~30px
-$font-size-h3:            ceil(($font-size-base * 1.7)); // ~24px
-$font-size-h4:            ceil(($font-size-base * 1.25)); // ~18px
+$font-size-h1:            math.floor($font-size-base * 2.6); // ~36px
+$font-size-h2:            math.floor($font-size-base * 2.15); // ~30px
+$font-size-h3:            math.ceil($font-size-base * 1.7); // ~24px
+$font-size-h4:            math.ceil($font-size-base * 1.25); // ~18px
 $font-size-h5:            $font-size-base;
-$font-size-h6:            ceil(($font-size-base * 0.85)); // ~12px
+$font-size-h6:            math.ceil($font-size-base * 0.85); // ~12px
 
 //** Unit-less `line-height` for use in components like buttons.
 $line-height-base:        1.428571429; // 20/14
 //** Computed "line-height" (`font-size` * `line-height`) for use with `margin`, `padding`, etc.
-$line-height-computed:    floor(($font-size-base * $line-height-base)); // ~20px
+$line-height-computed:    math.floor($font-size-base * $line-height-base); // ~20px
 
 //** By default, this inherits from the `<body>`.
 $headings-font-family:    inherit;
@@ -212,9 +213,9 @@ $input-color-placeholder:        #999;
 //** Default `.form-control` height
 $input-height-base:              ($line-height-computed + ($padding-base-vertical * 2) + 2);
 //** Large `.form-control` height
-$input-height-large:             (ceil($font-size-large * $line-height-large) + ($padding-large-vertical * 2) + 2);
+$input-height-large:             (math.ceil($font-size-large * $line-height-large) + ($padding-large-vertical * 2) + 2);
 //** Small `.form-control` height
-$input-height-small:             (floor($font-size-small * $line-height-small) + ($padding-small-vertical * 2) + 2);
+$input-height-small:             (math.floor($font-size-small * $line-height-small) + ($padding-small-vertical * 2) + 2);
 
 //** `.form-group` margin
 $form-group-margin-bottom:       15px;
@@ -358,7 +359,7 @@ $container-lg:                 $container-large-desktop;
 $navbar-height:                    50px;
 $navbar-margin-bottom:             $line-height-computed;
 $navbar-border-radius:             $border-radius-base;
-$navbar-padding-horizontal:        floor(($grid-gutter-width * 0.5));
+$navbar-padding-horizontal:        math.floor($grid-gutter-width * 0.5);
 $navbar-padding-vertical:          (($navbar-height - $line-height-computed) * 0.5);
 $navbar-collapse-max-height:       340px;
 
@@ -481,8 +482,8 @@ $jumbotron-padding:              30px;
 $jumbotron-color:                inherit;
 $jumbotron-bg:                   $gray-lighter;
 $jumbotron-heading-color:        inherit;
-$jumbotron-font-size:            ceil(($font-size-base * 1.5));
-$jumbotron-heading-font-size:    ceil(($font-size-base * 4.5));
+$jumbotron-font-size:            math.ceil($font-size-base * 1.5);
+$jumbotron-heading-font-size:    math.ceil($font-size-base * 4.5);
 
 //== Form states and alerts
 //


### PR DESCRIPTION
@asirvadAbrahamVarghese Please review.

This fixes a number of sass warnings in our own code, namely:

- Fix slash-div warnings regarding deprecation of division (This commit was implemented via the sass-migrator tool.)
- Fix color-functions warnings regarding deprecation of color functions (This commit was implemented via the sass-migrator tool.)
- Fix global-builtin warnings regarding math functions ceil/floor

After this PR the only warnings in our code are `import` warnings, which are more complex.