### PR TITLE
Replace elliptic package with @noble/curves

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
     "angular-sanitize": "~1.8.3",
     "bootstrap-select": "~1.13.18",
     "cheerio": "1.0.0-rc.12",
+    "elliptic": "npm:@soatok/elliptic-to-noble@9999.0.0",
     "get-intrinsic": "<=1.3.0",
     "lodash": "~4.18.0",
     "moment-timezone": "~0.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2493,10 +2493,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/curves@npm:^2.0.1":
+  version: 2.2.0
+  resolution: "@noble/curves@npm:2.2.0"
+  dependencies:
+    "@noble/hashes": "npm:2.2.0"
+  checksum: 10/f9545e55bb8b6cdf2618c936870b9229339c90b25f129fc368b4b534e723f274e5c0daf8abca2f891bcf0a59c3b49c5ac5205899aec07f5251f545ec616e3aa9
+  languageName: node
+  linkType: hard
+
 "@noble/hashes@npm:1.4.0":
   version: 1.4.0
   resolution: "@noble/hashes@npm:1.4.0"
   checksum: 10/e156e65794c473794c52fa9d06baf1eb20903d0d96719530f523cc4450f6c721a957c544796e6efd0197b2296e7cd70efeb312f861465e17940a3e3c7e0febc6
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@noble/hashes@npm:2.2.0"
+  checksum: 10/b1b78bedc2a01394be047429f3d888905015fe8a09f1b7e43e0b5736b54133df62f73dcc73ede43af38e96e86156afb45b86973fdeaa95d9f0880333c3fc0907
   languageName: node
   linkType: hard
 
@@ -5304,7 +5320,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bn.js@npm:^4.0.0, bn.js@npm:^4.1.0, bn.js@npm:^4.11.9":
+"bn.js@npm:^4.0.0, bn.js@npm:^4.1.0":
   version: 4.12.3
   resolution: "bn.js@npm:4.12.3"
   checksum: 10/57ed5a055f946f3e009f1589c45a5242db07f3dddfc72e4506f0dd9d8b145f0dbee4edabc2499288f3fc338eb712fb96a1c623a2ed2bcd49781df1a64db64dd1
@@ -5490,7 +5506,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brorand@npm:^1.0.1, brorand@npm:^1.1.0":
+"brorand@npm:^1.0.1":
   version: 1.1.0
   resolution: "brorand@npm:1.1.0"
   checksum: 10/8a05c9f3c4b46572dec6ef71012b1946db6cae8c7bb60ccd4b7dd5a84655db49fe043ecc6272e7ef1f69dc53d6730b9e2a3a03a8310509a3d797a618cbee52be
@@ -7745,18 +7761,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elliptic@npm:^6.5.3, elliptic@npm:^6.6.1":
-  version: 6.6.1
-  resolution: "elliptic@npm:6.6.1"
+"elliptic@npm:@soatok/elliptic-to-noble@9999.0.0":
+  version: 9999.0.0
+  resolution: "@soatok/elliptic-to-noble@npm:9999.0.0"
   dependencies:
-    bn.js: "npm:^4.11.9"
-    brorand: "npm:^1.1.0"
-    hash.js: "npm:^1.0.0"
-    hmac-drbg: "npm:^1.0.1"
-    inherits: "npm:^2.0.4"
-    minimalistic-assert: "npm:^1.0.1"
-    minimalistic-crypto-utils: "npm:^1.0.1"
-  checksum: 10/dc678c9febd89a219c4008ba3a9abb82237be853d9fd171cd602c8fb5ec39927e65c6b5e7a1b2a4ea82ee8e0ded72275e7932bb2da04a5790c2638b818e4e1c5
+    "@noble/curves": "npm:^2.0.1"
+  checksum: 10/83d124d297719dfd16955b07e2b9d7df063b3e6554dbbe0c22e5fd3c8760bf351199af765e846abe4e706d646aefea50dc3a2dd02f63a7a5bf383bd03463aee3
   languageName: node
   linkType: hard
 
