### PR TITLE
Git Domain Refresh Form Conversion from HAML to React

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -1815,17 +1815,13 @@ class MiqAeClassController < ApplicationController
     if params[:button] == "save"
       begin
         git_based_domain_import_service.import(params[:git_repo_id], params[:git_branch_or_tag], current_tenant.id)
-        add_flash(_("Successfully refreshed!"), :info)
-      rescue MiqException::Error => err
-        add_flash(err.message, :error)
+        render :json => {:message => _("Successfully refreshed!"), :level => "success"}
+      rescue => err
+        render :json => {:message => err.message, :level => "error"}, :status => 400
       end
     else
-      add_flash(_("Git based refresh canceled"), :info)
+      render :json => {:message => _("Git based refresh canceled"), :level => "warning"}
     end
-
-    session[:edit] = nil
-    @in_a_form = false
-    replace_right_cell(:replace_trees => [:ae])
   end
 
   def namespace
@@ -2803,7 +2799,7 @@ class MiqAeClassController < ApplicationController
   end
 
   def git_refresh
-    @in_a_form = true
+    @in_a_form = false
     @explorer = true
 
     session[:changed] = true
@@ -2831,17 +2827,14 @@ class MiqAeClassController < ApplicationController
     update_partial_div = :main_div
     update_partial = "git_domain_refresh"
 
