### PR TITLE
Pin uuid to v14

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
     "path-to-regexp": "~8.4.0",
     "patternfly": "~3.59.5",
     "request": "npm:@cypress/request@^3.0.9",
-    "tar": "~7.5.13"
+    "tar": "~7.5.13",
+    "uuid": "~14.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17423,12 +17423,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.3.0, uuid@npm:^8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
+"uuid@npm:~14.0.0":
+  version: 14.0.0
+  resolution: "uuid@npm:14.0.0"
   bin:
-    uuid: dist/bin/uuid
-  checksum: 10/9a5f7aa1d6f56dd1e8d5f2478f855f25c645e64e26e347a98e98d95781d5ed20062d6cca2eecb58ba7c84bc3910be95c0451ef4161906abaab44f9cb68ffbdd1
+    uuid: dist-node/bin/uuid
+  checksum: 10/8ee9b98f9650e25555515f7a28d3c3ae9364e72f7bb19b9e08b681bc135338beba5509b2830f6ae1cfaba4d45401da0d16d4d109b977097bc3d6ba0c5583341b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
```
cypress
└─ @cypress/request@npm:3.0.10
   └─ uuid@npm:8.3.2 (via npm:^8.3.2)

jest
└─ node-notifier@npm:8.0.2
   └─ uuid@npm:8.3.2 (via npm:^8.3.0)

webpack-dev-server
└─ sockjs@npm:0.3.24
   └─ uuid@npm:8.3.2 (via npm:^8.3.2)
```

 - `cypress` -> `@cypress/request` -> `uuid`
 
 `cy.request` seems to work fine with `uuid@14`, we use `cy.request` to trigger factory methods from Cypress

 There are open issues in Cypress to bump `uuid` and to move away from `@cypress/request`, which is a fork of the deprecated `request/request`

 - `jest` -> `@jest/core` -> `@jest/reporters` -> `node-notifier` -> `uuid`
 
`node-notifier` via `@jest/reporters` is looking fine, this module format and display test results in terminal.

Note that Jest v30 doesn’t use `node-modifier`, so once we bump Jest to the latest version (post RTL), this resolution won't affect Jest

 - `webpack-dev-server` -> `sockjs` -> `uuid`
 
This shouldn’t have any impact right now since it’s not really functioning due to the incompatibility with webpack and webpack-cli v4. We can probably remove dev-server for now (still under discussion).
If we do keep it, there are open issues in `sockjs` to bump `uuid` to the latest, which would be the ideal fix
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
