### PR TITLE
Fix publicPath for file-loader

### DIFF
--- a/config/webpack/loaders.js
+++ b/config/webpack/loaders.js
@@ -1,6 +1,6 @@
 const { merge } = require('webpack-merge');
 
-const { env, publicPath } = require('./configuration.js');
+const { env, output } = require('./configuration.js');
 const babelrc = require('../../.babelrc.js');
 const nodeModules = '../../node_modules';
 const appBasePath = (env.NODE_ENV === 'production') ? '/packs/' : '../../assets/images/layout/';// Need different paths for developement and prod envs.
@@ -46,7 +46,7 @@ module.exports = [
     use: [{
       loader: 'file-loader',
       options: {
-        publicPath,
+        publicPath: output.publicPath,
         name: '[name]-[hash].[ext]',
       },
     }],


### PR DESCRIPTION
[configuration](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/config/webpack/configuration.js) doesn’t export a `publicPath` variable, it exports `output` object, and thats where `publicPath` lives, so we should import `output` directly

Note: this wasn’t breaking so far because `publicPath` defaults to [__webpack_public_path__](https://webpack.js.org/api/module-variables/#__webpack_public_path__-webpack-specific) - [see](https://www.npmjs.com/package/file-loader#publicpath), which already maps to `output.publicPath` from [shared config](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/config/webpack/shared.js#L132)
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