-    presenter.update(update_partial_div, r[:partial => update_partial])
-
-    action_url = "refresh_git_domain"
-    presenter.show(:paging_div, :form_buttons_div)
-    presenter.update(:form_buttons_div, r[
-      :partial => "layouts/x_edit_buttons",
+    presenter.update(update_partial_div, r[
+      :partial => update_partial,
       :locals  => {
-        :record_id  => git_repo.id,
-        :action_url => action_url,
-        :serialize  => true,
-        :no_reset   => true
+        :git_repo_id  => @git_repo_id,
+        :ref_type     => @ref_type,
+        :ref_name     => @ref_name,
+        :branch_names => @branch_names,
+        :tag_names    => @tag_names
       }
     ])
 

--- a/app/javascript/components/git-domain-refresh-form/git-domain-refresh-form.schema.js
+++ b/app/javascript/components/git-domain-refresh-form/git-domain-refresh-form.schema.js
@@ -1,0 +1,46 @@
+import { componentTypes, validatorTypes } from '@@ddf';
+
+const createSchema = (branchNames, tagNames) => ({
+  fields: [
+    {
+      component: componentTypes.SELECT,
+      id: 'ref_type',
+      name: 'ref_type',
+      label: __('Branch/Tag'),
+      options: [
+        { label: __('Branch'), value: 'branch' },
+        { label: __('Tag'), value: 'tag' },
+      ],
+      validate: [{ type: validatorTypes.REQUIRED }],
+      isRequired: true,
+    },
+    {
+      component: componentTypes.SELECT,
+      id: 'branch_name',
+      name: 'branch_name',
+      label: __('Branches'),
+      options: branchNames.map((name) => ({ label: name, value: name })),
+      condition: {
+        when: 'ref_type',
+        is: 'branch',
+      },
+      validate: [{ type: validatorTypes.REQUIRED }],
+      isRequired: true,
+    },
+    {
+      component: componentTypes.SELECT,
+      id: 'tag_name',
+      name: 'tag_name',
+      label: __('Tags'),
+      options: tagNames.map((name) => ({ label: name, value: name })),
+      condition: {
+        when: 'ref_type',
+        is: 'tag',
+      },
+      validate: [{ type: validatorTypes.REQUIRED }],
+      isRequired: true,
+    },
+  ],
+});
+
+export default createSchema;

--- a/app/javascript/components/git-domain-refresh-form/index.jsx
+++ b/app/javascript/components/git-domain-refresh-form/index.jsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import MiqFormRenderer from '@@ddf';
+import { http } from '../../http_api';
+import miqRedirectBack from '../../helpers/miq-redirect-back';
+import createSchema from './git-domain-refresh-form.schema';
+
+const REF_TYPES = {
+  BRANCH: 'branch',
+  TAG: 'tag',
+};
+const DEFAULT_BRANCH = 'origin/master';
+
+const GitDomainRefreshForm = ({
+  gitRepoId,
+  refType: initialRefType,
+  refName: initialRefName,
+  branchNames,
+  tagNames,
+}) => {
+  // Set initial values based on ref type
+  const initialValues = {
+    git_repo_id: gitRepoId,
+    ref_type: initialRefType,
+    branch_name: initialRefType === REF_TYPES.BRANCH ? initialRefName : (branchNames[0] || DEFAULT_BRANCH),
+    tag_name: initialRefType === REF_TYPES.TAG ? initialRefName : (tagNames[0] || ''),
+  };
+
+  const onSubmit = (values) => {
+    miqSparkleOn();
+
+    const gitBranchOrTag = values.ref_type === REF_TYPES.BRANCH ? values.branch_name : values.tag_name;
+
+    const params = {
+      git_repo_id: gitRepoId,
+      git_branch_or_tag: gitBranchOrTag,
+      button: 'save',
+    };
+
+    return http.post('/miq_ae_class/refresh_git_domain', params, { skipErrors: [400] })
+      .then((response) => {
+        const message = response.message || __('Successfully refreshed!');
+        const level = response.level || 'success';
+        miqRedirectBack(message, level, '/miq_ae_class/explorer');
+      })
+      .catch((error) => {
+        const message = error.data?.message || error.message;
+        const level = error.data?.level || 'error';
+        miqRedirectBack(message, level, '/miq_ae_class/explorer');
+      });
+  };
+
+  const onCancel = () => {
+    const message = __('Git based refresh canceled');
+    miqRedirectBack(message, 'warning', '/miq_ae_class/explorer');
+  };
+
+  return (
+    <div className="git-domain-refresh-form">
+      <MiqFormRenderer
+        schema={createSchema(branchNames, tagNames)}
+        initialValues={initialValues}
+        onSubmit={onSubmit}
+        onCancel={onCancel}
+        buttonsLabels={{
+          submitLabel: __('Save'),
+          cancelLabel: __('Cancel'),
+        }}
+        canReset={false}
+      />
+    </div>
+  );
+};
+
+GitDomainRefreshForm.propTypes = {
+  gitRepoId: PropTypes.string.isRequired,
+  refType: PropTypes.string,
+  refName: PropTypes.string,
+  branchNames: PropTypes.arrayOf(PropTypes.string).isRequired,
+  tagNames: PropTypes.arrayOf(PropTypes.string).isRequired,
+};
+
+GitDomainRefreshForm.defaultProps = {
+  refType: REF_TYPES.BRANCH,
+  refName: DEFAULT_BRANCH,
+};
+
+export default GitDomainRefreshForm;

--- a/app/javascript/packs/component-definitions-common.js
+++ b/app/javascript/packs/component-definitions-common.js
@@ -184,6 +184,7 @@ import WorkflowRepositoryForm from '../components/workflow-repository-form';
 import XmlHolder from '../components/XmlHolder';
 import ZoneForm from '../components/zone-form';
 import MiqAeClass from '../components/miq-ae-class';
+import GitDomainRefreshForm from '../components/git-domain-refresh-form';
 
 /**
 * Add component definitions to this file.
@@ -246,6 +247,7 @@ ManageIQ.component.addReact('FormButtonsRedux', FormButtonsRedux);
 ManageIQ.component.addReact('GenericGroup', GenericGroup);
 ManageIQ.component.addReact('GenericGroupWrapper', GenericGroupWrapper);
 ManageIQ.component.addReact('GenericObjectForm', GenericObjectForm);
+ManageIQ.component.addReact('GitDomainRefreshForm', GitDomainRefreshForm);
 ManageIQ.component.addReact('GroupForm', GroupForm);
 ManageIQ.component.addReact('GtlView', GtlView);
 ManageIQ.component.addReact('HeatChart', HeatChart);

--- a/app/javascript/spec/git-domain-refresh-form/__snapshots__/git-domain-refresh-form.spec.js.snap
+++ b/app/javascript/spec/git-domain-refresh-form/__snapshots__/git-domain-refresh-form.spec.js.snap
@@ -1,0 +1,164 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GitDomainRefreshForm component should render correctly 1`] = `
+<div>
+  <div
+    class="git-domain-refresh-form"
+  >
+    <form
+      class="cds--form form-0-2-3 form-react"
+      novalidate=""
+    >
+      <div
+        class="cds--form-item"
+      >
+        <div
+          class="cds--select"
+        >
+          <label
+            class="cds--label"
+            dir="auto"
+            for="ref_type"
+          >
+            <span
+              aria-hidden="true"
+              class="ddorg__carbon-component-mapper_is-required isRequired-0-2-4"
+            >
+              *
+            </span>
+            Branch/Tag
+          </label>
+          <div
+            class="cds--select-input__wrapper"
+          >
+            <select
+              class="cds--select-input"
+              id="ref_type"
+              name="ref_type"
+              title="Branch"
+            >
+              <option
+                class="cds--select-option"
+                label="Branch"
+                value="branch"
+              >
+                Branch
+              </option>
+              <option
+                class="cds--select-option"
+                label="Tag"
+                value="tag"
+              >
+                Tag
+              </option>
+            </select>
+            <svg
+              aria-hidden="true"
+              class="cds--select__arrow"
+              fill="currentColor"
+              focusable="false"
+              height="16"
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 11 3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+              />
+            </svg>
+            
+          </div>
+        </div>
+      </div>
+      <div
+        class="cds--form-item"
+      >
+        <div
+          class="cds--select"
+        >
+          <label
+            class="cds--label"
+            dir="auto"
+            for="branch_name"
+          >
+            <span
+              aria-hidden="true"
+              class="ddorg__carbon-component-mapper_is-required isRequired-0-2-4"
+            >
+              *
+            </span>
+            Branches
+          </label>
+          <div
+            class="cds--select-input__wrapper"
+          >
+            <select
+              class="cds--select-input"
+              id="branch_name"
+              name="branch_name"
+              title="origin/main"
+            >
+              <option
+                class="cds--select-option"
+                label="origin/main"
+                value="origin/main"
+              >
+                origin/main
+              </option>
+              <option
+                class="cds--select-option"
+                label="origin/develop"
+                value="origin/develop"
+              >
+                origin/develop
+              </option>
+              <option
+                class="cds--select-option"
+                label="origin/feature/test"
+                value="origin/feature/test"
+              >
+                origin/feature/test
+              </option>
+            </select>
+            <svg
+              aria-hidden="true"
+              class="cds--select__arrow"
+              fill="currentColor"
+              focusable="false"
+              height="16"
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 11 3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+              />
+            </svg>
+            
+          </div>
+        </div>
+      </div>
+      <div
+        class="cds--btn-set"
+      >
+        <button
+          class="cds--btn cds--btn--primary cds--btn--disabled"
+          disabled=""
+          type="submit"
+          variant="primary"
+        >
+          Save
+        </button>
+        <button
+          class="cds--btn cds--btn--secondary"
+          type="button"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  </div>
+</div>
+`;

--- a/app/javascript/spec/git-domain-refresh-form/git-domain-refresh-form.spec.js
+++ b/app/javascript/spec/git-domain-refresh-form/git-domain-refresh-form.spec.js
@@ -1,0 +1,234 @@
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import fetchMock from 'fetch-mock';
+
+import GitDomainRefreshForm from '../../components/git-domain-refresh-form';
+import { renderWithRedux } from '../helpers/mountForm';
+import { http } from '../../http_api';
+
+import miqRedirectBack from '../../helpers/miq-redirect-back';
+import '../helpers/miqSparkle';
+
+jest.mock('../../helpers/miq-redirect-back', () => jest.fn());
+jest.mock('../../http_api');
+
+describe('GitDomainRefreshForm component', () => {
+  let initialProps;
+  let submitSpyMiqSparkleOn;
+
+  beforeEach(() => {
+    initialProps = {
+      gitRepoId: '789',
+      branchNames: ['origin/main', 'origin/develop', 'origin/feature/test'],
+      tagNames: ['v1.0.0', 'v1.1.0', 'v2.0.0'],
+      refType: 'branch',
+      refName: 'origin/main',
+    };
+
+    submitSpyMiqSparkleOn = jest.spyOn(window, 'miqSparkleOn');
+  });
+
+  afterEach(() => {
+    fetchMock.reset();
+    fetchMock.restore();
+    submitSpyMiqSparkleOn.mockRestore();
+  });
+
+  it('should render correctly', () => {
+    const { container } = renderWithRedux(<GitDomainRefreshForm {...initialProps} />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render with branch as default ref_type', async() => {
+    renderWithRedux(<GitDomainRefreshForm {...initialProps} />);
+
+    await waitFor(() => {
+      const refTypeSelect = screen.getByLabelText(/branch\/tag/i);
+      expect(refTypeSelect).toHaveValue('branch');
+    });
+  });
+
+  it('should render branch select when ref_type is branch', async() => {
+    renderWithRedux(<GitDomainRefreshForm {...initialProps} />);
+
+    await waitFor(() => {
+      const branchSelect = screen.getByLabelText(/branches/i);
+      expect(branchSelect).toBeInTheDocument();
+    });
+  });
+
+  it('should render tag select when ref_type is tag', async() => {
+    const user = userEvent.setup();
+    renderWithRedux(<GitDomainRefreshForm {...initialProps} />);
+
+    const refTypeSelect = screen.getByLabelText(/branch\/tag/i);
+    await user.selectOptions(refTypeSelect, 'tag');
+
+    await waitFor(() => {
+      const tagSelect = screen.getByLabelText(/tags/i);
+      expect(tagSelect).toBeInTheDocument();
+    });
+  });
+
+  it('should have correct branch options', async() => {
+    renderWithRedux(<GitDomainRefreshForm {...initialProps} />);
+
+    await waitFor(() => {
+      const branchSelect = screen.getByLabelText(/branches/i);
+      const options = Array.from(branchSelect.options).map((opt) => opt.text);
+
+      expect(options).toContain('origin/main');
+      expect(options).toContain('origin/develop');
+      expect(options).toContain('origin/feature/test');
+    });
+  });
+
+  it('should have correct tag options', async() => {
+    const user = userEvent.setup();
+    renderWithRedux(<GitDomainRefreshForm {...initialProps} />);
+
+    const refTypeSelect = screen.getByLabelText(/branch\/tag/i);
+    await user.selectOptions(refTypeSelect, 'tag');
+
+    await waitFor(() => {
+      const tagSelect = screen.getByLabelText(/tags/i);
+      const options = Array.from(tagSelect.options).map((opt) => opt.text);
+
+      expect(options).toContain('v1.0.0');
+      expect(options).toContain('v1.1.0');
+      expect(options).toContain('v2.0.0');
+    });
+  });
+
+  it('should render Save and Cancel buttons', () => {
+    renderWithRedux(<GitDomainRefreshForm {...initialProps} />);
+
+    expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+  });
+
+  it('should set initial branch value to current branch', async() => {
+    renderWithRedux(<GitDomainRefreshForm {...initialProps} />);
+
+    await waitFor(() => {
+      const branchSelect = screen.getByLabelText(/branches/i);
+      expect(branchSelect).toHaveValue('origin/main');
+    });
+  });
+
+  it('should call correct API endpoint on submit with branch', async() => {
+    const user = userEvent.setup();
+
+    http.post = jest.fn().mockResolvedValue({
+      message: 'Successfully Refreshed!',
+      level: 'success',
+    });
+
+    renderWithRedux(<GitDomainRefreshForm {...initialProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/branches/i)).toBeInTheDocument();
+    });
+
+    const branchSelect = screen.getByLabelText(/branches/i);
+    await user.selectOptions(branchSelect, 'origin/develop');
+
+    const submitButton = screen.getByRole('button', { name: /save/i });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(http.post).toHaveBeenCalledWith(
+        '/miq_ae_class/refresh_git_domain',
+        expect.objectContaining({
+          git_repo_id: '789',
+          git_branch_or_tag: 'origin/develop',
+          button: 'save',
+        }),
+        { skipErrors: [400] }
+      );
+    });
+
+    expect(miqSparkleOn).toHaveBeenCalled();
+    expect(miqRedirectBack).toHaveBeenCalledWith(
+      'Successfully Refreshed!',
+      'success',
+      '/miq_ae_class/explorer'
+    );
+  });
+
+  it('should call correct API endpoint on submit with tag', async() => {
+    const user = userEvent.setup();
+
+    http.post = jest.fn().mockResolvedValue({
+      message: 'Successfully Refreshed!',
+      level: 'success',
+    });
+
+    renderWithRedux(<GitDomainRefreshForm {...initialProps} />);
+
+    const refTypeSelect = screen.getByLabelText(/branch\/tag/i);
+    await user.selectOptions(refTypeSelect, 'tag');
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/tags/i)).toBeInTheDocument();
+    });
+
+    const tagSelect = screen.getByLabelText(/tags/i);
+    await user.selectOptions(tagSelect, 'v2.0.0');
+
+    const submitButton = screen.getByRole('button', { name: /save/i });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(http.post).toHaveBeenCalledWith(
+        '/miq_ae_class/refresh_git_domain',
+        expect.objectContaining({
+          git_repo_id: '789',
+          git_branch_or_tag: 'v2.0.0',
+          button: 'save',
+        }),
+        { skipErrors: [400] }
+      );
+    });
+
+    expect(miqSparkleOn).toHaveBeenCalled();
+    expect(miqRedirectBack).toHaveBeenCalledWith(
+      'Successfully Refreshed!',
+      'success',
+      '/miq_ae_class/explorer'
+    );
+  });
+
+  it('should redirect back on cancel', async() => {
+    const user = userEvent.setup();
+    window.__ = jest.fn((str) => str);
+
+    renderWithRedux(<GitDomainRefreshForm {...initialProps} />);
+
+    const cancelButton = screen.getByRole('button', { name: /cancel/i });
+    await user.click(cancelButton);
+
+    await waitFor(() => {
+      expect(miqRedirectBack).toHaveBeenCalledWith(
+        expect.stringContaining('canceled'),
+        'warning',
+        '/miq_ae_class/explorer'
+      );
+    });
+  });
+
+  it('should default to first branch if refName not provided', async() => {
+    const propsWithoutRefName = {
+      ...initialProps,
+      refName: '',
+    };
+
+    renderWithRedux(<GitDomainRefreshForm {...propsWithoutRefName} />);
+
+    await waitFor(() => {
+      const branchSelect = screen.getByLabelText(/branches/i);
+      expect(branchSelect).toHaveValue('origin/main');
+    });
+  });
+});

--- a/app/stylesheet/ddf_override.scss
+++ b/app/stylesheet/ddf_override.scss
@@ -570,3 +570,22 @@ form .miq-validation-button, .miq-async-action-button {
     }
   }
 }
+
+.git-domain-refresh-form {
+  .cds--form-item {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    
+    .cds--label {
+      margin-bottom: 0.5rem;
+    }
+    
+    .cds--select,
+    .cds--dropdown,
+    .cds--list-box__wrapper {
+      width: 100%;
+      max-width: 100%;
+    }
+  }
+}

--- a/app/views/miq_ae_class/_git_domain_refresh.html.haml
+++ b/app/views/miq_ae_class/_git_domain_refresh.html.haml
@@ -1,37 +1,7 @@
 = render :partial => "layouts/flash_msg"
-- ref_type = @ref_type || "branch"
-- ref_name = @ref_name || "origin/master"
-%form#form_div
-  = hidden_field_tag(:git_repo_id, @git_repo_id, :class => "hidden-git-repo-id")
-  %input{:type => "hidden", :class => "git-branch-or-tag", :name => "git_branch_or_tag"}
-
-  .form-horizontal
-    .form-group
-      %label.col-md-2.control-label
-        = _("Branch/Tag")
-      .col-md-8
-        = select_tag("branch_or_tag_select",
-                     options_for_select([["#{_('Branch')}", 'branch'], ["#{_('Tag')}", 'tag']]),
-                     :class => "git-branch-or-tag-select selectpicker")
-
-    .form-group.git-branch-group
-      %label.col-md-2.control-label
-        = _("Branches")
-      .col-md-8
-        = select_tag("git_branches", options_for_select(@branch_names), :class => "git-branches selectpicker")
-
-    .form-group.git-tag-group{:style => "display: none;"}
-      %label.col-md-2.control-label
-        = _("Tags")
-      .col-md-8
-        = select_tag("git_tags", options_for_select(@tag_names), :class => "git-tags selectpicker")
-
-:javascript
-  $(function() {
-    miqInitSelectPicker();
-
-    Automate.setUpGitRefreshClickHandlers();
-    Automate.setUpDefaultGitBranchOrTagValue('#{ref_type}', '#{ref_name}');
-
-    miqButtons('show');
-  });
+= react('GitDomainRefreshForm',
+        :gitRepoId   => git_repo_id.to_s,
+        :refType     => ref_type || 'branch',
+        :refName     => ref_name || 'origin/master',
+        :branchNames => branch_names || [],
+        :tagNames    => tag_names || [])

--- a/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/git-domain-refresh-form.cy.js
+++ b/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/git-domain-refresh-form.cy.js
@@ -1,0 +1,202 @@
+import { flashClassMap } from '../../../../../support/assertions/assertion_constants';
+
+describe('Automation > Embedded Automate > Explorer > Git Domain Refresh', () => {
+  let gitDomainName;
+
+  beforeEach(() => {
+    // Enable git_owner role in MiqRegion (required for git refresh button to be visible)
+    // Create an active assigned_server_role for git_owner
+    cy.appFactories([
+      ['create', 'miq_server'],
+    ]).then((serverResults) => {
+      cy.appEval(`
+        server = MiqServer.find(${serverResults[0].id})
+        server_role = ServerRole.find_or_create_by(:name => 'git_owner')
+        FactoryBot.create(:assigned_server_role,
+                          :miq_server => server,
+                          :server_role => server_role,
+                          :active => true,
+                          :priority => 1)
+      `);
+    });
+
+    // Set up a git domain using FactoryBot via appFactories
+    cy.appFactories([
+      ['create', 'git_repository', {
+        url: 'https://github.com/GilbertCherrie/CloudForms_Infoblox',
+      }],
+    ]).then((results) => {
+      const gitRepoId = results[0].id;
+
+      // Create git branches and tags matching the actual GitHub repository
+      cy.appFactories([
+        ['create', 'git_branch', {
+          name: 'master',
+          git_repository_id: gitRepoId,
+        }],
+        ['create', 'git_branch', {
+          name: 'test-branch-0',
+          git_repository_id: gitRepoId,
+        }],
+        ['create', 'git_branch', {
+          name: 'test-branch-1',
+          git_repository_id: gitRepoId,
+        }],
+        ['create', 'git_tag', {
+          name: 'test1',
+          git_repository_id: gitRepoId,
+        }],
+        ['create', 'git_tag', {
+          name: 'test2',
+          git_repository_id: gitRepoId,
+        }],
+        ['create', 'git_tag', {
+          name: 'test3',
+          git_repository_id: gitRepoId,
+        }],
+      ]).then(() => {
+        // Create the git domain with a name matching the repository
+        cy.appFactories([
+          ['create', 'miq_ae_git_domain', {
+            name: 'CloudForms_Infoblox',
+            git_repository_id: gitRepoId,
+            ref: 'origin/master',
+            ref_type: 'branch',
+          }],
+        ]).then((gitResults) => {
+          gitDomainName = gitResults[0].name;
+        });
+      });
+    });
+
+    cy.login();
+    cy.menu('Automation', 'Embedded Automate', 'Explorer');
+    cy.expect_explorer_title('Datastore');
+    cy.accordion('Datastore');
+  });
+
+  afterEach(() => {
+    cy.appDbState('restore');
+  });
+
+  describe('Git Domain Refresh Form', () => {
+    beforeEach(() => {
+      // Navigate to the specific git domain by name
+      // Git domains display as: "CloudForms_Infoblox (master) (Locked)"
+      // Match the domain name followed by branch/tag info and (Locked)
+      cy.selectAccordionItem(['Datastore', new RegExp(`${gitDomainName}.*\\(Locked\\)`)]);
+    });
+
+    it('Clicks the cancel button', () => {
+      cy.toolbar('Configuration', 'Refresh with a new branch or tag');
+
+      // Click cancel button
+      cy.getFormButtonByTypeWithText({ buttonText: 'Cancel' }).click();
+
+      // Verify we're back at the explorer (flash message confirms cancel)
+      cy.expect_flash(flashClassMap.warning, 'canceled');
+    });
+
+    it('Displays the git domain refresh form with branch selection', () => {
+      cy.toolbar('Configuration', 'Refresh with a new branch or tag');
+
+      // Verify form elements are present
+      cy.getFormSelectFieldById({ selectId: 'ref_type' }).should('be.visible');
+      cy.getFormSelectFieldById({ selectId: 'branch_name' }).should('be.visible');
+    });
+
+    it('Switches between branch and tag selection', () => {
+      cy.toolbar('Configuration', 'Refresh with a new branch or tag');
+
+      // Select branch type
+      cy.getFormSelectFieldById({ selectId: 'ref_type' }).select('branch');
+      cy.getFormSelectFieldById({ selectId: 'branch_name' }).should('be.visible');
+      cy.getFormSelectFieldById({ selectId: 'tag_name' }).should('not.exist');
+
+      // Select tag type
+      cy.getFormSelectFieldById({ selectId: 'ref_type' }).select('tag');
+      cy.getFormSelectFieldById({ selectId: 'tag_name' }).should('be.visible');
+      cy.getFormSelectFieldById({ selectId: 'branch_name' }).should('not.exist');
+    });
+
+    it('Refreshes git domain with a new branch', () => {
+      cy.toolbar('Configuration', 'Refresh with a new branch or tag');
+
+      // Intercept the POST request
+      cy.intercept('POST', '/miq_ae_class/refresh_git_domain').as('refreshGitDomain');
+
+      // Verify initial branch is selected
+      cy.getFormSelectFieldById({ selectId: 'ref_type' }).should('have.value', 'branch');
+      cy.getFormSelectFieldById({ selectId: 'branch_name' }).should('be.visible');
+
+      // Get the selected branch name before changing
+      cy.getFormSelectFieldById({ selectId: 'branch_name' }).invoke('val').then((initialBranch) => {
+        // Select a different branch (third option)
+        cy.getFormSelectFieldById({ selectId: 'branch_name' }).select(2);
+
+        // Verify the branch selection changed
+        cy.getFormSelectFieldById({ selectId: 'branch_name' }).invoke('val').should('not.equal', initialBranch);
+
+        // Get the newly selected branch value
+        cy.getFormSelectFieldById({ selectId: 'branch_name' }).invoke('val').then((selectedBranch) => {
+          // Click Save button
+          cy.getFormButtonByTypeWithText({ buttonText: 'Save', buttonType: 'submit' }).click();
+
+          // Verify the request was made with correct body including the selected branch
+          cy.wait('@refreshGitDomain').then((interception) => {
+            expect(interception.request.body).to.have.property('git_repo_id');
+            expect(interception.request.body).to.have.property('git_branch_or_tag', selectedBranch);
+            expect(interception.request.body).to.have.property('button', 'save');
+          });
+
+          // Verify success flash message appears
+          cy.expect_flash(flashClassMap.success, 'Successfully refreshed');
+
+          // Verify the explorer title shows the updated branch
+          cy.get('#explorer_title_text').should('contain', selectedBranch);
+          cy.get('#explorer_title_text').should('contain', gitDomainName);
+        });
+      });
+    });
+
+    it('Refreshes git domain with a tag', () => {
+      cy.toolbar('Configuration', 'Refresh with a new branch or tag');
+
+      // Intercept the POST request
+      cy.intercept('POST', '/miq_ae_class/refresh_git_domain').as('refreshGitDomain');
+
+      // Switch to tag type
+      cy.getFormSelectFieldById({ selectId: 'ref_type' }).select('tag');
+
+      // Verify tag select is now visible and branch select is hidden
+      cy.getFormSelectFieldById({ selectId: 'tag_name' }).should('be.visible');
+      cy.getFormSelectFieldById({ selectId: 'branch_name' }).should('not.exist');
+
+      // Select a tag (second option)
+      cy.getFormSelectFieldById({ selectId: 'tag_name' }).select(1);
+
+      // Get the selected tag value
+      cy.getFormSelectFieldById({ selectId: 'tag_name' }).invoke('val').then((selectedTag) => {
+        // Verify a tag is selected
+        expect(selectedTag).to.not.be.empty;
+
+        // Click Save button
+        cy.getFormButtonByTypeWithText({ buttonText: 'Save', buttonType: 'submit' }).click();
+
+        // Verify the request was made with correct body including the selected tag
+        cy.wait('@refreshGitDomain').then((interception) => {
+          expect(interception.request.body).to.have.property('git_repo_id');
+          expect(interception.request.body).to.have.property('git_branch_or_tag', selectedTag);
+          expect(interception.request.body).to.have.property('button', 'save');
+        });
+
+        // Verify success flash message appears
+        cy.expect_flash(flashClassMap.success, 'Successfully refreshed');
+
+        // Verify the explorer title shows the updated tag
+        cy.get('#explorer_title_text').should('contain', selectedTag);
+        cy.get('#explorer_title_text').should('contain', gitDomainName);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fixes part of #10059 

Converts the git domain refresh form from  Ruby haml file to use React

Automation / Embedded automate / Explorer / Configuration / Refresh with a new tag or branch

Before:
<img width="1920" height="958" alt="image" src="https://github.com/user-attachments/assets/2da85546-d7d5-45f9-af52-581ec032b91e" />

After:
<img width="1920" height="956" alt="image" src="https://github.com/user-attachments/assets/c5b40309-cc9e-4d7c-aca4-2b09e0d3f940" />
<img width="1920" height="954" alt="image" src="https://github.com/user-attachments/assets/0680ea88-e955-4924-97ff-e6fd111ce93c" />






<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