@@ -9731,16 +9741,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hash.js@npm:^1.0.0, hash.js@npm:^1.0.3":
-  version: 1.1.7
-  resolution: "hash.js@npm:1.1.7"
-  dependencies:
-    inherits: "npm:^2.0.3"
-    minimalistic-assert: "npm:^1.0.1"
-  checksum: 10/0c89ee4006606a40f92df5cc3c263342e7fea68110f3e9ef032bd2083650430505db01b6b7926953489517d4027535e4fdc7f970412893d3031c361d3ec8f4b3
-  languageName: node
-  linkType: hard
-
 "hasha@npm:5.2.2":
   version: 5.2.2
   resolution: "hasha@npm:5.2.2"
@@ -9771,17 +9771,6 @@ __metadata:
     tiny-warning: "npm:^1.0.0"
     value-equal: "npm:^1.0.1"
   checksum: 10/042373f69dad6419a4d551b995ef40f449a8854775a1157c4e9f077ee39aea6ca7ed8f45ec3e1762ef1891357a724d17dad11f2fe7d0edeebcbcf9f48ed3e4d4
-  languageName: node
-  linkType: hard
-
-"hmac-drbg@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "hmac-drbg@npm:1.0.1"
-  dependencies:
-    hash.js: "npm:^1.0.3"
-    minimalistic-assert: "npm:^1.0.0"
-    minimalistic-crypto-utils: "npm:^1.0.1"
-  checksum: 10/0298a1445b8029a69b713d918ecaa84a1d9f614f5857e0c6e1ca517abfa1357216987b2ee08cc6cc73ba82a6c6ddf2ff11b9717a653530ef03be599d4699b836
   languageName: node
   linkType: hard
 
@@ -12639,17 +12628,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimalistic-assert@npm:^1.0.0, minimalistic-assert@npm:^1.0.1":
+"minimalistic-assert@npm:^1.0.0":
   version: 1.0.1
   resolution: "minimalistic-assert@npm:1.0.1"
   checksum: 10/cc7974a9268fbf130fb055aff76700d7e2d8be5f761fb5c60318d0ed010d839ab3661a533ad29a5d37653133385204c503bfac995aaa4236f4e847461ea32ba7
-  languageName: node
-  linkType: hard
-
-"minimalistic-crypto-utils@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "minimalistic-crypto-utils@npm:1.0.1"
-  checksum: 10/6e8a0422b30039406efd4c440829ea8f988845db02a3299f372fceba56ffa94994a9c0f2fd70c17f9969eedfbd72f34b5070ead9656a34d3f71c0bd72583a0ed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
elliptic has a number of security issues, namely CVE-2025-14505. This package is pulled in via webpack 4, so hopefully this can go away when we get to webpack 5.

This commit substitutes elliptic with `@noble/curves` via the `@soatok/elliptic-to-noble` shim package in order to remove elliptic entirely. If elliptic puts out a fix eventually, we can undo this.

See also https://soatok.blog/2025/11/19/moving-beyond-the-npm-elliptic-package/

Before:
```
yarn why -R elliptic
└─ manageiq-ui-classic@workspace:.
   └─ webpack@npm:4.47.0 [5c616] (via npm:~4.47.0 [5c616])
      └─ node-libs-browser@npm:2.2.1 (via npm:^2.2.1)
         └─ crypto-browserify@npm:3.12.1 (via npm:^3.11.0)
            ├─ browserify-sign@npm:4.2.5 (via npm:^4.2.3)
            │  └─ elliptic@npm:6.6.1 (via npm:^6.6.1)
            └─ create-ecdh@npm:4.0.4 (via npm:^4.0.4)
               └─ elliptic@npm:6.6.1 (via npm:^6.5.3)
```

After:
```
yarn why -R @noble/curves
└─ manageiq-ui-classic@workspace:.
   └─ webpack@npm:4.47.0 [5c616] (via npm:~4.47.0 [5c616])
      └─ node-libs-browser@npm:2.2.1 (via npm:^2.2.1)
         └─ crypto-browserify@npm:3.12.1 (via npm:^3.11.0)
            ├─ browserify-sign@npm:4.2.5 (via npm:^4.2.3)
            │  └─ @soatok/elliptic-to-noble@npm:9999.0.0 (via npm:@soatok/elliptic-to-noble@9999.0.0)
            │     └─ @noble/curves@npm:2.2.0 (via npm:^2.0.1)
            └─ create-ecdh@npm:4.0.4 (via npm:^4.0.4)
               └─ @soatok/elliptic-to-noble@npm:9999.0.0 (via npm:@soatok/elliptic-to-noble@9999.0.0)
```

@asirvadAbrahamVarghese Please review.