### PR TITLE
Fix the snapshot page delete toolbar button

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -512,6 +512,19 @@ module ApplicationController::CiProcessing
   # Delete selected snapshot for vm
   def deletesnapsvms
     assert_privileges(params[:pressed])
+
+    snap_selected = Snapshot.find_by(:id => session[:snap_selected])
+    record = find_record_with_rbac(record_class, params[:id])
+    error_message = record.try(:remove_snapshot_denied_message, snap_selected.current?)
+    if error_message
+      javascript_flash(
+        :text       => error_message,
+        :severity   => :error,
+        :scroll_top => true
+      )
+      return
+    end
+
     generic_button_operation('remove_snapshot', _('Delete Snapshot'), vm_button_action,
                              @explorer ? {} : {:refresh_partial => 'vm_common/config'})
   end
@@ -520,6 +533,19 @@ module ApplicationController::CiProcessing
   # Delete selected snapshot for vm
   def revertsnapsvms
     assert_privileges(params[:pressed])
+
+    snap_selected = Snapshot.find_by(:id => session[:snap_selected])
+    record = find_record_with_rbac(record_class, params[:id])
+    error_message = record.try(:revert_to_snapshot_denied_message, snap_selected.current?)
+    if error_message
+      javascript_flash(
+        :text       => error_message,
+        :severity   => :error,
+        :scroll_top => true
+      )
+      return
+    end
+
     generic_button_operation('revert_to_snapshot', _('Revert to a Snapshot'), vm_button_action,
                              @explorer ? {} : {:refresh_partial => 'vm_common/config'})
   end

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -513,9 +513,9 @@ module ApplicationController::CiProcessing
   def deletesnapsvms
     assert_privileges(params[:pressed])
 
-    snap_selected = Snapshot.find_by(:id => session[:snap_selected])
-    record = find_record_with_rbac(record_class, params[:id])
-    error_message = record.try(:remove_snapshot_denied_message, snap_selected.current?)
+    snap_selected = Snapshot.find_by(:id => session[:snap_selected]) if session[:snap_selected]
+    record = find_record_with_rbac(record_class, params[:id]) if params[:id]
+    error_message = record.try(:remove_snapshot_denied_message, snap_selected.current?) if snap_selected
     if error_message
       javascript_flash(
         :text       => error_message,

--- a/app/helpers/application_helper/button/vm_snapshot_remove_one.rb
+++ b/app/helpers/application_helper/button/vm_snapshot_remove_one.rb
@@ -3,7 +3,6 @@ class ApplicationHelper::Button::VmSnapshotRemoveOne < ApplicationHelper::Button
 
   def disabled?
     # TODO: move ovirt's @active special case into supports mechanism.
-    @error_message = @record.try(:remove_snapshot_denied_message, @active)
     @error_message ||= unless @record.supports?(:remove_snapshot)
                          @record.unsupported_reason(:remove_snapshot)
                        end

--- a/app/helpers/application_helper/button/vm_snapshot_revert.rb
+++ b/app/helpers/application_helper/button/vm_snapshot_revert.rb
@@ -8,7 +8,6 @@ class ApplicationHelper::Button::VmSnapshotRevert < ApplicationHelper::Button::B
 
   def disabled?
     # TODO: move ovirt's @active special case into supports mechanism.
-    @error_message = @record.try(:revert_to_snapshot_denied_message, @active)
     @error_message ||= unless @record.supports?(:revert_to_snapshot)
                          @record.unsupported_reason(:revert_to_snapshot)
                        end

--- a/spec/helpers/application_helper/buttons/vm_snapshot_remove_one_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_snapshot_remove_one_spec.rb
@@ -18,15 +18,6 @@ describe ApplicationHelper::Button::VmSnapshotRemoveOne do
   before { stub_supports(record.ext_management_system, :snapshots) }
   describe '#disabled?' do
     subject { button.disabled? }
-    context 'when record.kind_of?(ManageIQ::Providers::Redhat::InfraManager::Vm)' do
-      context 'when record is active' do
-        it { is_expected.to be_truthy }
-      end
-      context 'when record is not active' do
-        let(:active) { false }
-        it { is_expected.to be_falsey }
-      end
-    end
     context 'when !record.kind_of?(ManageIQ::Providers::Redhat::InfraManager::Vm)' do
       let(:record) do
         record = FactoryBot.create(:vm_vmware, :ems_id => ems.id, :host_id => host.id)


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq/issues/23818

Fixes an issue where the delete button on the snapshot page is always disabled. This is because the snapshot page renders with the active snapshot selected and the toolbar state doesn't refresh with the React form. Instead, the button will be enabled and if the user tries to delete the active snapshot, an error will be thrown. This same issue exists with the revert button on this page, which is also fixed in this PR.