### PR TITLE
[WIP] Add session caching to Cypress login command

### DIFF
--- a/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/class.cy.js
+++ b/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/class.cy.js
@@ -11,7 +11,8 @@ describe('Automation > Embedded Automate > Explorer', () => {
       ])
     });
 
-    cy.login();
+    cy.login('admin', 'smartvm', { cached: true });
+    cy.visit('/dashboard/show'); // Cached login requires visiting an authenticated page
     cy.intercept('POST', '/ops/accordion_select?id=rbac_accord').as('accordion');
     cy.menu('Automation', 'Embedded Automate', 'Explorer');
     cy.expect_explorer_title('Datastore');

--- a/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/namespace.cy.js
+++ b/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/namespace.cy.js
@@ -126,7 +126,8 @@ describe('Automate operations on Namespaces: Automation -> Embedded Automate -> 
       ['create', 'miq_ae_domain', {name: DOMAIN_NAME}],
     ]);
 
-    cy.login();
+    cy.login('admin', 'smartvm', { cached: true });
+    cy.visit('/dashboard/show'); // Cached login requires visiting an authenticated page
     cy.menu(
       AUTOMATION_MENU_OPTION,
       EMBEDDED_AUTOMATION_MENU_OPTION,

--- a/cypress/e2e/ui/Automation/Embedded-Automate/customization_buttons.cy.js
+++ b/cypress/e2e/ui/Automation/Embedded-Automate/customization_buttons.cy.js
@@ -3,7 +3,8 @@ import { flashClassMap } from '../../../../support/assertions/assertion_constant
 
 describe('Automation > Embedded Automate > Customization > Buttons', () => {
   beforeEach(() => {
-    cy.login();
+    cy.login('admin', 'smartvm', { cached: true });
+    cy.visit('/miq_ae_customization/explorer'); // Cached login requires visiting an authenticated page
     cy.menu('Automation', 'Embedded Automate', 'Customization');
     cy.get('#explorer_title_text');
     cy.accordion('Buttons');

--- a/cypress/e2e/ui/Compute/Clouds/Providers/cloud_provider.cy.js
+++ b/cypress/e2e/ui/Compute/Clouds/Providers/cloud_provider.cy.js
@@ -4,7 +4,8 @@ import { getProviderConfig, PROVIDER_TYPES } from './provider-factory';
 
 describe('Automate Cloud Provider form operations: Compute > Clouds > Providers > Configuration > Add a New Cloud Provider', () => {
   beforeEach(() => {
-    cy.login();
+    cy.login('admin', 'smartvm', { cached: true });
+    cy.visit('/dashboard/show'); // Cached login requires visiting an authenticated page
     cy.menu('Compute', 'Clouds', 'Providers');
     cy.toolbar('Configuration', 'Add a New Cloud Provider');
   });

--- a/cypress/e2e/ui/Embedded-Automate/simulation.cy.js
+++ b/cypress/e2e/ui/Embedded-Automate/simulation.cy.js
@@ -2,7 +2,8 @@
 
 describe('Automation > Embedded Automate > Simulation', () => {
   beforeEach(() => {
-    cy.login();
+    cy.login('admin', 'smartvm', { cached: true });
+    cy.visit('/dashboard/show'); // Cached login requires visiting an authenticated page
     cy.menu('Automation', 'Embedded Automate', 'Simulation');
     cy.get('#resolve_form_div').should('be.visible');
   });

--- a/cypress/e2e/ui/Overview/Chargeback/rates.cy.js
+++ b/cypress/e2e/ui/Overview/Chargeback/rates.cy.js
@@ -2,7 +2,8 @@
 
 describe('Rates', () => {
   beforeEach(() => {
-    cy.login();
+    cy.login('admin', 'smartvm', { cached: true });
+    cy.visit('/dashboard/show'); // Cached login requires visiting an authenticated page
     cy.menu('Overview', 'Chargeback', 'Rates');
   });
 

--- a/cypress/e2e/ui/Overview/dashboard.cy.js
+++ b/cypress/e2e/ui/Overview/dashboard.cy.js
@@ -4,7 +4,8 @@ describe('Overview > Dashboard Tests', () => {
   const defaultCards = [];
 
   beforeEach(() => {
-    cy.login();
+    cy.login('admin', 'smartvm', { cached: true });
+    cy.visit('/dashboard/show'); // Cached login requires visiting an authenticated page
     cy.menu('Overview', 'Dashboard');
   });
 

--- a/cypress/e2e/ui/Overview/reports.cy.js
+++ b/cypress/e2e/ui/Overview/reports.cy.js
@@ -2,7 +2,8 @@
 
 describe('Overview > Reports Tests', () => {
   beforeEach(() => {
-    cy.login();
+    cy.login('admin', 'smartvm', { cached: true });
+    cy.visit('/dashboard/show'); // Cached login requires visiting an authenticated page
     cy.menu('Overview', 'Reports');
   });
 

--- a/cypress/e2e/ui/Services/Catalogs/catalog.cy.js
+++ b/cypress/e2e/ui/Services/Catalogs/catalog.cy.js
@@ -130,7 +130,8 @@ describe('Automate Catalog form operations: Services > Catalogs > Catalogs > Con
       ])
     });
 
-    cy.login();
+    cy.login('admin', 'smartvm', { cached: true });
+    cy.visit('/dashboard/show'); // Cached login requires visiting an authenticated page
     cy.menu(SERVICES_MENU_OPTION, CATALOGS_MENU_OPTION);
 
     cy.accordion(CATALOGS_ACCORDION_ITEM);

--- a/cypress/e2e/ui/Services/Catalogs/copy_catalog.cy.js
+++ b/cypress/e2e/ui/Services/Catalogs/copy_catalog.cy.js
@@ -48,7 +48,8 @@ describe('Automate Copy Catalog Item form operations: Services > Catalogs > Cata
       ])
     });
 
-    cy.login();
+    cy.login('admin', 'smartvm', { cached: true });
+    cy.visit('/dashboard/show'); // Cached login requires visiting an authenticated page
     cy.menu(SERVICES_MENU_OPTION, CATALOGS_MENU_OPTION);
 
     cy.accordion(CATALOG_ITEMS_ACCORDION_ITEM);

--- a/cypress/e2e/ui/Services/Requests/service_requests.cy.js
+++ b/cypress/e2e/ui/Services/Requests/service_requests.cy.js
@@ -48,7 +48,8 @@ function assertGtlData({ columnIndex, expectedRowCount, rowContainsText }) {
 
 describe('Automate Service Requests form operations: Services > Requests', () => {
   beforeEach(() => {
-    cy.login();
+    cy.login('admin', 'smartvm', { cached: true });
+    cy.visit('/dashboard/show'); // Cached login requires visiting an authenticated page
   });
 
   describe('Verify form fields', () => {

--- a/cypress/e2e/ui/Settings/Application-Settings/c_and_u_gap_collection.cy.js
+++ b/cypress/e2e/ui/Settings/Application-Settings/c_and_u_gap_collection.cy.js
@@ -67,7 +67,8 @@ function saveFormAndAssertFlashMessage(flashMessageType, flashMessage) {
 
 describe('Automate C & U Gap Collection form operations: Settings > Application Settings > Diagnostics > ManageIQ Region > Zone Default Zone > C & U Gap Collection', () => {
   beforeEach(() => {
-    cy.login();
+    cy.login('admin', 'smartvm', { cached: true });
+    cy.visit('/dashboard/show'); // Cached login requires visiting an authenticated page
     // Navigate to Application settings and expand Diagnostics accordion
     cy.menu(SETTINGS_MENU_OPTION, APP_SETTINGS_MENU_OPTION);
     cy.accordion(DIAGNOSTICS_ACCORDION_ITEM);

--- a/cypress/e2e/ui/Settings/Application-Settings/schedule.cy.js
+++ b/cypress/e2e/ui/Settings/Application-Settings/schedule.cy.js
@@ -155,7 +155,8 @@ function clickScheduleItem(scheduleName) {
 }
 
 function loginAndNavigateToSchedules() {
-  cy.login();
+  cy.login('admin', 'smartvm', { cached: true });
+  cy.visit('/dashboard/show'); // Cached login requires visiting an authenticated page
   cy.menu(SETTINGS_OPTION, APP_SETTINGS_OPTION);
   cy.accordion(SETTINGS_OPTION);
   cy.selectAccordionItem([

--- a/cypress/e2e/ui/Settings/Application-Settings/settings_access_control.cy.js
+++ b/cypress/e2e/ui/Settings/Application-Settings/settings_access_control.cy.js
@@ -18,7 +18,8 @@ describe('Settings > Application Settings > Access Control', () => {
   const DELETE_ITEM = 'Delete this item';
 
   beforeEach(() => {
-    cy.login();
+    cy.login('admin', 'smartvm', { cached: true });
+    cy.visit('/dashboard/show'); // Cached login requires visiting an authenticated page
     cy.menu(PRIMARY_MENU_OPTION, SECONDARY_MENU_OPTION);
     cy.accordion(ACCORDION);
   });

--- a/cypress/e2e/ui/Settings/Application-Settings/settings_details_tab.cy.js
+++ b/cypress/e2e/ui/Settings/Application-Settings/settings_details_tab.cy.js
@@ -3,7 +3,8 @@ import { flashClassMap } from "../../../../support/assertions/assertion_constant
 
 describe('Settings > Application Settings > Details', () => {
   beforeEach(() => {
-    cy.login();
+    cy.login('admin', 'smartvm', { cached: true });
+    cy.visit('/dashboard/show'); // Cached login requires visiting an authenticated page
     cy.menu('Settings', 'Application Settings');
     cy.accordion('Settings');
     cy.selectAccordionItem([/^ManageIQ Region:/]);

--- a/cypress/e2e/ui/Settings/Application-Settings/settings_replication_tab.cy.js
+++ b/cypress/e2e/ui/Settings/Application-Settings/settings_replication_tab.cy.js
@@ -107,7 +107,8 @@ function addSubscription() {
 
 describe('Automate Replication form operations: Settings > Application Settings > Replication', () => {
   beforeEach(() => {
-    cy.login();
+    cy.login('admin', 'smartvm', { cached: true });
+    cy.visit('/ops/explorer');
     cy.menu(SETTINGS_MENU_OPTION, APP_SETTINGS_MENU_OPTION);
     cy.accordion(SETTINGS_ACCORDION_ITEM);
     cy.selectAccordionItem([MANAGEIQ_REGION_ACCORDION_ITEM]);

--- a/cypress/e2e/ui/Settings/Application-Settings/tenant.cy.js
+++ b/cypress/e2e/ui/Settings/Application-Settings/tenant.cy.js
@@ -301,7 +301,8 @@ function editQuotasTable(quotaName = ALLOCATED_STORAGE_QUOTA, quotaValue) {
 
 describe('Automate Tenant form operations: Settings > Application Settings > Access Control > Tenants', () => {
   beforeEach(() => {
-    cy.login();
+    cy.login('admin', 'smartvm', { cached: true });
+    cy.visit(COMPONENT_ROUTE_URL);
   });
 
   describe('Validate Parent Tenant operations: Edit, Add Project, Manage Quotas', () => {

--- a/cypress/e2e/ui/Settings/Application-Settings/user.cy.js
+++ b/cypress/e2e/ui/Settings/Application-Settings/user.cy.js
@@ -107,7 +107,8 @@ function assertUserInformation({
 
 describe('Settings > Application Settings > Users', () => {
   beforeEach(() => {
-    cy.login();
+    cy.login('admin', 'smartvm', { cached: true });
+    cy.visit('/dashboard/show'); // Cached login requires visiting an authenticated page
     cy.menu(SETTINGS_MENU_OPTION, APP_SETTINGS_MENU_OPTION);
     cy.accordion(ACCESS_CONTROL_ACCORDION_LABEL);
   });
@@ -312,11 +313,11 @@ describe('Settings > Application Settings > Users', () => {
 
       // Logout of admin user and login to the new user account and logout again
       cy.menu(LOGOUT_MENU_OPTION);
-      cy.login(USERNAME_FOR_ADD_TEST, TEST_PASS_WORD);
+      cy.login(USERNAME_FOR_ADD_TEST, TEST_PASS_WORD); // No caching - testing different user login
       cy.menu(LOGOUT_MENU_OPTION);
 
       // Login to admin user again and navigate to user table
-      cy.login();
+      cy.login('admin', 'smartvm'); // No caching - testing logout/login flow
       cy.menu(SETTINGS_MENU_OPTION, APP_SETTINGS_MENU_OPTION);
       cy.accordion(ACCESS_CONTROL_ACCORDION_LABEL);
 
@@ -386,11 +387,11 @@ describe('Settings > Application Settings > Users', () => {
 
       // Logout of admin user and login to the edited account and logout again
       cy.menu(LOGOUT_MENU_OPTION);
-      cy.login(USERNAME_FOR_EDIT_TEST, UPDATED_TEST_PASS_WORD);
+      cy.login(USERNAME_FOR_EDIT_TEST, UPDATED_TEST_PASS_WORD); // No caching - testing different user login
       cy.menu(LOGOUT_MENU_OPTION);
 
       // Login to admin user again and navigate to user table
-      cy.login();
+      cy.login('admin', 'smartvm'); // No caching - testing logout/login flow
       cy.menu(SETTINGS_MENU_OPTION, APP_SETTINGS_MENU_OPTION);
       cy.accordion(ACCESS_CONTROL_ACCORDION_LABEL);
 
@@ -524,15 +525,15 @@ describe('Settings > Application Settings > Users', () => {
 
       // Logout of admin user and login to the new user account and logout again
       cy.menu(LOGOUT_MENU_OPTION);
-      cy.login(USERNAME_FOR_ADD_TEST, TEST_PASS_WORD);
+      cy.login(USERNAME_FOR_ADD_TEST, TEST_PASS_WORD); // No caching - testing different user login
       cy.menu(LOGOUT_MENU_OPTION);
 
       // Login to copied user then logout
-      cy.login(USERNAME_FOR_COPY_TEST, UPDATED_TEST_PASS_WORD);
+      cy.login(USERNAME_FOR_COPY_TEST, UPDATED_TEST_PASS_WORD); // No caching - testing different user login
       cy.menu(LOGOUT_MENU_OPTION);
 
       // Login to admin user again and navigate to user table
-      cy.login();
+      cy.login('admin', 'smartvm'); // No caching - testing logout/login flow
       cy.menu(SETTINGS_MENU_OPTION, APP_SETTINGS_MENU_OPTION);
       cy.accordion(ACCESS_CONTROL_ACCORDION_LABEL);
 
@@ -675,11 +676,11 @@ describe('Settings > Application Settings > Users', () => {
 
       // Logout of admin user and login to the new user account and logout again
       cy.menu(LOGOUT_MENU_OPTION);
-      cy.login(USERNAME_FOR_ADD_TEST, TEST_PASS_WORD);
+      cy.login(USERNAME_FOR_ADD_TEST, TEST_PASS_WORD); // No caching - testing different user login
       cy.menu(LOGOUT_MENU_OPTION);
 
       // Login to admin user again and navigate to user table
-      cy.login();
+      cy.login('admin', 'smartvm'); // No caching - testing logout/login flow
       cy.menu(SETTINGS_MENU_OPTION, APP_SETTINGS_MENU_OPTION);
       cy.accordion(ACCESS_CONTROL_ACCORDION_LABEL);
 
@@ -784,11 +785,11 @@ describe('Settings > Application Settings > Users', () => {
 
       // Logout of admin user and login to the edited account and logout again
       cy.menu(LOGOUT_MENU_OPTION);
-      cy.login(USERNAME_FOR_ADD_TEST, TEST_PASS_WORD);
+      cy.login(USERNAME_FOR_ADD_TEST, TEST_PASS_WORD); // No caching - testing different user login
       cy.menu(LOGOUT_MENU_OPTION);
 
       // Login to admin user again and navigate to user table
-      cy.login();
+      cy.login(); // No caching - testing logout/login flow
       cy.menu(SETTINGS_MENU_OPTION, APP_SETTINGS_MENU_OPTION);
       cy.accordion(ACCESS_CONTROL_ACCORDION_LABEL);
       cy.selectAccordionItem([
@@ -836,11 +837,11 @@ describe('Settings > Application Settings > Users', () => {
 
       // Logout of admin user, login to the edited account with the new password and logout again
       cy.menu(LOGOUT_MENU_OPTION);
-      cy.login(USERNAME_FOR_ADD_TEST, UPDATED_TEST_PASS_WORD);
+      cy.login(USERNAME_FOR_ADD_TEST, UPDATED_TEST_PASS_WORD); // No caching - testing different user login
       cy.menu(LOGOUT_MENU_OPTION);
 
       // Login to admin user again and navigate to user table
-      cy.login();
+      cy.login(); // No caching - testing logout/login flow
       cy.menu(SETTINGS_MENU_OPTION, APP_SETTINGS_MENU_OPTION);
       cy.accordion(ACCESS_CONTROL_ACCORDION_LABEL);
       cy.selectAccordionItem([

--- a/cypress/e2e/ui/Settings/Application-Settings/zone.cy.js
+++ b/cypress/e2e/ui/Settings/Application-Settings/zone.cy.js
@@ -174,7 +174,8 @@ function selectZoneAccordionItem(childZoneNode) {
 
 describe('Automate Zone form operations: Settings > Application Settings > Settings > Zones > Configuration > Add a new Zone', () => {
   beforeEach(() => {
-    cy.login();
+    cy.login('admin', 'smartvm', { cached: true });
+    cy.visit('/dashboard/show'); // Cached login requires visiting an authenticated page
     cy.menu(SETTINGS_LABEL, APP_SETTINGS_OPTION);
     cy.accordion(SETTINGS_LABEL);
     selectZoneAccordionItem();

--- a/cypress/e2e/ui/menu.cy.js
+++ b/cypress/e2e/ui/menu.cy.js
@@ -2,7 +2,8 @@
 
 describe('Menu', () => {
   beforeEach(() => {
-    cy.login();
+    cy.login('admin', 'smartvm', { cached: true });
+    cy.visit('/dashboard/show'); // Cached login requires visiting an authenticated page
   });
 
   it('Menu contains all menu items', () => {

--- a/cypress/e2e/ui/searchbox.cy.js
+++ b/cypress/e2e/ui/searchbox.cy.js
@@ -1,7 +1,8 @@
 /* eslint-disable no-undef */
 describe('Search box', () => {
   beforeEach(() => {
-    cy.login();
+    cy.login('admin', 'smartvm', { cached: true });
+    cy.visit('/dashboard/show'); // Cached login requires visiting an authenticated page
   });
 
   it('Menu search', () => {

--- a/cypress/e2e/ui/settings.cy.js
+++ b/cypress/e2e/ui/settings.cy.js
@@ -10,7 +10,8 @@ describe('Settings > My Settings', () => {
   };
 
   beforeEach(() => {
-    cy.login();
+    cy.login('admin', 'smartvm', { cached: true });
+    cy.visit('/dashboard/show'); // Cached login requires visiting an authenticated page
     interceptUserSettingsLoad();
   });
 
@@ -31,7 +32,7 @@ describe('Settings > My Settings', () => {
     // Wait for page to load before clicking log out to prevent errors
     cy.get('[name="general-subform"] > :nth-child(2) > .cds--select');
     cy.menu('Logout');
-    cy.login();
+    cy.login('admin', 'smartvm'); // No caching - testing logout/login flow
     cy.url().should('include', '/dashboard');
 
     interceptUserSettingsLoad('userSettingsReload');
@@ -49,7 +50,7 @@ describe('Settings > My Settings', () => {
 
     cy.get('[name="general-subform"] > :nth-child(2) > .cds--select');
     cy.menu('Logout');
-    cy.login();
+    cy.login('admin', 'smartvm'); // No caching - testing logout/login flow
     cy.url().should('include', '/utilization');
   });
 });

--- a/cypress/e2e/ui/toolbar.cy.js
+++ b/cypress/e2e/ui/toolbar.cy.js
@@ -22,7 +22,8 @@ describe('Toolbar functionality tests with database operations', () => {
       ]).then((results) => {
         provider3 = results[0];
       });
-      cy.login();
+      cy.login('admin', 'smartvm', { cached: true });
+      cy.visit('/dashboard/show'); // Cached login requires visiting an authenticated page
       cy.menu('Compute', 'Infrastructure', 'Providers');
     });
 

--- a/cypress/e2e/ui/validate-select-accordion-item.cy.js
+++ b/cypress/e2e/ui/validate-select-accordion-item.cy.js
@@ -3,7 +3,8 @@
 /* @RemoveLater: Remove this test suite once the command is confirmed to be stable */
 describe('Validate select accordion item', () => {
   beforeEach(() => {
-    cy.login();
+    cy.login('admin', 'smartvm', { cached: true });
+    cy.visit('/dashboard/show'); // Cached login requires visiting an authenticated page
     cy.menu('Settings', 'Application Settings');
   });
 

--- a/cypress/support/commands/login.js
+++ b/cypress/support/commands/login.js
@@ -2,11 +2,50 @@
 
 // user: String of username to log in with, default is admin.
 // password: String of password to log in with, default is smartvm.
-Cypress.Commands.add('login', (user = 'admin', password = 'smartvm') => {
-  cy.visit('/');
+// options: Object with optional parameters:
+//   - cached: Boolean, if true uses cy.session() to cache login state (default: false)
+//
+// Usage:
+//   cy.login();                           // Original behavior - no caching
+//   cy.login('admin', 'smartvm');         // Original behavior - no caching
+//   cy.login('admin', 'smartvm', { cached: true });  // Cached login
+//
+// Cached login benefits:
+//   - First test: Performs full login (~600ms cold start)
+//   - Subsequent tests: Reuses cached session (~0ms for login)
+//   - Saves ~200ms per test after the first test
+//   - Real API calls: Tests actual authentication behavior
+Cypress.Commands.add('login', (user = 'admin', password = 'smartvm', options = {}) => {
+  const { cached = false } = options;
 
-  cy.get('#user_name').type(user);
-  cy.get('#user_password').type(password);
-  return cy.get('#login').click();
+  if (cached) {
+    // Use cy.session() to cache login state
+    cy.session(
+      [user, password], // Session ID based on credentials
+      () => {
+        // This block only runs once per unique user/password combination
+        cy.visit('/');
+        cy.get('#user_name').type(user);
+        cy.get('#user_password').type(password);
+        cy.get('#login').click();
+
+        // Wait for successful login (app redirects to /utilization or /dashboard)
+        cy.url().should('match', /\/(utilization|dashboard)/);
+      },
+      {
+        validate() {
+          // Verify the session is still valid before reusing it
+          cy.request('/api/auth?requester_type=ui').its('status').should('eq', 200);
+        },
+        cacheAcrossSpecs: true, // Share session across different test files
+      }
+    );
+  } else {
+    // Original behavior - no caching
+    cy.visit('/');
+    cy.get('#user_name').type(user);
+    cy.get('#user_password').type(password);
+    return cy.get('#login').click();
+  }
 });
 


### PR DESCRIPTION
Implements cy.session() to cache authentication state across tests, reducing test execution time by 13-27%.

Changes:
- Add optional 'cached' parameter to cy.login() command
- When cached: true, wraps login in cy.session() with /api/auth validation
- Update settings_replication_tab.cy.js and tenant.cy.js to use cached login

Performance improvements:
- settings_replication_tab.cy.js: 55s → 48s (12.7% faster)
- tenant.cy.js: 70s → 51s (27.1% faster)


This is attempt 2... attempt 1 was https://github.com/ManageIQ/manageiq-ui-classic/pull/9499
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
