### PR TITLE
[WIP] Delete HAML table code

### DIFF
--- a/app/views/host/_form.html.haml
+++ b/app/views/host/_form.html.haml
@@ -4,11 +4,7 @@
     = n_("Host", "Hosts", session[:host_items].length)
     = _('Selected')
   = _('Click on a Host to fetch its settings')
-  %table.admittable{:height => '75'}
-    %tbody
-      %tr
-        %td
-          - if session[:host_items]
-            - @embedded = true
-            = render :partial => 'layouts/gtl'
+  - if session[:host_items]
+    - @embedded = true
+    = render :partial => 'layouts/gtl'
 = react('HostEditForm', {:ids => (@host.id ? [@host.id] : session[:host_items])})

--- a/app/views/ops/_settings_details_tab.html.haml
+++ b/app/views/ops/_settings_details_tab.html.haml
@@ -4,12 +4,8 @@
     - if @edit
       = react('RegionForm', :maxDescLen => ViewHelper::MAX_LEN_SMALL_TEXT_FIELD, :id => region.id.to_s)
     .spacer
-
-    %table.table.table-striped.table-bordered.table-hover
-      %tbody
-        = react('SettingsDetailsTab', 
-          :region       => region,
-          :scanItemsCount    => @scan_items.size,
-          :zonesCount        => @zones.size,
-          :miqSchedulesCount => @miq_schedules.size)
-       
+    = react('SettingsDetailsTab',
+      :region            => region,
+      :scanItemsCount    => @scan_items.size,
+      :zonesCount        => @zones.size,
+      :miqSchedulesCount => @miq_schedules.size)


### PR DESCRIPTION
Delete technical debt for HAML tables that are not needed.

1) Edit Host Form

We can delete this table code from the HAML because it isn't needed. The screenshots below show no changes after deleting this code.

Before:
<img width="1001" height="697" alt="Screenshot 2026-06-02 at 10 42 28 AM" src="https://github.com/user-attachments/assets/cb7c3070-a1b2-4d16-8eda-58abe81bcbf3" />

After:
<img width="949" height="722" alt="Screenshot 2026-06-02 at 10 41 47 AM" src="https://github.com/user-attachments/assets/4bdc7915-c075-4448-b35b-73e30dc11884" />

2) Settings Detail Table

We can delete this table code from the HAML because it isn't needed. The screenshots below show no changes after deleting this code.

Before:
<img width="888" height="310" alt="Screenshot 2026-06-17 at 10 03 40 AM" src="https://github.com/user-attachments/assets/0cc12c03-cb6a-4ce2-8f91-1f620cd20845" />

After:
<img width="887" height="463" alt="Screenshot 2026-06-17 at 10 06 33 AM" src="https://github.com/user-attachments/assets/25c71503-f5ae-471e-989d-34e8ae06ac23" />