### PR TITLE
Pin serialize-javascript to v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
     "path-to-regexp": "~8.4.0",
     "patternfly": "~3.59.5",
     "request": "npm:@cypress/request@^3.0.9",
+    "serialize-javascript": "~7.0.5",
     "tar": "~7.5.13",
     "uuid": "~14.0.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15600,21 +15600,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serialize-javascript@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "serialize-javascript@npm:4.0.0"
-  dependencies:
-    randombytes: "npm:^2.1.0"
-  checksum: 10/df6809168973a84facade7d73e2d6dc418f5dee704d1e6cbe79e92fdb4c10af55237e99d2e67881ae3b29aa96ba596a0dfec4e609bd289ab8ec93c5ae78ede8e
-  languageName: node
-  linkType: hard
-
-"serialize-javascript@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "serialize-javascript@npm:5.0.1"
-  dependencies:
-    randombytes: "npm:^2.1.0"
-  checksum: 10/76bf4539bca2e870fd08ab0cd8689e74699b55a47f8803cab50017ce761aa1648cb720148dfc29c323861f9e442fa6a4ac537ae5ef73cd748ec1cc77b388761a
+"serialize-javascript@npm:~7.0.5":
+  version: 7.0.5
+  resolution: "serialize-javascript@npm:7.0.5"
+  checksum: 10/6237c76ef6df3d1ad61dd4a393b71ca758c7654f4d1cf77529e513134c0f0660302e03b7ec88a8f3a3daa79e1f93d6de8218ecbc45e073d7cc6b66284a1d3e83
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`serialize-javascript` v4 & v5 are pulled in by:
```
compression-webpack-plugin@6.1.2
└── serialize-javascript@5.0.1
```
```
webpack@npm:4.47.0
└── terser-webpack-plugin@npm:1.4.6
    └── serialize-javascript@npm:4.0.0
```

Doesn’t look like v7 has many breaking changes (even supports Node 12). Webpack builds also look fine

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
