### PR TITLE
Fix host power state to show normalized state

### DIFF
--- a/app/helpers/host_helper/textual_summary.rb
+++ b/app/helpers/host_helper/textual_summary.rb
@@ -194,7 +194,7 @@ module HostHelper::TextualSummary
   end
 
   def textual_power_state
-    textual_power_state_whitelisted(@record.state)
+    textual_power_state_whitelisted(@record.normalized_state)
   end
 
   def textual_lockdown_mode

--- a/spec/helpers/host_helper/textual_summary_spec.rb
+++ b/spec/helpers/host_helper/textual_summary_spec.rb
@@ -38,6 +38,31 @@ describe HostHelper::TextualSummary do
     guid
   )
 
+  describe '.textual_power_state' do
+    subject { textual_power_state }
+    {
+      'on'      => {:fonticon => 'currentstate-on', :background => 'green'},
+      'off'     => {:fonticon => 'currentstate-off', :background => 'black'},
+      'archive' => {:fonticon => 'fa fa-archive', :background => nil},
+    }.each do |state, quad_icon|
+      context "when normalized_state is #{state}" do
+        before do
+          allow(@record).to receive(:normalized_state).and_return(state)
+          allow(QuadiconHelper).to receive(:machine_state).with(state).and_return(quad_icon)
+        end
+
+        it "returns the whitelisted power state for #{state}" do
+          expect(subject).to eq(
+            :label      => 'Power State',
+            :value      => state,
+            :icon       => quad_icon[:fonticon],
+            :background => quad_icon[:background]
+          )
+        end
+      end
+    end
+  end
+
   include_examples "textual_group", "Relationships", %i(
     ems
     cluster


### PR DESCRIPTION
Fix the host summary page to show the normalized state instead of the power state.

Before:
<img width="1113" height="187" alt="Screenshot 2026-06-03 at 11 15 26 AM" src="https://github.com/user-attachments/assets/0deac781-02c3-4e6d-8d15-9826379fb206" />

After:
<img width="1099" height="190" alt="Screenshot 2026-06-03 at 11 16 20 AM" src="https://github.com/user-attachments/assets/0e710786-025b-412f-b7ce-6dcf6233a255" />

