### PR TITLE
Cloud provider cypress refactor

### DIFF
--- a/cypress/e2e/ui/Compute/Clouds/Providers/cloud_provider.cy.js
+++ b/cypress/e2e/ui/Compute/Clouds/Providers/cloud_provider.cy.js
@@ -4,8 +4,6 @@ import { getProviderConfig, PROVIDER_TYPES } from './provider-factory';
 describe('Automate Cloud Provider form operations: Compute > Clouds > Providers > Configuration > Add a New Cloud Provider', () => {
   beforeEach(() => {
     cy.login();
-    cy.menu('Compute', 'Clouds', 'Providers');
-    cy.toolbar('Configuration', 'Add a New Cloud Provider');
   });
 
   // Generate tests for VMware vCloud provider

--- a/cypress/e2e/ui/Compute/Clouds/Providers/provider-factory.js
+++ b/cypress/e2e/ui/Compute/Clouds/Providers/provider-factory.js
@@ -55,24 +55,24 @@ export const SELECT_OPTIONS = {
   EVENT_STREAM_TYPE_AMQP: 'AMQP',
   EVENT_STREAM_TYPE_STF: 'STF',
   ENABLED: 'Enabled',
-  API_VERSION_V3: 'Keystone V3',
-  API_VERSION_V5: 'vCloud API 5.5',
+  API_VERSION_V3: 'v3',
+  API_VERSION_V5: '5.5',
   API_VERSION_V9: 'vCloud API 9.0',
   API_VERSION_2017: 'V2017_03_09',
   ZONE_DEFAULT: 'default',
-  SECURITY_PROTOCOL_SSL: 'SSL',
+  SECURITY_PROTOCOL_SSL: 'ssl-with-validation',
   SECURITY_PROTOCOL_NON_SSL: 'Non-SSL',
 };
 
 // Common region options
 export const REGION_OPTIONS = {
-  CENTRAL_INDIA: 'Central India',
+  CENTRAL_INDIA: 'centralindia',
   CENTRAL_US: 'Central US',
   HYDERABAD: 'ap-hyderabad-1',
   MELBOURNE: 'ap-melbourne-1',
-  AUSTRALIA: 'Australia (Sydney)',
+  AUSTRALIA: 'au-syd',
   SPAIN: 'EU Spain (Madrid)',
-  CANADA: 'Canada (Central)',
+  CANADA: 'ca-central-1',
   ASIA_PACIFIC: 'Asia Pacific (Malaysia)',
 };
 
@@ -143,6 +143,143 @@ export const PROVIDER_TYPES = {
   IBM_CIC: 'IBM Cloud Infrastructure Center',
   OPENSTACK: 'OpenStack',
 };
+
+/**
+ * Gets the factory name and configuration object for creating a cloud provider
+ * @param {Object} providerConfig - The provider configuration object
+ * @returns {Object} Object containing factoryName and factoryConfig
+ * @example
+ * const { factoryName, factoryConfig } = getProviderFactoryConfig(providerConfig);
+ * cy.appFactories([['create', factoryName, factoryConfig]]);
+ */
+export function getProviderFactoryConfig(providerConfig) {
+  const { formValues, type: providerType } = providerConfig;
+  const defaultFormValues = formValues?.default;
+  const baseConfig = {
+    name: formValues.common.name,
+  };
+  const withDefaultAuth = {
+    ...baseConfig,
+    authtype: 'default',
+  };
+  const withHostAndPort = {
+    hostname: defaultFormValues?.['endpoints.default.hostname'],
+    port: defaultFormValues?.['endpoints.default.port'],
+  };
+  const withEndpoint = {
+    ...withHostAndPort,
+    security_protocol:
+      defaultFormValues?.['endpoints.default.security_protocol'],
+  };
+  const withTenantIdAndApiVersion = {
+    uid_ems: defaultFormValues.uid_ems,
+    api_version: defaultFormValues.api_version,
+  };
+
+  switch (providerType) {
+    case PROVIDER_TYPES.AMAZON_EC2:
+      return {
+        factoryName: 'ems_amazon',
+        factoryConfig: {
+          ...withDefaultAuth,
+          provider_region: defaultFormValues.provider_region,
+        },
+      };
+    case PROVIDER_TYPES.AZURE:
+      return {
+        factoryName: 'ems_azure',
+        factoryConfig: {
+          ...withDefaultAuth,
+          provider_region: defaultFormValues.provider_region,
+          uid_ems: defaultFormValues.uid_ems,
+          subscription: defaultFormValues.subscription,
+        },
+      };
+    case PROVIDER_TYPES.GOOGLE_COMPUTE:
+      return {
+        factoryName: 'ems_google',
+        factoryConfig: {
+          ...withDefaultAuth,
+          project: defaultFormValues.project,
+        },
+      };
+    case PROVIDER_TYPES.OPENSTACK:
+      return {
+        factoryName: 'ems_openstack_with_authentication',
+        factoryConfig: {
+          ...baseConfig,
+          ...withEndpoint,
+          ...withTenantIdAndApiVersion,
+          provider_region: defaultFormValues.provider_region,
+        },
+      };
+    case PROVIDER_TYPES.VMWARE_VCLOUD:
+      return {
+        factoryName: 'ems_vmware_cloud',
+        factoryConfig: {
+          ...withDefaultAuth,
+          ...withHostAndPort,
+          api_version: defaultFormValues.api_version,
+        },
+      };
+    case PROVIDER_TYPES.ORACLE_CLOUD:
+      return {
+        factoryName: 'ems_oracle_cloud_with_authentication',
+        factoryConfig: {
+          ...baseConfig,
+          provider_region: defaultFormValues.provider_region,
+          uid_ems: defaultFormValues.uid_ems,
+        },
+      };
+    case PROVIDER_TYPES.IBM_CLOUD_VPC:
+      return {
+        factoryName: 'ems_ibm_cloud_vpc',
+        factoryConfig: {
+          ...withDefaultAuth,
+          provider_region: defaultFormValues.provider_region,
+        },
+      };
+    case PROVIDER_TYPES.IBM_POWER_SYSTEMS:
+      return {
+        factoryName: 'ems_ibm_cloud_power_virtual_servers_cloud',
+        factoryConfig: {
+          ...withDefaultAuth,
+          uid_ems: defaultFormValues.uid_ems,
+        },
+      };
+    case PROVIDER_TYPES.AZURE_STACK:
+      return {
+        factoryName: 'ems_azure_stack',
+        factoryConfig: {
+          ...withDefaultAuth,
+          ...withEndpoint,
+          ...withTenantIdAndApiVersion,
+          subscription: defaultFormValues.subscription,
+        },
+      };
+    case PROVIDER_TYPES.IBM_POWERVC:
+      return {
+        factoryName: 'ems_ibm_power_vc',
+        factoryConfig: {
+          ...withDefaultAuth,
+          ...withEndpoint,
+          uid_ems: defaultFormValues.uid_ems,
+          api_version: SELECT_OPTIONS.API_VERSION_V3, // for rendering the domain ID field
+        },
+      };
+    case PROVIDER_TYPES.IBM_CIC:
+      return {
+        factoryName: 'ems_ibm_cic',
+        factoryConfig: {
+          ...withDefaultAuth,
+          ...withEndpoint,
+          ...withTenantIdAndApiVersion,
+        },
+      };
+    default:
+      cy.logAndThrowError(`getProviderFactoryConfig: Provider type "${providerType}" does not have a factory configuration`);
+  }
+}
 
 /**
  * Creates a provider configuration object with all necessary properties

--- a/cypress/e2e/ui/Compute/Clouds/Providers/provider-factory.js
+++ b/cypress/e2e/ui/Compute/Clouds/Providers/provider-factory.js
@@ -80,8 +80,7 @@ export const REGION_OPTIONS = {
 export const FIELD_VALUES = {
   TEST_NAME: 'Test Name:',
   TENANT_ID: '101',
-  SUBSCRIPTION_ID: 'z565815f-05b6-402f-1999-045155da7dq4',
-  ENDPOINT_URL: '/api',
+  SUBSCRIPTION_ID: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
   CLIENT_ID: 'manageiq.example.com',
   CLIENT_KEY: 'test_client_key',
   PORT: '3000',
@@ -94,11 +93,9 @@ export const FIELD_VALUES = {
   CLOUD_API_KEY: 'fake-ibm-cloud-api-key-for-testing',
   GUID: 'fake-guid-0000-0000-0000-000000000000',
   PROJECT_ID: 'fake-miq-project-id-for-testing',
-  ASSUME_ROLE: 'arn:aws:iam::000000000000:role/FakeTestRole',
   ACCESS_KEY_ID: 'FAKE-ACCESS-KEY-ID-FOR-TESTING',
   SECRET_ACCESS_KEY: 'fake-secret-access-key-for-testing-do-not-use',
   DOMAIN_ID_DEFAULT: 'default',
-  PROVIDER_REGION: 'RegionOne',
 };
 
 // Common flash message text snippets
@@ -156,7 +153,6 @@ export const PROVIDER_TYPES = {
 function createProviderConfig(type, config = {}) {
   const baseConfig = {
     type,
-    nameValue: `${FIELD_VALUES.TEST_NAME} ${type}`,
     validationError: VALIDATION_ERRORS[type.replace(/\s+/g, '_').toUpperCase()],
     formFields: {
       common: [
@@ -185,8 +181,22 @@ function createProviderConfig(type, config = {}) {
     fieldSelectionValues: {},
   };
 
-  // Merge with provided config
-  return { ...baseConfig, ...config };
+  // Deep merge formValues and formFields to preserve common values
+  const mergedConfig = { ...baseConfig, ...config };
+  if (config.formFields) {
+    mergedConfig.formFields = {
+      ...baseConfig.formFields,
+      ...config.formFields,
+    };
+  }
+  if (config.formValues) {
+    mergedConfig.formValues = {
+      ...baseConfig.formValues,
+      ...config.formValues,
+    };
+  }
+
+  return mergedConfig;
 }
 
 /**
@@ -272,6 +282,7 @@ function getVMwareVcloudProviderConfig() {
     formValues: {
       default: {
         api_version: SELECT_OPTIONS.API_VERSION_V5,
+        'endpoints.default.hostname': 'vmware-vcloud.example.com',
         'endpoints.default.port': FIELD_VALUES.PORT,
         'authentications.default.userid': FIELD_VALUES.USERNAME,
         'authentications.default.password': FIELD_VALUES.PASSWORD,
@@ -541,6 +552,7 @@ function getAzureStackProviderConfig() {
         api_version: SELECT_OPTIONS.API_VERSION_2017,
         'endpoints.default.security_protocol':
           SELECT_OPTIONS.SECURITY_PROTOCOL_SSL,
+        'endpoints.default.hostname': 'azure-stack.example.com',
         'endpoints.default.port': FIELD_VALUES.PORT,
         'authentications.default.userid': FIELD_VALUES.USERNAME,
         'authentications.default.password': FIELD_VALUES.PASSWORD,
@@ -580,7 +592,7 @@ function getAzureProviderConfig() {
           label: FIELD_LABELS.ENDPOINT_URL,
           id: 'endpoints.default.url',
           type: 'text',
-          required: true,
+          required: false,
         },
         {
           label: FIELD_LABELS.CLIENT_ID,
@@ -602,7 +614,6 @@ function getAzureProviderConfig() {
         provider_region: REGION_OPTIONS.CENTRAL_INDIA,
         uid_ems: FIELD_VALUES.TENANT_ID,
         subscription: FIELD_VALUES.SUBSCRIPTION_ID,
-        'endpoints.default.url': FIELD_VALUES.ENDPOINT_URL,
         'authentications.default.userid': FIELD_VALUES.CLIENT_ID,
         'authentications.default.password': FIELD_VALUES.CLIENT_KEY,
       },
@@ -629,7 +640,7 @@ function getAmazonEC2ProviderConfig() {
           label: FIELD_LABELS.ENDPOINT_URL,
           id: 'endpoints.default.url',
           type: 'text',
-          required: true,
+          required: false,
         },
         {
           label: FIELD_LABELS.ASSUME_ROLE_ARN,
@@ -670,8 +681,6 @@ function getAmazonEC2ProviderConfig() {
     formValues: {
       default: {
         provider_region: REGION_OPTIONS.CANADA,
-        'endpoints.default.url': FIELD_VALUES.ENDPOINT_URL,
-        'authentications.default.service_account': FIELD_VALUES.ASSUME_ROLE,
         'authentications.default.userid': FIELD_VALUES.ACCESS_KEY_ID,
         'authentications.default.password': FIELD_VALUES.SECRET_ACCESS_KEY,
       },
@@ -691,6 +700,12 @@ function getIBMPowerVCProviderConfig() {
         {
           label: FIELD_LABELS.PROVIDER_REGION,
           id: 'provider_region',
+          type: 'text',
+          required: false,
+        },
+        {
+          label: FIELD_LABELS.DOMAIN_ID,
+          id: 'uid_ems',
           type: 'text',
           required: true,
         },
@@ -788,6 +803,7 @@ function getIBMPowerVCProviderConfig() {
         'endpoints.default.security_protocol':
           SELECT_OPTIONS.SECURITY_PROTOCOL_SSL,
         'endpoints.default.port': FIELD_VALUES.PORT,
+        'endpoints.default.hostname': 'ibm-powervc.example.com',
         'authentications.default.userid': FIELD_VALUES.USERNAME,
         'authentications.default.password': FIELD_VALUES.PASSWORD,
       },
@@ -813,7 +829,7 @@ function getIBMCICProviderConfig() {
           label: FIELD_LABELS.PROVIDER_REGION,
           id: 'provider_region',
           type: 'text',
-          required: true,
+          required: false,
         },
         {
           label: FIELD_LABELS.API_VERSION,
@@ -911,11 +927,11 @@ function getIBMCICProviderConfig() {
     },
     formValues: {
       default: {
-        provider_region: FIELD_VALUES.PROVIDER_REGION,
         api_version: SELECT_OPTIONS.API_VERSION_V3,
         uid_ems: FIELD_VALUES.DOMAIN_ID_DEFAULT,
         'endpoints.default.security_protocol':
           SELECT_OPTIONS.SECURITY_PROTOCOL_SSL,
+        'endpoints.default.hostname': 'ibm-cic.example.com',
         'endpoints.default.port': FIELD_VALUES.PORT,
         'authentications.default.userid': FIELD_VALUES.USERNAME,
         'authentications.default.password': FIELD_VALUES.PASSWORD,
@@ -948,7 +964,7 @@ function getOpenStackProviderConfig() {
           label: FIELD_LABELS.PROVIDER_REGION,
           id: 'provider_region',
           type: 'text',
-          required: true,
+          required: false,
         },
         {
           label: FIELD_LABELS.OPENSTACK_INFRA_PROVIDER,
@@ -1052,11 +1068,11 @@ function getOpenStackProviderConfig() {
     },
     formValues: {
       default: {
-        provider_region: FIELD_VALUES.PROVIDER_REGION,
         api_version: SELECT_OPTIONS.API_VERSION_V3,
         uid_ems: FIELD_VALUES.DOMAIN_ID_DEFAULT,
         'endpoints.default.security_protocol':
           SELECT_OPTIONS.SECURITY_PROTOCOL_SSL,
+        'endpoints.default.hostname': 'openstack.example.com',
         'endpoints.default.port': FIELD_VALUES.PORT,
         'authentications.default.userid': FIELD_VALUES.USERNAME,
         'authentications.default.password': FIELD_VALUES.PASSWORD,

--- a/cypress/support/commands/provider_helper_commands.js
+++ b/cypress/support/commands/provider_helper_commands.js
@@ -5,6 +5,7 @@ import {
   PROVIDER_TYPES,
   REGION_OPTIONS,
   FLASH_MESSAGES,
+  getProviderFactoryConfig,
 } from '../../e2e/ui/Compute/Clouds/Providers/provider-factory';
 import { flashClassMap } from '../assertions/assertion_constants';
 
@@ -639,6 +640,11 @@ function generateAddFormValidationTests(providerConfig, testOptions = {}) {
   const { isAzureStack = false, isAmazonEc2 = false } = testOptions;
 
   describe(`Validate ${providerConfig.type} add form`, () => {
+    beforeEach(() => {
+      cy.menu('Compute', 'Clouds', 'Providers');
+      cy.toolbar('Configuration', 'Add a New Cloud Provider');
+    });
+
     it('Validate visibility of elements', () => {
       cy.validateProviderFormFields(providerConfig, false);
     });
@@ -712,9 +718,19 @@ function generateAddFormValidationTests(providerConfig, testOptions = {}) {
  * @param {boolean} testOptions.isAmazonEc2 - Whether the provider is Amazon EC2
  */
 function generateEditFormValidationTests(providerConfig, testOptions = {}) {
+  const { factoryName, factoryConfig } = getProviderFactoryConfig(providerConfig);
   const { isAzureStack = false, isAmazonEc2 = false } = testOptions;
 
   describe(`Validate ${providerConfig.type} edit form`, () => {
+    beforeEach(() => {
+      cy.appFactories([
+        ['create', factoryName, factoryConfig],
+      ]).then((createdProviderData) => {
+        expect(createdProviderData.length).to.equal(1);
+        cy.menu('Compute', 'Clouds', 'Providers');
+      });
+    });
+
     it('Validate visibility of elements', () => {
       openEditFormForCreatedProvider(providerConfig, isAzureStack);
       cy.validateProviderFormFields(providerConfig, true);
@@ -792,9 +808,20 @@ function generateEditFormValidationTests(providerConfig, testOptions = {}) {
  * @param {Object} providerConfig - The provider configuration object
  */
 function generateNameUniquenessTests(providerConfig) {
+  const { factoryName, factoryConfig } = getProviderFactoryConfig(providerConfig);
+
   describe(`${providerConfig.type} provider name uniqueness validation`, () => {
+    beforeEach(() => {
+      cy.appFactories([
+        ['create', factoryName, factoryConfig],
+      ]).then((createdProviderData) => {
+        expect(createdProviderData.length).to.equal(1);
+        cy.menu('Compute', 'Clouds', 'Providers');
+        cy.toolbar('Configuration', 'Add a New Cloud Provider');
+      });
+    });
+
     it('Should display error on duplicate name usage', () => {
-      cy.toolbar('Configuration', 'Add a New Cloud Provider');
       cy.fillProviderForm(providerConfig);
       assertNameAlreadyExistsError();
     });

--- a/cypress/support/commands/provider_helper_commands.js
+++ b/cypress/support/commands/provider_helper_commands.js
@@ -642,8 +642,13 @@ function selectProviderAndDeleteWithOptionalFlashMessage({
 /**
  * Generates a test suite for validating the add form of a provider
  * @param {Object} providerConfig - The provider configuration object
+ * @param {Object} testOptions - Test configuration options
+ * @param {boolean} testOptions.isAzureStack - Whether the provider is Azure Stack (requires special handling)
+ * @param {boolean} testOptions.isAmazonEc2 - Whether the provider is Amazon EC2 (includes refresh operation test)
  */
-function generateAddFormValidationTests(providerConfig, isAzureStack = false) {
+function generateAddFormValidationTests(providerConfig, testOptions = {}) {
+  const { isAzureStack = false, isAmazonEc2 = false } = testOptions;
+  
   describe(`Validate ${providerConfig.type} add form`, () => {
     it('Validate visibility of elements', () => {
       cy.validateProviderFormFields(providerConfig, false);
@@ -667,12 +672,12 @@ function generateAddFormValidationTests(providerConfig, isAzureStack = false) {
       );
     });
 
-    it('Verify successful validate + add/refresh/delete operations', () => {
+    it(`Verify successful validate + add/${isAmazonEc2 ? 'refresh/' : ''}delete operations`, () => {
       /**
        * The provider's unique name is set in nameValue variable
        */
       const uniqueId = generateUniqueIdentifier();
-      const nameValue = `${providerConfig.nameValue} - verify-validate-add-refresh-and-delete-operations - ${uniqueId}`;
+      const nameValue = `${providerConfig.nameValue} - verify-validate-add-${isAmazonEc2 ? 'refresh-' : ''}and-delete-operations - ${uniqueId}`;
       const hostValue = `${slugifyWith(
         providerConfig.type,
         '-'
@@ -685,14 +690,24 @@ function generateAddFormValidationTests(providerConfig, isAzureStack = false) {
       assertValidationSuccessMessage();
       cy.interceptAddProviderApi({ isAzureStack });
       cy.expect_flash(flashClassMap.success, FLASH_MESSAGES.OPERATION_SAVED);
-      // Refresh
-      selectCreatedProvider(nameValue);
-      cy.expect_browser_confirm_with_text({
-        confirmTriggerFn: () =>
-          cy.toolbar('Configuration', 'Refresh Relationships and Power States'),
-        containsText: FLASH_MESSAGES.REFRESH_OPERATION,
-      });
-      cy.expect_flash(flashClassMap.success, FLASH_MESSAGES.REFRESH_OPERATION);
+
+      if (isAmazonEc2) {
+        // Refresh
+        selectCreatedProvider(nameValue);
+        cy.expect_browser_confirm_with_text({
+          confirmTriggerFn: () =>
+            cy.toolbar(
+              'Configuration',
+              'Refresh Relationships and Power States'
+            ),
+          containsText: FLASH_MESSAGES.REFRESH_OPERATION,
+        });
+        cy.expect_flash(
+          flashClassMap.success,
+          FLASH_MESSAGES.REFRESH_OPERATION
+        );
+      }
+      
       // Delete
       // FIXME: remove this block once bug is fixed
       // Bug: After refresh, config option other than add remains disabled and requires any action to be performed to enable it back
@@ -711,9 +726,13 @@ function generateAddFormValidationTests(providerConfig, isAzureStack = false) {
 /**
  * Generates a test suite for validating the edit form of a provider
  * @param {Object} providerConfig - The provider configuration object
- * @param {boolean} isAzureStack - Whether the provider is Azure Stack (requires special handling)
+ * @param {Object} testOptions - Test configuration options
+ * @param {boolean} testOptions.isAzureStack - Whether the provider is Azure Stack (requires special handling)
+ * @param {boolean} testOptions.isAmazonEc2 - Whether the provider is Amazon EC2
  */
-function generateEditFormValidationTests(providerConfig, isAzureStack = false) {
+function generateEditFormValidationTests(providerConfig, testOptions = {}) {
+  const { isAzureStack = false, isAmazonEc2 = false } = testOptions;
+
   describe(`Validate ${providerConfig.type} edit form`, () => {
     /**
      * The provider's unique name is set in this variable at the start of each test
@@ -735,34 +754,36 @@ function generateEditFormValidationTests(providerConfig, isAzureStack = false) {
       cy.validateProviderFormFields(providerConfig, true);
     });
 
-    it("Should show the error message from the task_results API upon validation failure and validate reset & cancel buttons' behavior", () => {
-      // TODO: Replace with better data set-up approach
-      const uniqueId = generateUniqueIdentifier();
-      nameFieldValue = `${providerConfig.nameValue} - verify-edit-form-validation-error - ${uniqueId}`;
-      hostValue = `${slugifyWith(providerConfig.type, '-')}-${uniqueId}.com`;
-      addProviderAndOpenEditForm(
-        providerConfig,
-        nameFieldValue,
-        hostValue,
-        isAzureStack
-      );
-      updateProviderFieldsForEdit(providerConfig.type);
-      cy.providerValidation({
-        stubErrorResponse: true,
-        errorMessage: providerConfig.validationError,
+    if (isAmazonEc2) {
+      it("Should show the error message from the task_results API upon validation failure and validate reset & cancel buttons' behavior", () => {
+        // TODO: Replace with better data set-up approach
+        const uniqueId = generateUniqueIdentifier();
+        nameFieldValue = `${providerConfig.nameValue} - verify-edit-form-validation-error - ${uniqueId}`;
+        hostValue = `${slugifyWith(providerConfig.type, '-')}-${uniqueId}.com`;
+        addProviderAndOpenEditForm(
+          providerConfig,
+          nameFieldValue,
+          hostValue,
+          false
+        );
+        updateProviderFieldsForEdit(providerConfig.type);
+        cy.providerValidation({
+          stubErrorResponse: true,
+          errorMessage: providerConfig.validationError,
+        });
+        assertValidationFailureMessage();
+        cy.getFormButtonByTypeWithText({ buttonText: 'Reset' })
+          .should('be.enabled')
+          .click();
+        cy.getFormButtonByTypeWithText({
+          buttonText: 'Cancel',
+        }).click();
+        cy.expect_flash(
+          flashClassMap.success,
+          FLASH_MESSAGES.OPERATION_CANCELLED
+        );
       });
-      assertValidationFailureMessage();
-      cy.getFormButtonByTypeWithText({ buttonText: 'Reset' })
-        .should('be.enabled')
-        .click();
-      cy.getFormButtonByTypeWithText({
-        buttonText: 'Cancel',
-      }).click();
-      cy.expect_flash(
-        flashClassMap.success,
-        FLASH_MESSAGES.OPERATION_CANCELLED
-      );
-    });
+    }
 
     it('Verify successful validate + edit operation', () => {
       // TODO: Replace with better data set-up approach
@@ -821,9 +842,12 @@ function generateEditFormValidationTests(providerConfig, isAzureStack = false) {
 /**
  * Generates a test suite for validating the name uniqueness of a provider
  * @param {Object} providerConfig - The provider configuration object
- * @param {boolean} isAzureStack - Whether the provider is Azure Stack (requires special handling)
+ * @param {Object} testOptions - Test configuration options
+ * @param {boolean} testOptions.isAzureStack - Whether the provider is Azure Stack (requires special handling)
  */
-function generateNameUniquenessTests(providerConfig, isAzureStack = false) {
+function generateNameUniquenessTests(providerConfig, testOptions = {}) {
+  const { isAzureStack = false } = testOptions;
+
   describe(`${providerConfig.type} provider name uniqueness validation`, () => {
     /**
      * The provider's unique name is set in this variable at the start of the test
@@ -862,11 +886,14 @@ function generateNameUniquenessTests(providerConfig, isAzureStack = false) {
  * @param {Object} providerConfig - The provider configuration object
  */
 export function generateProviderTests(providerConfig) {
-  const isAzureStack = providerConfig.type === PROVIDER_TYPES.AZURE_STACK;
+  const testOptions = {
+    isAzureStack: providerConfig.type === PROVIDER_TYPES.AZURE_STACK,
+    isAmazonEc2: providerConfig.type === PROVIDER_TYPES.AMAZON_EC2,
+  };
 
   describe(`Validate cloud provider type: ${providerConfig.type}`, () => {
-    generateAddFormValidationTests(providerConfig, isAzureStack);
-    generateEditFormValidationTests(providerConfig, isAzureStack);
-    generateNameUniquenessTests(providerConfig, isAzureStack);
+    generateAddFormValidationTests(providerConfig, testOptions);
+    generateEditFormValidationTests(providerConfig, testOptions);
+    generateNameUniquenessTests(providerConfig, testOptions);
   });
 }

--- a/cypress/support/commands/provider_helper_commands.js
+++ b/cypress/support/commands/provider_helper_commands.js
@@ -1,21 +1,12 @@
 import {
   SELECT_OPTIONS,
   TAB_LABELS,
-  FIELD_LABELS,
   VALIDATION_MESSAGES,
   PROVIDER_TYPES,
   REGION_OPTIONS,
   FLASH_MESSAGES,
 } from '../../e2e/ui/Compute/Clouds/Providers/provider-factory';
 import { flashClassMap } from '../assertions/assertion_constants';
-
-/**
- * Generates a unique identifier using timestamp
- * @returns {string}
- */
-function generateUniqueIdentifier() {
-  return new Date().getTime();
-}
 
 /**
  * Transforms any text string into a slug format using the given seperator('-', '_')
@@ -31,14 +22,12 @@ function slugifyWith(text, separator) {
 /**
  * Fills common form fields that are present in all provider forms
  * @param {Object} providerConfig - The provider configuration object
- * @param {string} nameValue - The name to use for the provider
  */
-function fillCommonFormFields(providerConfig, nameValue) {
-  cy.getFormSelectFieldById({ selectId: 'type' }).select(providerConfig.type);
-  cy.getFormInputFieldByIdAndType({ inputId: 'name' }).type(nameValue);
-  cy.getFormSelectFieldById({ selectId: 'zone_id' }).select(
-    SELECT_OPTIONS.ZONE_DEFAULT
-  );
+function fillCommonFormFields(providerConfig) {
+  const commonValues = providerConfig.formValues.common;
+  cy.getFormSelectFieldById({ selectId: 'type' }).select(commonValues.type);
+  cy.getFormInputFieldByIdAndType({ inputId: 'name' }).type(commonValues.name);
+  cy.getFormSelectFieldById({ selectId: 'zone_id' }).select(commonValues.zone_id);
 }
 
 /**
@@ -92,68 +81,68 @@ function fillFormFields(fields, values) {
 /**
  * Fills a provider form based on provider configuration
  * @param {Object} providerConfig - The provider configuration object
- * @param {string} nameValue - The name to use for the provider
- * @param {string} hostValue - The hostname to use for the provider
  */
 Cypress.Commands.add(
   'fillProviderForm',
-  (providerConfig, nameValue, hostValue) => {
-    fillCommonFormFields(providerConfig, nameValue);
+  (providerConfig) => {
+    fillCommonFormFields(providerConfig);
     const defaultTabKey = slugifyWith(TAB_LABELS.DEFAULT, '_');
     const defaultTabFormFields = providerConfig.formFields[defaultTabKey];
     const defaultTabFormValues = providerConfig.formValues[defaultTabKey];
     if (defaultTabFormFields && defaultTabFormValues) {
       fillFormFields(defaultTabFormFields, defaultTabFormValues);
     }
-
-    // Since the host value needs to be unique per test, it's passed as a parameter instead of
-    // being hardcoded in the static formValues object. Only the default field is used(endpoints.default.hostname)
-    if (hostValue) {
-      const defaultHostFieldId = 'endpoints.default.hostname';
-      const defaultHostFieldExists = providerConfig.formFields[
-        defaultTabKey
-      ].find((fieldObject) => fieldObject.id === defaultHostFieldId);
-      if (defaultHostFieldExists) {
-        cy.getFormInputFieldByIdAndType({
-          inputId: defaultHostFieldId,
-        }).type(hostValue);
-      }
-    }
   }
 );
 
 /**
  * Validates common form fields that are present in all provider forms
+ * @param {Object} providerConfig - The provider configuration object
  * @param {boolean} isEdit - Whether the form is in edit mode
  */
-function validateCommonFormFields(providerType, isEdit) {
-  cy.getFormLabelByForAttribute({ forValue: 'type' })
-    .should('be.visible')
-    .and('contain.text', FIELD_LABELS.TYPE);
-  if (isEdit) {
-    cy.getFormSelectFieldById({ selectId: 'type' })
+function validateCommonFormFields(providerConfig, isEdit) {
+  const commonFields = providerConfig.formFields.common;
+
+  commonFields.forEach((field) => {
+    const labelElement = cy.getFormLabelByForAttribute({ forValue: field.id })
       .should('be.visible')
-      .and('be.disabled')
-      .find('option:selected')
-      .should('have.text', providerType);
-  } else {
-    cy.getFormSelectFieldById({ selectId: 'type' })
-      .should('be.visible')
-      .and('be.enabled')
-      .select(providerType);
-  }
-  cy.getFormLabelByForAttribute({ forValue: 'name' })
-    .should('be.visible')
-    .and('contain.text', FIELD_LABELS.NAME);
-  cy.getFormInputFieldByIdAndType({ inputId: 'name' })
-    .should('be.visible')
-    .and('be.enabled');
-  cy.getFormLabelByForAttribute({ forValue: 'zone_id' })
-    .should('be.visible')
-    .and('contain.text', FIELD_LABELS.ZONE);
-  cy.getFormSelectFieldById({ selectId: 'zone_id' })
-    .should('be.visible')
-    .and('be.enabled');
+      .and('contain.text', field.label);
+
+    // Validate required field indicator (asterisk)
+    if (field.required) {
+      labelElement.find('span.ddorg__carbon-component-mapper_is-required')
+        .should('be.visible')
+        .and('contain.text', '*');
+    }
+
+    switch (field.type) {
+      case 'select':
+        if (field.id === 'type' && isEdit) {
+          // Type field is disabled in edit mode
+          cy.getFormSelectFieldById({ selectId: field.id })
+            .should('be.visible')
+            .and('be.disabled')
+            .find('option:selected')
+            .should('have.text', providerConfig.type);
+        } else {
+          cy.getFormSelectFieldById({ selectId: field.id })
+            .should('be.visible')
+            .and('be.enabled');
+          // Select the type if it's the type field in add mode
+          if (field.id === 'type' && !isEdit) {
+            cy.getFormSelectFieldById({ selectId: field.id }).select(providerConfig.type);
+          }
+        }
+        break;
+      case 'text':
+        cy.getFormInputFieldByIdAndType({ inputId: field.id })
+          .should('be.visible')
+          .and('be.enabled');
+        break;
+      default:
+        break;
+    }
+  });
 }
 
 /**
@@ -165,10 +154,17 @@ function validateFormFields(fields, isEdit) {
   fields.forEach((field) => {
     // Skip label validation for placeholder fields in edit mode
     if (!(isEdit && field.isPlaceholderInEditMode)) {
-      cy.getFormLabelByForAttribute({ forValue: field.id })
+      const labelElement = cy.getFormLabelByForAttribute({ forValue: field.id })
         .scrollIntoView()
         .should('be.visible')
         .and('contain.text', field.label);
+
+      // Validate required field indicator (asterisk)
+      if (field.required) {
+        labelElement.find('.ddorg__carbon-component-mapper_is-required')
+          .should('be.visible')
+          .and('contain.text', '*');
+      }
     }
 
     switch (field.type) {
@@ -335,7 +331,7 @@ function setupTabForValidation(tab, providerConfig) {
  * @param {boolean} isEdit - Whether the form is in edit mode
  */
 Cypress.Commands.add('validateProviderFormFields', (providerConfig, isEdit) => {
-  validateCommonFormFields(providerConfig.type, isEdit);
+  validateCommonFormFields(providerConfig, isEdit);
   providerConfig.tabs.forEach((tab) => {
     // If not on the default tab, switch to it
     if (tab !== TAB_LABELS.DEFAULT) {
@@ -462,27 +458,20 @@ Cypress.Commands.add(
 );
 
 /**
- * Adds a provider and opens the edit form
+ * Opens the edit form for a provider that was created
  * @param {Object} providerConfig - The provider configuration object
- * @param {string} nameValue - The name to use for the provider
- * @param {string} hostValue - The hostname to use for the provider (optional)
  * @param {boolean} isAzureStack - Whether the provider is Azure Stack, which requires special handling when opening edit form
  */
-function addProviderAndOpenEditForm(
+function openEditFormForCreatedProvider(
   providerConfig,
-  nameValue,
-  hostValue,
   isAzureStack
 ) {
-  cy.fillProviderForm(providerConfig, nameValue, hostValue);
-  cy.providerValidation({
-    stubErrorResponse: false,
-  });
-  cy.interceptAddProviderApi({ isAzureStack });
+  const nameValue = providerConfig.formValues.common.name;
   selectCreatedProvider(nameValue);
   // Azure-Stack needs to be handled differently, add similar cases if needed
   // These APIs help populate the form fields
   if (isAzureStack) {
+    const hostValue = providerConfig.formValues.default?.['endpoints.default.hostname'];
     // TODO: Switch to cy.interceptApi once its enhanced to support multiple api intercepts from a single event
     cy.intercept(
       'GET',
@@ -648,18 +637,14 @@ function selectProviderAndDeleteWithOptionalFlashMessage({
  */
 function generateAddFormValidationTests(providerConfig, testOptions = {}) {
   const { isAzureStack = false, isAmazonEc2 = false } = testOptions;
-  
+
   describe(`Validate ${providerConfig.type} add form`, () => {
     it('Validate visibility of elements', () => {
       cy.validateProviderFormFields(providerConfig, false);
     });
 
     it('Should show the error message from the task_results API upon validation failure and validate cancel button behavior', () => {
-      cy.fillProviderForm(
-        providerConfig,
-        providerConfig.nameValue,
-        'manageiq.example.com'
-      );
+      cy.fillProviderForm(providerConfig);
       cy.providerValidation({
         stubErrorResponse: true,
         errorMessage: providerConfig.validationError,
@@ -673,16 +658,8 @@ function generateAddFormValidationTests(providerConfig, testOptions = {}) {
     });
 
     it(`Verify successful validate + add/${isAmazonEc2 ? 'refresh/' : ''}delete operations`, () => {
-      /**
-       * The provider's unique name is set in nameValue variable
-       */
-      const uniqueId = generateUniqueIdentifier();
-      const nameValue = `${providerConfig.nameValue} - verify-validate-add-${isAmazonEc2 ? 'refresh-' : ''}and-delete-operations - ${uniqueId}`;
-      const hostValue = `${slugifyWith(
-        providerConfig.type,
-        '-'
-      )}-${uniqueId}.com`;
-      cy.fillProviderForm(providerConfig, nameValue, hostValue);
+      const nameValue = providerConfig.formValues.common.name;
+      cy.fillProviderForm(providerConfig);
       //Add
       cy.providerValidation({
         stubErrorResponse: false,
@@ -707,7 +684,7 @@ function generateAddFormValidationTests(providerConfig, testOptions = {}) {
           FLASH_MESSAGES.REFRESH_OPERATION
         );
       }
-      
+
       // Delete
       // FIXME: remove this block once bug is fixed
       // Bug: After refresh, config option other than add remains disabled and requires any action to be performed to enable it back
@@ -719,6 +696,10 @@ function generateAddFormValidationTests(providerConfig, testOptions = {}) {
         createdProviderName: nameValue,
         assertDeleteFlashMessage: true,
       });
+    });
+
+    after(() => {
+      cy.appDbState('restore');
     });
   });
 }
@@ -734,38 +715,14 @@ function generateEditFormValidationTests(providerConfig, testOptions = {}) {
   const { isAzureStack = false, isAmazonEc2 = false } = testOptions;
 
   describe(`Validate ${providerConfig.type} edit form`, () => {
-    /**
-     * The provider's unique name is set in this variable at the start of each test
-     */
-    let nameFieldValue;
-    let hostValue;
-
     it('Validate visibility of elements', () => {
-      // TODO: Replace with better data set-up approach
-      const uniqueId = generateUniqueIdentifier();
-      nameFieldValue = `${providerConfig.nameValue} - verify-edit-form-elements - ${uniqueId}`;
-      hostValue = `${slugifyWith(providerConfig.type, '-')}-${uniqueId}.com`;
-      addProviderAndOpenEditForm(
-        providerConfig,
-        nameFieldValue,
-        hostValue,
-        isAzureStack
-      );
+      openEditFormForCreatedProvider(providerConfig, isAzureStack);
       cy.validateProviderFormFields(providerConfig, true);
     });
 
     if (isAmazonEc2) {
       it("Should show the error message from the task_results API upon validation failure and validate reset & cancel buttons' behavior", () => {
-        // TODO: Replace with better data set-up approach
-        const uniqueId = generateUniqueIdentifier();
-        nameFieldValue = `${providerConfig.nameValue} - verify-edit-form-validation-error - ${uniqueId}`;
-        hostValue = `${slugifyWith(providerConfig.type, '-')}-${uniqueId}.com`;
-        addProviderAndOpenEditForm(
-          providerConfig,
-          nameFieldValue,
-          hostValue,
-          false
-        );
+        openEditFormForCreatedProvider(providerConfig, false);
         updateProviderFieldsForEdit(providerConfig.type);
         cy.providerValidation({
           stubErrorResponse: true,
@@ -786,16 +743,7 @@ function generateEditFormValidationTests(providerConfig, testOptions = {}) {
     }
 
     it('Verify successful validate + edit operation', () => {
-      // TODO: Replace with better data set-up approach
-      const uniqueId = generateUniqueIdentifier();
-      nameFieldValue = `${providerConfig.nameValue} - verify-validate-and-edit-operations - ${uniqueId}`;
-      hostValue = `${slugifyWith(providerConfig.type, '-')}-${uniqueId}.com`;
-      addProviderAndOpenEditForm(
-        providerConfig,
-        nameFieldValue,
-        hostValue,
-        isAzureStack
-      );
+      openEditFormForCreatedProvider(providerConfig, isAzureStack);
       // Update fields based on provider type
       updateProviderFieldsForEdit(providerConfig.type);
       cy.providerValidation({
@@ -842,36 +790,12 @@ function generateEditFormValidationTests(providerConfig, testOptions = {}) {
 /**
  * Generates a test suite for validating the name uniqueness of a provider
  * @param {Object} providerConfig - The provider configuration object
- * @param {Object} testOptions - Test configuration options
- * @param {boolean} testOptions.isAzureStack - Whether the provider is Azure Stack (requires special handling)
  */
-function generateNameUniquenessTests(providerConfig, testOptions = {}) {
-  const { isAzureStack = false } = testOptions;
-
+function generateNameUniquenessTests(providerConfig) {
   describe(`${providerConfig.type} provider name uniqueness validation`, () => {
-    /**
-     * The provider's unique name is set in this variable at the start of the test
-     */
-    let nameFieldValue;
-    let hostValue;
-
-    beforeEach(() => {
-      // TODO: Replace with better data set-up approach
-      const uniqueId = generateUniqueIdentifier();
-      nameFieldValue = `${providerConfig.nameValue} - verify-duplicate-restriction - ${uniqueId}`;
-      hostValue = `${slugifyWith(providerConfig.type, '-')}-${uniqueId}.com`;
-
-      cy.fillProviderForm(providerConfig, nameFieldValue, hostValue);
-      cy.providerValidation({
-        stubErrorResponse: false,
-      });
-      cy.interceptAddProviderApi({ isAzureStack });
-    });
-
     it('Should display error on duplicate name usage', () => {
       cy.toolbar('Configuration', 'Add a New Cloud Provider');
-      // Add same name as above
-      cy.fillProviderForm(providerConfig, nameFieldValue, hostValue);
+      cy.fillProviderForm(providerConfig);
       assertNameAlreadyExistsError();
     });
 


### PR DESCRIPTION
PR to refactor cloud-provider Cypress test to improve test runtime

- Branched the refresh test to run only for I~~BM Cloud Infrastructure Center for now, let me know if we should consider any other provider instead of CIC~~ Amazon. Keeping this test because the refresh flow helps confirm that:
    - data populates correctly in the React data table
    - the table checkbox works properly for selecting the target row
    - and the `ems_cloud_refresh` call returns the expected flash message

- ~~Removed validation failure testing from the edit form since that coverage already exists in the add form tests~~
Branched the validation failure test from the edit form to run only for Amazon. Keeping this test since we should have coverage for at least one edit form (especially in light of https://github.com/ManageIQ/manageiq-ui-classic/issues/10042 - once that bug is fixed, I will add that use case for Amazon) This helps us catch any issues caused by differences in React Forms APIs/hooks between edit and add forms.
- ~~Same for cancel button validation, we already cover that in the add form flow~~
Same as above including cancel button validation for Amazon
- ~~Also removed the reset test because reset itself doesn’t trigger any flash message. The only thing we really need to validate there is its visibility, which is already covered in the edit form element validation test
Another possible way to test reset could be:
edit a few fields, click reset, and verify that the modified fields revert back to their original state, let me know if that makes sense~~
Same as above including reset button validation for Amazon

**Before:**
<img width="1458" height="406" alt="image" src="https://github.com/user-attachments/assets/99c6125b-20e0-4fad-b612-def7c9e72d41" />

**After:**
<img width="1472" height="482" alt="image" src="https://github.com/user-attachments/assets/25b2af29-fe7b-4220-984f-8637ba3a45a7" />

**After (with data setup using factories):**
<img width="1428" height="428" alt="image" src="https://github.com/user-attachments/assets/c5d6fb27-dc5f-4488-8ea4-3bdd87855f5a" />

Requires:
- [x] https://github.com/ManageIQ/manageiq-providers-oracle_cloud/pull/129

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
