### PR TITLE
Fix catalog item form with missing request

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -202,10 +202,14 @@ class CatalogController < ApplicationController
         if request
           prov_set_form_vars(request) # Set vars from existing request
         else
-          add_flash(_("Can not edit selected item, Request is missing"), :error)
-          @edit = @record = nil
-          replace_right_cell
-          return
+          # Request-backed catalog items can outlive the original request. In that case,
+          # initialize a new provisioning workflow using the catalog item's provision type.
+          @edit ||= {}
+          @edit[:new] ||= {}
+          @edit[:current] ||= {}
+          @edit[:st_prov_type] = @record.prov_type
+          @edit[:new][:st_prov_type] = @record.prov_type
+          prov_set_form_vars
         end
       else
         # prov_set_form_vars

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -223,6 +223,8 @@ describe CatalogController do
 
       it "falls back to a new-request edit form when Request is missing" do
         @miq_request.destroy
+        MiqDialog.seed
+        EvmSpecHelper.create_guid_miq_server_zone
         post :x_button, :params => {:id => service_template_with_root_tenant.id, :pressed => "catalogitem_edit", :format => :js}
         expect(assigns(:flash_array)).to be_blank
         expect(assigns(:edit)).not_to be_nil

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -221,11 +221,15 @@ describe CatalogController do
         service_template_with_root_tenant.save
       end
 
-      it "shows flash message for missing Request" do
+      it "falls back to a new-request edit form when Request is missing" do
         @miq_request.destroy
         post :x_button, :params => {:id => service_template_with_root_tenant.id, :pressed => "catalogitem_edit", :format => :js}
-        expect(assigns(:flash_array).first[:message]).to include("Can not edit selected item, Request is missing")
-        expect(assigns(:edit)).to be_nil
+        expect(assigns(:flash_array)).to be_blank
+        expect(assigns(:edit)).not_to be_nil
+        expect(assigns(:edit)[:key]).to eq("prov_edit__new")
+        expect(assigns(:edit)[:wf]).not_to be_nil
+        expect(assigns(:edit)[:new][:current_tab_key]).not_to be_nil
+        expect(assigns(:edit)[:new][:st_prov_type]).to eq("vmware")
       end
 
       it "continues with setting edit screen when Request is present" do


### PR DESCRIPTION
Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/23831

Fixes an issue where if the request of a catalog item is somehow missing the edit catalog form would not open. This PR now allows the user to edit the catalog item even if the request is not present and the form acts as if the user is adding a new request.