### PR TITLE
Remove eslint-disable for no-unused-vars

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -175,8 +175,10 @@
       "args": "after-used",
       "argsIgnorePattern": "^_",
       "vars": "local",
+      "varsIgnorePattern": "^_",
       "caughtErrors": "all",
-      "caughtErrorsIgnorePattern": "^_"
+      "caughtErrorsIgnorePattern": "^_",
+      "ignoreRestSiblings": true
     }],
     "no-alert": 2,
     "no-debugger": 2,

--- a/app/javascript/.eslintrc.json
+++ b/app/javascript/.eslintrc.json
@@ -56,8 +56,10 @@
       "args": "after-used",
       "argsIgnorePattern": "^_",
       "vars": "local",
+      "varsIgnorePattern": "^_",
       "caughtErrors": "all",
-      "caughtErrorsIgnorePattern": "^_"
+      "caughtErrorsIgnorePattern": "^_",
+      "ignoreRestSiblings": true
     }],
     "no-use-before-define": ["error", {
       "functions": false,

--- a/app/javascript/components/create-report-chart-form/index.jsx
+++ b/app/javascript/components/create-report-chart-form/index.jsx
@@ -6,8 +6,7 @@ import {
 } from '../carbon-charts';
 import { sampleData, pieData } from '../carbon-charts/helpers';
 
-// eslint-disable-next-line no-unused-vars
-const ReportChartWidget = ({ data, id }) => {
+const ReportChartWidget = ({ data, _id }) => {
   if (data.miqChart === 'Area') {
     return (<AreaChartGraph data={sampleData} />);
   }
@@ -40,12 +39,12 @@ const ReportChartWidget = ({ data, id }) => {
 
 ReportChartWidget.propTypes = {
   data: PropTypes.objectOf(PropTypes.any),
-  id: PropTypes.string,
+  _id: PropTypes.string,
 };
 
 ReportChartWidget.defaultProps = {
   data: null,
-  id: null,
+  _id: null,
 };
 
 export default ReportChartWidget;

--- a/app/javascript/components/dashboard-widgets/dashboard-charts/index.jsx
+++ b/app/javascript/components/dashboard-widgets/dashboard-charts/index.jsx
@@ -7,8 +7,7 @@ import {
 import { getConvertedData } from '../../carbon-charts/helpers';
 import EmptyChart from './emptyChart';
 
-// eslint-disable-next-line no-unused-vars
-const DashboardWidget = ({ data, id, title }) => {
+const DashboardWidget = ({ data, _id, title }) => {
   const convertedData = getConvertedData(data);
   let showLegend = true;
   const nameTable = data.miq.name_table;
@@ -55,13 +54,13 @@ const DashboardWidget = ({ data, id, title }) => {
 
 DashboardWidget.propTypes = {
   data: PropTypes.objectOf(PropTypes.any),
-  id: PropTypes.string,
+  _id: PropTypes.string,
   title: PropTypes.string,
 };
 
 DashboardWidget.defaultProps = {
   data: null,
-  id: null,
+  _id: null,
   title: null,
 };
 

--- a/app/javascript/components/embedded-terraform-credential-mapping-form/embedded-terraform-credential-mapping-form.schema.js
+++ b/app/javascript/components/embedded-terraform-credential-mapping-form/embedded-terraform-credential-mapping-form.schema.js
@@ -29,7 +29,6 @@ const createSchema = (credentials, credentialReferences, payloadCredentials, wor
   const deleteMapping = (selectedRow, cellType, formOptions) => {
     if (cellType === 'buttonCallback' && credentials[selectedRow.cells[0].value]) {
       // This is creating a new credentials object without the mapping we're trying to delete
-      // eslint-disable-next-line no-unused-vars
       const { [selectedRow.cells[0].value]: _, ...newCredentials } = credentials;
       setState((state) => ({
         ...state,

--- a/app/javascript/components/performance-charts/index.jsx
+++ b/app/javascript/components/performance-charts/index.jsx
@@ -7,8 +7,7 @@ import { getConvertedData, getLineConvertedData } from '../carbon-charts/helpers
 import EmptyChart from '../dashboard-widgets/dashboard-charts/emptyChart';
 
 const PerformanceChartWidget = ({
-  // eslint-disable-next-line no-unused-vars
-  data, id, size, title,
+  data, _id, size, title,
 }) => {
   let convertedData = getLineConvertedData(data);
   if (data.miq && data.miq.empty) {
@@ -26,14 +25,14 @@ const PerformanceChartWidget = ({
 
 PerformanceChartWidget.propTypes = {
   data: PropTypes.instanceOf(Object),
-  id: PropTypes.string,
+  _id: PropTypes.string,
   size: PropTypes.string,
   title: PropTypes.string,
 };
 
 PerformanceChartWidget.defaultProps = {
   data: null,
-  id: null,
+  _id: null,
   size: '400px',
   title: '',
 };

--- a/app/javascript/components/provider-form/detect-button.jsx
+++ b/app/javascript/components/provider-form/detect-button.jsx
@@ -3,13 +3,11 @@ import React from 'react';
 import { componentTypes, useFormApi } from '@@ddf';
 import componentMapper from '../../forms/mappers/componentMapper';
 
-// eslint-disable-next-line no-unused-vars
-const Component = componentMapper[componentTypes.BUTTON];
+const _Component = componentMapper[componentTypes.BUTTON];
 
-// eslint-disable-next-line no-unused-vars, react/prop-types
-const DetectButton = ({ dependencies, target, ...props }) => {
-  // eslint-disable-next-line no-unused-vars
-  const formOptions = useFormApi();
+// eslint-disable-next-line react/prop-types
+const DetectButton = ({ dependencies: _dependencies, target: _target, ..._props }) => {
+  const _formOptions = useFormApi();
   return <span />;
 
   // const onClick = () => {

--- a/app/javascript/components/quadicon/Quadicon.jsx
+++ b/app/javascript/components/quadicon/Quadicon.jsx
@@ -7,7 +7,6 @@ import Quaditem from './Quaditem';
 const quadSet = ['topLeft', 'topRight', 'bottomLeft', 'bottomRight', 'middle'];
 
 const renderSingle = (item) => {
-  // eslint-disable-next-line no-unused-vars
   const { className: _className, ...rest } = item;
   return (
     <div className="single-wrapper">
@@ -19,7 +18,6 @@ const renderSingle = (item) => {
 const renderQuad = (data) => (
   <div className="quad-wrapper">
     {quadSet.filter((key) => data[key]).map((item) => {
-      // eslint-disable-next-line no-unused-vars
       const { className: _className, ...rest } = data[item];
       return (<Quaditem key={item} className={kebabCase(item)} {...rest} />);
     })}

--- a/app/javascript/components/quadicon/Quadicon.jsx
+++ b/app/javascript/components/quadicon/Quadicon.jsx
@@ -7,7 +7,7 @@ import Quaditem from './Quaditem';
 const quadSet = ['topLeft', 'topRight', 'bottomLeft', 'bottomRight', 'middle'];
 
 const renderSingle = (item) => {
-  const { className: _className, ...rest } = item;
+  const { className, ...rest } = item;
   return (
     <div className="single-wrapper">
       <Quaditem {...rest} />
@@ -18,7 +18,7 @@ const renderSingle = (item) => {
 const renderQuad = (data) => (
   <div className="quad-wrapper">
     {quadSet.filter((key) => data[key]).map((item) => {
-      const { className: _className, ...rest } = data[item];
+      const { className, ...rest } = data[item];
       return (<Quaditem key={item} className={kebabCase(item)} {...rest} />);
     })}
   </div>

--- a/app/javascript/components/remove-generic-item-modal.jsx
+++ b/app/javascript/components/remove-generic-item-modal.jsx
@@ -37,8 +37,6 @@ export const removeItems = (items, force, {
   ajaxReload, apiUrl, asyncDelete, redirectUrl, treeSelect,
 }) => {
   const apiPromises = [];
-  // eslint-disable-next-line no-unused-vars
-  const flashArray = [];
   const deleteMessage = asyncDelete ? __('Deletion of item %s has been successfully initiated') : __('The item "%s" has been successfully deleted');
 
   miqSparkleOn();
@@ -211,8 +209,7 @@ class RemoveGenericItemModal extends React.Component {
               type="checkbox"
               id="forceCheckbox"
               checked={force}
-              // eslint-disable-next-line no-unused-vars
-              onChange={(ev) => {
+              onChange={(_ev) => {
                 this.setState({
                   force: !force,
                 });

--- a/app/javascript/components/remove-generic-item-modal.jsx
+++ b/app/javascript/components/remove-generic-item-modal.jsx
@@ -209,7 +209,7 @@ class RemoveGenericItemModal extends React.Component {
               type="checkbox"
               id="forceCheckbox"
               checked={force}
-              onChange={(_ev) => {
+              onChange={() => {
                 this.setState({
                   force: !force,
                 });

--- a/app/javascript/components/settings-replication-form/index.jsx
+++ b/app/javascript/components/settings-replication-form/index.jsx
@@ -15,7 +15,6 @@ const SettingsReplicationForm = ({ pglogicalReplicationFormId }) => {
   const [{
     subscriptions, form, replicationHelperText, helperTextType,
     isLoading, replicationType, selectedRowId, selectedSubscription, isSubscriptionModified,
-    // eslint-disable-next-line no-unused-vars
     savedSubscriptions, savedReplicationType,
   }, setState] = useState(
     {

--- a/app/javascript/components/toolbar/ToolbarKebab.jsx
+++ b/app/javascript/components/toolbar/ToolbarKebab.jsx
@@ -53,8 +53,7 @@ KebabListItem.defaultProps = {
   item: null,
 };
 
-// eslint-disable-next-line no-unused-vars
-export const DropDownMenu = forwardRef((props, ref) => (
+export const DropDownMenu = forwardRef((props, _ref) => (
   <SideNavItems className="button_groups">
     {props.items.map((item) => KebabListItem(item, props))}
   </SideNavItems>

--- a/app/javascript/components/workflow-credential-mapping-form/workflow-credential-mapping-form.schema.js
+++ b/app/javascript/components/workflow-credential-mapping-form/workflow-credential-mapping-form.schema.js
@@ -29,7 +29,6 @@ const createSchema = (credentials, credentialReferences, payloadCredentials, wor
   const deleteMapping = (selectedRow, cellType, formOptions) => {
     if (cellType === 'buttonCallback' && credentials[selectedRow.cells[0].value]) {
       // This is creating a new credentials object without the mapping we're trying to delete
-      // eslint-disable-next-line no-unused-vars
       const { [selectedRow.cells[0].value]: _, ...newCredentials } = credentials;
       setState((state) => ({
         ...state,

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -23,7 +23,7 @@ module.exports = defineConfig({
       openMode: false,
       runMode: true,
     },
-    setupNodeEvents(_on, _config) {
+    setupNodeEvents(on, _config) {
       // Check for Cypress build marker
       const markerPath = path.resolve(__dirname, 'tmp/.cypress-build-marker');
       if (!fs.existsSync(markerPath)) {

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -23,8 +23,7 @@ module.exports = defineConfig({
       openMode: false,
       runMode: true,
     },
-    // eslint-disable-next-line no-unused-vars
-    setupNodeEvents(on, config) {
+    setupNodeEvents(_on, _config) {
       // Check for Cypress build marker
       const markerPath = path.resolve(__dirname, 'tmp/.cypress-build-marker');
       if (!fs.existsSync(markerPath)) {


### PR DESCRIPTION
Added ESLint rules `varsIgnorePattern: "^_"` and `ignoreRestSiblings: true`. Removed eslint-disable comments for `no-unused-vars`. Variables are now prefixed with underscore or use rest siblings pattern instead of suppressing linting errors.

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
