### PR TITLE
Cleanup react imports to align with React 17

### DIFF
--- a/app/javascript/components/git-domain-refresh-form/index.jsx
+++ b/app/javascript/components/git-domain-refresh-form/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import MiqFormRenderer from '@@ddf';
 import { http } from '../../http_api';

--- a/app/javascript/forms/required-label.jsx
+++ b/app/javascript/forms/required-label.jsx
@@ -1,11 +1,10 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 const RequiredLabel = ({ label }) => (
-  <React.Fragment>
+  <>
     <span style={{ color: '#ff0000' }}>* </span>
     { label }
-  </React.Fragment>
+  </>
 );
 
 RequiredLabel.propTypes = {

--- a/app/javascript/spec/git-domain-refresh-form/git-domain-refresh-form.spec.js
+++ b/app/javascript/spec/git-domain-refresh-form/git-domain-refresh-form.spec.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';


### PR DESCRIPTION
Remove unnecessary `import React from "react` and refactored React.Fragment code to use modern syntax

@miq-bot add-label cleanup
@miq-bot add-reviewer @GilbertCherrie
@miq-bot add-reviewer @asirvadAbrahamVarghese  
