### PR TITLE
Allow listening to cypress node event hooks in open mode

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -11,6 +11,11 @@ module.exports = defineConfig({
     numTestsKeptInMemory: 5,
     videoCompression: false,
     allowCypressEnv: false,
+    // Enable before:run event in open mode (cypress open) for local development.
+    // Required for on('before:run'...) hook (see #10026) to capture DB state.
+    // Note: after:run is only used in CI (run mode). Can be removed if Cypress defaults
+    // to enabling these events or if we no longer need the before:run hook.
+    experimentalInteractiveRunEvents: true,
 
     // See: https://docs.cypress.io/app/references/experiments#Experimental-Flake-Detection-Features
     retries: {


### PR DESCRIPTION
Follow-up to https://github.com/ManageIQ/manageiq-ui-classic/pull/10026
We moved DB capture to the `before:run` hook, but open mode requires `experimentalInteractiveRunEvents` flag for node event hooks to fire ([see](https://docs.cypress.io/api/node-events/before-run-api#Syntax))

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
