### PR TITLE
Fix the generic object page navigation

### DIFF
--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -221,7 +221,7 @@ module Menu
         Menu::Section.new(:automate, N_("Embedded Automate"), nil, [
           Menu::Item.new('miq_ae_class',         N_('Explorer'),        'miq_ae_class_explorer',         {:feature => 'miq_ae_domain_view'},            '/miq_ae_class/explorer'),
           Menu::Item.new('miq_ae_tools',         N_('Simulation'),      'miq_ae_class_simulation',       {:feature => 'miq_ae_class_simulation'},       '/miq_ae_tools/resolve'),
-          Menu::Item.new('generic_object_definition', N_('Generic Objects'), 'generic_object_definition', {:feature => 'generic_object_definition'},   '/generic_object_definition/show_list'),
+          Menu::Item.new('generic_object_definition', N_('Generic Objects'), 'generic_object_definition', {:feature => 'generic_object_definition'},   '/generic_object_definition/show_list?id=root'),
           Menu::Item.new('miq_ae_customization', N_('Customization'),   'miq_ae_customization_explorer', {:feature => 'miq_ae_customization_explorer', :any => true}, '/miq_ae_customization/explorer'),
           Menu::Item.new('miq_ae_export',        N_('Import / Export'), 'miq_ae_class_import_export',    {:feature => 'miq_ae_class_import_export'},    '/miq_ae_tools/import_export'),
           Menu::Item.new('miq_ae_logs',          N_('Log'),             'miq_ae_class_log',              {:feature => 'miq_ae_class_log'},              '/miq_ae_tools/log'),


### PR DESCRIPTION
Similar fix to this PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/10063

This PR fixes a bug where the generic object definition page will redirect to the last visited summary page when navigating to this page from the sidebar menu.

<img width="873" height="462" alt="Screenshot 2026-06-01 at 2 32 01 PM" src="https://github.com/user-attachments/assets/e0c7e06d-7d86-43f5-ba5c-6cfecfe1f979" />

This PR fixes this issue to instead redirect to the explorer screen on the root node.

<img width="1049" height="488" alt="Screenshot 2026-06-01 at 2 33 49 PM" src="https://github.com/user-attachments/assets/5cc18e94-1f58-4851-a8a9-eecd3bbb73be" />
