### PR TITLE
Remove request package resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,7 +174,6 @@
     "moment-timezone": "~0.6.0",
     "path-to-regexp": "~8.4.0",
     "patternfly": "~3.59.5",
-    "request": "npm:@cypress/request@^3.0.9",
     "serialize-javascript": "~7.0.5",
     "tar": "~7.5.13",
     "uuid": "~14.0.0"


### PR DESCRIPTION
No packages depend on `request`:
```
yarn why request
└── (empty)
```

Only Cypress uses `@cypress/request` internally:
```
yarn why @cypress/request
└─ cypress@npm:15.14.2
   └─ @cypress/request@npm:3.0.10 (via npm:^3.0.10)
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
