### PR TITLE
Optimize cypress db state

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -47,6 +47,15 @@ module.exports = defineConfig({
         throw new Error('Webpack was not built with CYPRESS=true. See console for details');
       }
 
+      // Capture DB state once before entire test run
+      on('before:run', async () => {
+        await fetch('http://localhost:3000/__e2e__/command', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: 'db_state', options: 'capture' })
+        });
+      });
+
       on('after:spec', (spec, results) => {
         // Delete the video on CI if the spec passed and no tests retried
         if (process.env.CI && results && results.video && fs.existsSync(results.video)) {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -46,11 +46,8 @@
 //   });
 // });
 
+// Use cy.appDbState('restore') in afterEach to clean up test data.
+// Note, db_state is automatically captured once before the suite via before:run.
 Cypress.Commands.add('appDbState', function (options) {
   return cy.app('db_state', options)
-});
-
-// capture the database table state before all tests
-before(() => {
-  cy.appDbState('capture');
 });


### PR DESCRIPTION
- [x] Merge after #10025

Previously, DB state was captured once per test file, taking ~600ms each
for a total of ~17 seconds. This captures DB state once before the entire
test suite runs using Cypress's before:run hook.

Tests still restore DB state as needed using cy.appDbState('restore'),
maintaining test isolation.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
