### PR TITLE
Drop source map generation in production

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -58,7 +58,7 @@ const packagesFromModules = (modules) => {
 
 module.exports = merge(sharedConfig, {
   mode: 'production',
-  devtool: 'source-map',
+  devtool: false,
   stats: 'normal',
 
   plugins: [


### PR DESCRIPTION
After this change, we will get roughly 30MB disk savings in production.

@asirvadAbrahamVarghese Please review.

Part of https://github.com/ManageIQ/manageiq-pods/issues/736
Related to https://github.com/ManageIQ/manageiq-ui-classic/pull/10024
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
