### PR TITLE
Configure Renovate to update snapshots

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,8 @@
         "commands": [
           "yarn test -u"
         ],
-        "fileFilters": ["**/*.snap"]
+        "fileFilters": ["**/*.snap"],
+        "executionMode": "branch"
       }
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,17 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "inheritConfig": true,
-  "inheritConfigRepoName": "manageiq/renovate-config"
+  "inheritConfigRepoName": "manageiq/renovate-config",
+  "packageRules": [
+    {
+      "description": "Auto-update Jest snapshots for Carbon packages",
+      "matchPackageNames": ["@carbon/charts-react", "@carbon/react"],
+      "postUpgradeTasks": {
+        "commands": [
+          "yarn test -u"
+        ],
+        "fileFilters": ["**/*.snap"]
+      }
+    }
+  ]
 }


### PR DESCRIPTION
PR to enable snapshot updates in Renovate for Carbon packages
Reference: https://docs.renovatebot.com/configuration-options/

Once this is in, let's see how it works in https://github.com/ManageIQ/manageiq-ui-classic/pull/10076

Not sure whether this should be configured here or in [ManageIQ/renovate-config](https://github.com/ManageIQ/renovate-config/blob/master/org-inherited-config.json). I feel like it makes more sense here. I don't recall seeing Renovate PRs fail because of snapshot mismatches in other repos (I also don't really remember seeing Jest used in those repos)
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
