### PR TITLE
Fix initial render state update in router form edit mode

### DIFF
--- a/app/javascript/components/routers-form/index.jsx
+++ b/app/javascript/components/routers-form/index.jsx
@@ -98,27 +98,26 @@ const RoutersForm = ({ routerId }) => {
       API.get(`/api/network_routers/${routerId}?attributes=cloud_network.cloud_subnets.ids,external_gateway_info`)
         .then((initialValues) => {
           const data = formatInitialData(initialValues);
-          API.get(
-            `/api/cloud_subnets?expand=resources&attributes=name,ems_ref&filter[]=cloud_network_id=${data.cloud_network_id}`
-          ).then((data) => {
-            let subnets = data.resources;
-            subnets = subnets.map(({ id, name }) => ({ label: name, value: id }));
-            setState((state) => ({
-              ...state,
-              subnets,
-            }));
-          });
-          setState({
+          Promise.all([
+          API.get(`/api/cloud_subnets?expand=resources&attributes=name,ems_ref&filter[]=cloud_network_id=${data.cloud_network_id}`),
+          API.options(`/api/network_routers/${routerId}`)
+        ]).then(([subnetsResponse, optionsResponse]) => {
+          const subnets = subnetsResponse.resources.map(({ id, name }) => ({ 
+            label: name, 
+            value: id 
+          }));
+          loadSchema({})(optionsResponse);
+          setState((state) => ({
+            ...state,
             initialValues,
+            subnets,
             isLoading: false,
-          });
-          API.options(`/api/network_routers/${routerId}`).then(
-            loadSchema({})
-          );
+          }));
           miqSparkleOff();
         });
-    }
-  }, [routerId]);
+      })
+  }
+}, [routerId]);
 
   const onSubmit = (values) => {
     const resources = getSubmitData(values);

--- a/app/javascript/components/select/index.jsx
+++ b/app/javascript/components/select/index.jsx
@@ -64,7 +64,7 @@ SelectWithOnChange.defaultProps = {
   isDisabled: undefined,
   loadOptions: undefined,
   onChange: undefined,
-  options: [],
+  options: undefined,
   placeholder: `<${__('Choose')}>`,
 };
 

--- a/app/javascript/spec/network-router-form/__snapshots__/network-router-form.spec.js.snap
+++ b/app/javascript/spec/network-router-form/__snapshots__/network-router-form.spec.js.snap
@@ -487,14 +487,16 @@ exports[`Network Router form component should render edit variant 1`] = `
       class="cds--btn-set"
     >
       <button
-        class="cds--btn cds--btn--primary"
+        class="cds--btn cds--btn--primary cds--btn--disabled"
+        disabled=""
         type="submit"
         variant="primary"
       >
         Save
       </button>
       <button
-        class="cds--btn cds--btn--secondary"
+        class="cds--btn cds--btn--secondary cds--btn--disabled"
+        disabled=""
         type="button"
       >
         Reset


### PR DESCRIPTION
In #9940, it was noticed that the [network-router-form test](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/javascript/spec/network-router-form/network-router-form.spec.js) fails with this error from [SelectWithOnChange](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/javascript/components/select/index.jsx) (RTL renders the whole tree, not just the top-level components) since `options` becomes `undefined` at some point:
<img width="1406" height="400" alt="image" src="https://github.com/user-attachments/assets/61f3e3f8-4a00-4de1-a8db-8ddcddce2b27" />

From network routers form `subnets` is what gets passed to the Select’s options prop

**Why is this working fine in the real flow?**

In the actual case, the API promise resolves with a delay, so it works fine, `API.get()` starts async work, `.then` is scheduled for later, execution immediately continues and
```
setState({
    initialValues,
    isLoading: false,
 });
``` 
runs synchronously from where `subnets` goes undefined first, then the scheduled `.then` runs and the value becomes defined. 

**Why does this break in tests? (was breaking in #9940)**

But in test, the API is mocked, so it behaves the other way around the promise resolves immediately, the `.then` runs right away, `subnets` gets set first, and then it becomes `undefined`
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
