### PR TITLE
Rework menu hiding

### DIFF
--- a/app/presenters/menu/item.rb
+++ b/app/presenters/menu/item.rb
@@ -33,7 +33,7 @@ module Menu
     end
 
     def visible?
-      return true if rbac_feature.nil?
+      return false unless Vmdb::PermissionStores.instance.supported_ui_menu?(id)
 
       rbac_feature.nil? || ApplicationHelper.role_allows?(**rbac_feature)
     end

--- a/app/presenters/menu/section.rb
+++ b/app/presenters/menu/section.rb
@@ -33,10 +33,12 @@ module Menu
     end
 
     def visible?
+      return false unless Vmdb::PermissionStores.instance.supported_ui_menu?(id)
+
       userid = User.current_userid
-      store = Vmdb::PermissionStores.instance
-      auth  = store.can?(id) && User.current_user.role_allows_any?(:identifiers => features_recursive)
+      auth = User.current_user.role_allows_any?(:identifiers => features_recursive)
       $log.debug("Role Authorization #{auth ? "successful" : "failed"} for: userid [#{userid}], main tab [#{id}]")
+
       auth
     end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -42,23 +42,6 @@ describe ApplicationHelper do
       @user = login_as FactoryBot.create(:user, :features => features)
     end
 
-    context "permission store" do
-      it 'consults the permission store' do
-        menu = Menu::DefaultMenu.services_menu_section
-        allow(Vmdb::PermissionStores.instance).to receive(:can?).and_return(true)
-        allow(Vmdb::PermissionStores.instance).to receive(:can?).with(menu.id).and_return(false)
-
-        expect(Menu::DefaultMenu.services_menu_section.visible?).to be_falsey
-        expect(Menu::DefaultMenu.overview_menu_section.visible?).to be_truthy
-
-        # TODO: Fix this assert, it's bad.  We need to create the right feature
-        # for this user so it's allowed using normal permissions but not with
-        # the permission store.
-        allow(User).to receive_message_chain(:current_user, :role_allows_any?).and_return(true)
-        expect(Menu::DefaultMenu.services_menu_section.visible?).to be_falsey
-      end
-    end
-
     context "when with :feature" do
       context "and :any" do
         it "and entitled" do
@@ -80,17 +63,6 @@ describe ApplicationHelper do
           login_as FactoryBot.create(:user, :features => "service")
           expect(helper.role_allows?(:feature => "miq_report")).to be_falsey
         end
-      end
-    end
-
-    context "when with :main_tab_id" do
-      it "and entitled" do
-        expect(Menu::DefaultMenu.services_menu_section.visible?).to be_truthy
-      end
-
-      it "and not entitled" do
-        allow(@user).to receive(:role_allows_any?).and_return(false)
-        expect(Menu::DefaultMenu.services_menu_section.visible?).to be_falsey
       end
     end
 

--- a/spec/presenters/menu/default_menu_spec.rb
+++ b/spec/presenters/menu/default_menu_spec.rb
@@ -81,4 +81,49 @@ describe Menu::DefaultMenu do
       end
     end
   end
+
+  describe "visibility" do
+    before do
+      @user = login_as(FactoryBot.create(:user_admin))
+    end
+
+    describe "by role" do
+      it "when entitled" do
+        expect(Menu::DefaultMenu.services_menu_section).to be_visible
+      end
+
+      it "when not entitled" do
+        allow(@user).to receive(:role_allows_any?).and_return(false)
+
+        expect(Menu::DefaultMenu.services_menu_section).to_not be_visible
+      end
+    end
+
+    describe "by Vmdb::PermissionStores" do
+      it "when everything is permitted" do
+        allow(Vmdb::PermissionStores).to receive(:instance).and_return(
+          Vmdb::PermissionStores.new([])
+        )
+
+        expect(Menu::DefaultMenu.services_menu_section).to be_visible
+      end
+
+      it "when section is not permitted" do
+        allow(Vmdb::PermissionStores).to receive(:instance).and_return(
+          Vmdb::PermissionStores.new(["ui-menu:svc"])
+        )
+
+        expect(Menu::DefaultMenu.services_menu_section).to_not be_visible
+      end
+
+      it "when item is not permitted" do
+        allow(Vmdb::PermissionStores).to receive(:instance).and_return(
+          Vmdb::PermissionStores.new(["ui-menu:services"])
+        )
+
+        expect(Menu::DefaultMenu.services_menu_section).to be_visible
+        expect(Menu::DefaultMenu.services_menu_section.items.detect { |i| i.id == "services" }).to_not be_visible
+      end
+    end
+  end
 end

