### PR TITLE
[WIP] Drop inline source map for smaller payload

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -43,7 +43,7 @@ jobs:
       TEST_SUITE: spec:cypress
       CYPRESS: true
       CYPRESS_BROWSER: "${{ matrix.cypress-browser }}"
-      RUN_CYPRESS: "${{ matrix.cypress-browser == 'chrome' || (matrix.cypress-browser != 'chrome' && github.event_name != 'pull_request') }}"
+      RUN_CYPRESS: "true"
       PGHOST: localhost
       PGPASSWORD: smartvm
     steps:

--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -14,7 +14,7 @@ const {
 
 module.exports = merge(sharedConfig, {
   mode: 'development',
-  devtool: 'inline-source-map',
+  devtool: 'source-map',
   plugins: [
     new NodeVersionCheckPlugin(),
   ],


### PR DESCRIPTION
vendor-*.js was ~70 MB, with this, it's around 20 MB...

We found that firefox's cache size was 50 MB so it wasn't being cached in dev mode/cypress.