--- a/spec/presenters/menu/section_spec.rb
+++ b/spec/presenters/menu/section_spec.rb
@@ -1,0 +1,110 @@
+describe Menu::Section do
+  let(:admin) { FactoryBot.create(:user_admin) }
+  let(:user)  { FactoryBot.create(:user, :features => ["vm_infra_explorer", "my_settings_view"]) }
+
+  subject do
+    Menu::Section.new(:outer_section, "Outer Section", nil, [
+      Menu::Section.new(:inner_section, "Inner Section", nil, [
+        Menu::Item.new('vm_infra',    'Virtual Machines', 'vm_infra_explorer', {:feature => 'vm_infra_explorer', :any => true}, '/vm_infra/explorer'),
+        Menu::Item.new('ems_storage', 'Storage Managers', 'ems_storage',       {:feature => 'ems_storage_show_list'},           '/ems_storage/show_list'),
+      ]),
+      Menu::Item.new('configuration', 'My Settings',         'my_settings',  {:feature => 'my_settings_view', :any => true}, '/configuration/index'),
+      Menu::Item.new('ops_explorer', 'Application Settings', 'ops_explorer', {:feature => 'ops_explorer',     :any => true}, '/ops/explorer'),
+    ])
+  end
+
+  def each_menu_component(menu = subject, &block)
+    yield menu
+    menu.items.each { |i| each_menu_component(i, &block) }
+  end
+
+  describe "#visible?" do
+    context "with a user with all permissions" do
+      before { login_as(admin) }
+
+      it "by default all are visible" do
+        each_menu_component do |m|
+          expect(m).to be_visible
+        end
+      end
+
+      it "when a section is configured to be hidden" do
+        allow(Vmdb::PermissionStores).to receive(:instance).and_return(
+          Vmdb::PermissionStores.new(["ui-menu:inner_section"])
+        )
+        expected_hidden = [:inner_section]
+
+        each_menu_component do |m|
+          if expected_hidden.include?(m.id)
+            expect(m).to_not be_visible
+          else
+            expect(m).to be_visible
+          end
+        end
+      end
+
+      it "when an item is configured to be hidden" do
+        allow(Vmdb::PermissionStores).to receive(:instance).and_return(
+          Vmdb::PermissionStores.new(["ui-menu:vm_infra"])
+        )
+        expected_hidden = ["vm_infra"]
+
+        each_menu_component do |m|
+          if expected_hidden.include?(m.id)
+            expect(m).to_not be_visible
+          else
+            expect(m).to be_visible
+          end
+        end
+      end
+    end
+
+    context "with a user with partial permissions" do
+      before { login_as(user) }
+
+      let(:default_visible) { [:outer_section, :inner_section, "vm_infra", "configuration"] }
+
+      it "by default can only see items they have access to" do
+        expected_visible = default_visible
+
+        each_menu_component do |m|
+          if expected_visible.include?(m.id)
+            expect(m).to be_visible
+          else
+            expect(m).to_not be_visible
+          end
+        end
+      end
+
+      it "when a section is configured to be hidden" do
+        allow(Vmdb::PermissionStores).to receive(:instance).and_return(
+          Vmdb::PermissionStores.new(["ui-menu:inner_section"])
+        )
+        expected_visible = default_visible - [:inner_section]
+
+        each_menu_component do |m|
+          if expected_visible.include?(m.id)
+            expect(m).to be_visible
+          else
+            expect(m).to_not be_visible
+          end
+        end
+      end
+
+      it "when an item is configured to be hidden" do
+        allow(Vmdb::PermissionStores).to receive(:instance).and_return(
+          Vmdb::PermissionStores.new(["ui-menu:configuration"])
+        )
+        expected_visible = default_visible - ["configuration"]
+
+        each_menu_component do |m|
+          if expected_visible.include?(m.id)
+            expect(m).to be_visible
+          else
+            expect(m).to_not be_visible
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Fixes a bug where Menu items were not able to be hidden (only sections)
- Changes the permissions.yaml entry to require a prefix of "ui-menu", via the supports_ui_menu? helper function.

Fixes ManageIQ/manageiq#23823

Depends on
- [x] https://github.com/ManageIQ/manageiq/pull/23827

@agrare Please review.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
