### PR TITLE
Fix EmbeddedWorkflow Credential Mapping

### DIFF
--- a/app/javascript/components/workflow-credential-mapping-form/credential-utils.js
+++ b/app/javascript/components/workflow-credential-mapping-form/credential-utils.js
@@ -1,0 +1,133 @@
+/**
+ * Utility functions for extracting and processing workflow credential references
+ */
+
+/**
+ * Regular expressions for matching JSONPath credential references
+ */
+const JSONPATH_PATTERNS = {
+  // Matches: $$.Credentials.my_credential_name
+  DOT_NOTATION: /\$\$\.Credentials\.([a-zA-Z0-9_-]+)/,
+  // Matches: $$['Credentials']['my_credential_name']
+  BRACKET_NOTATION: /\$\$\['Credentials'\]\['([a-zA-Z0-9_-]+)'\]/,
+};
+
+/**
+ * Extracts the credential reference name from a JSONPath value
+ * Supports both dot notation ($$.Credentials.xxx) and bracket notation ($$['Credentials']['xxx'])
+ * 
+ * @param {string} value - The JSONPath string (e.g., "$$.Credentials.my_ssh_credential")
+ * @returns {string|null} The extracted credential reference name, or null if not found
+ * 
+ * @example
+ * extractCredentialReference("$$.Credentials.my_ssh_credential") // returns "my_ssh_credential"
+ * extractCredentialReference("$$['Credentials']['my_api_token']") // returns "my_api_token"
+ * extractCredentialReference("invalid") // returns null
+ */
+export const extractCredentialReference = (value) => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  // Try dot notation first (most common)
+  const dotMatch = value.match(JSONPATH_PATTERNS.DOT_NOTATION);
+  if (dotMatch && dotMatch[1]) {
+    return dotMatch[1];
+  }
+
+  // Try bracket notation
+  const bracketMatch = value.match(JSONPATH_PATTERNS.BRACKET_NOTATION);
+  if (bracketMatch && bracketMatch[1]) {
+    return bracketMatch[1];
+  }
+
+  return null;
+};
+
+/**
+ * Parses a workflow payload and extracts all credential references
+ * 
+ * @param {string} payload - JSON string containing the workflow definition
+ * @returns {Object} Map of credential reference names to their JSONPath values
+ * @throws {Error} If the payload is invalid or contains no credentials
+ * 
+ * @example
+ * const payload = JSON.stringify({
+ *   States: {
+ *     ExecuteScript: {
+ *       Credentials: {
+ *         ssh_cred: "$$.Credentials.my_ssh_credential",
+ *         api_token: "$$.Credentials.my_api_token"
+ *       }
+ *     }
+ *   }
+ * });
+ * 
+ * parseWorkflowCredentials(payload)
+ * // Returns: {
+ * //   my_ssh_credential: "$$.Credentials.my_ssh_credential",
+ * //   my_api_token: "$$.Credentials.my_api_token"
+ * // }
+ */
+export const parseWorkflowCredentials = (payload) => {
+  // Parse the JSON payload
+  let parsedPayload;
+  try {
+    parsedPayload = JSON.parse(payload);
+  } catch (error) {
+    throw new Error(`Failed to parse workflow payload: ${error.message}`);
+  }
+
+  // Validate the payload structure
+  if (!parsedPayload.States || typeof parsedPayload.States !== 'object') {
+    throw new Error('Invalid payload structure: missing or invalid States property');
+  }
+
+  const payloadCredentials = {};
+  const jsonPayload = parsedPayload.States;
+
+  // Iterate through all states in the workflow
+  Object.values(jsonPayload).forEach((state) => {
+    // Check if this state has credentials
+    if (!state.Credentials || typeof state.Credentials !== 'object') {
+      return;
+    }
+
+    // Process each credential in this state
+    Object.entries(state.Credentials).forEach(([placeholderName, jsonPathValue]) => {
+      // Extract the actual credential reference from the JSONPath value
+      const credentialRef = extractCredentialReference(jsonPathValue);
+
+      if (credentialRef) {
+        // Use the extracted credential reference as the key
+        payloadCredentials[credentialRef] = jsonPathValue;
+      } else {
+        // Fallback: if we can't extract a reference, use the placeholder name
+        // This handles cases where the value might not be in JSONPath format
+        payloadCredentials[placeholderName] = jsonPathValue;
+      }
+    });
+  });
+
+  // Validate that we found at least one credential
+  if (Object.keys(payloadCredentials).length === 0) {
+    throw new Error('Workflow does not have any credentials to map.');
+  }
+
+  return payloadCredentials;
+};
+
+/**
+ * Validates that a credential reference name is valid
+ * 
+ * @param {string} credentialRef - The credential reference to validate
+ * @returns {boolean} True if valid, false otherwise
+ */
+export const isValidCredentialReference = (credentialRef) => {
+  if (typeof credentialRef !== 'string' || credentialRef.length === 0) {
+    return false;
+  }
+
+  // Valid credential references should only contain alphanumeric characters, underscores, and hyphens
+  return /^[a-zA-Z0-9_-]+$/.test(credentialRef);
+};

--- a/app/javascript/components/workflow-credential-mapping-form/credential-utils.js
+++ b/app/javascript/components/workflow-credential-mapping-form/credential-utils.js
@@ -15,10 +15,10 @@ const JSONPATH_PATTERNS = {
 /**
  * Extracts the credential reference name from a JSONPath value
  * Supports both dot notation ($$.Credentials.xxx) and bracket notation ($$['Credentials']['xxx'])
- * 
+ *
  * @param {string} value - The JSONPath string (e.g., "$$.Credentials.my_ssh_credential")
  * @returns {string|null} The extracted credential reference name, or null if not found
- * 
+ *
  * @example
  * extractCredentialReference("$$.Credentials.my_ssh_credential") // returns "my_ssh_credential"
  * extractCredentialReference("$$['Credentials']['my_api_token']") // returns "my_api_token"
@@ -46,11 +46,11 @@ export const extractCredentialReference = (value) => {
 
 /**
  * Parses a workflow payload and extracts all credential references
- * 
+ *
  * @param {string} payload - JSON string containing the workflow definition
  * @returns {Object} Map of credential reference names to their JSONPath values
  * @throws {Error} If the payload is invalid or contains no credentials
- * 
+ *
  * @example
  * const payload = JSON.stringify({
  *   States: {
@@ -62,7 +62,7 @@ export const extractCredentialReference = (value) => {
  *     }
  *   }
  * });
- * 
+ *
  * parseWorkflowCredentials(payload)
  * // Returns: {
  * //   my_ssh_credential: "$$.Credentials.my_ssh_credential",
@@ -119,7 +119,7 @@ export const parseWorkflowCredentials = (payload) => {
 
 /**
  * Validates that a credential reference name is valid
- * 
+ *
  * @param {string} credentialRef - The credential reference to validate
  * @returns {boolean} True if valid, false otherwise
  */

--- a/app/javascript/components/workflow-credential-mapping-form/credential-utils.js
+++ b/app/javascript/components/workflow-credential-mapping-form/credential-utils.js
@@ -116,18 +116,3 @@ export const parseWorkflowCredentials = (payload) => {
 
   return payloadCredentials;
 };
-
-/**
- * Validates that a credential reference name is valid
- *
- * @param {string} credentialRef - The credential reference to validate
- * @returns {boolean} True if valid, false otherwise
- */
-export const isValidCredentialReference = (credentialRef) => {
-  if (typeof credentialRef !== 'string' || credentialRef.length === 0) {
-    return false;
-  }
-
-  // Valid credential references should only contain alphanumeric characters, underscores, and hyphens
-  return /^[a-zA-Z0-9_-]+$/.test(credentialRef);
-};

--- a/app/javascript/components/workflow-credential-mapping-form/credential-utils.test.js
+++ b/app/javascript/components/workflow-credential-mapping-form/credential-utils.test.js
@@ -1,0 +1,222 @@
+/**
+ * Tests for credential utility functions
+ */
+
+import { extractCredentialReference, parseWorkflowCredentials, isValidCredentialReference } from './credential-utils';
+
+describe('extractCredentialReference', () => {
+  it('should extract credential reference from dot notation', () => {
+    expect(extractCredentialReference('$$.Credentials.my_ssh_credential')).toBe('my_ssh_credential');
+    expect(extractCredentialReference('$$.Credentials.api_token')).toBe('api_token');
+    expect(extractCredentialReference('$$.Credentials.database-cred')).toBe('database-cred');
+  });
+
+  it('should extract credential reference from bracket notation', () => {
+    expect(extractCredentialReference("$$['Credentials']['my_ssh_credential']")).toBe('my_ssh_credential');
+    expect(extractCredentialReference("$$['Credentials']['api_token']")).toBe('api_token');
+  });
+
+  it('should return null for invalid formats', () => {
+    expect(extractCredentialReference('invalid')).toBeNull();
+    expect(extractCredentialReference('$$.SomethingElse.credential')).toBeNull();
+    expect(extractCredentialReference('$.Credentials.credential')).toBeNull();
+    expect(extractCredentialReference('')).toBeNull();
+  });
+
+  it('should return null for non-string values', () => {
+    expect(extractCredentialReference(null)).toBeNull();
+    expect(extractCredentialReference(undefined)).toBeNull();
+    expect(extractCredentialReference(123)).toBeNull();
+    expect(extractCredentialReference({})).toBeNull();
+  });
+});
+
+describe('parseWorkflowCredentials', () => {
+  it('should parse credentials from a valid payload with dot notation', () => {
+    const payload = JSON.stringify({
+      States: {
+        ExecuteScript: {
+          Credentials: {
+            ssh_cred: '$$.Credentials.my_ssh_credential',
+            api_token: '$$.Credentials.my_api_token',
+          },
+        },
+      },
+    });
+
+    const result = parseWorkflowCredentials(payload);
+    
+    expect(result).toEqual({
+      my_ssh_credential: '$$.Credentials.my_ssh_credential',
+      my_api_token: '$$.Credentials.my_api_token',
+    });
+  });
+
+  it('should parse credentials from a valid payload with bracket notation', () => {
+    const payload = JSON.stringify({
+      States: {
+        ExecuteScript: {
+          Credentials: {
+            ssh_cred: "$$['Credentials']['my_ssh_credential']",
+          },
+        },
+      },
+    });
+
+    const result = parseWorkflowCredentials(payload);
+    
+    expect(result).toEqual({
+      my_ssh_credential: "$$['Credentials']['my_ssh_credential']",
+    });
+  });
+
+  it('should parse credentials from multiple states', () => {
+    const payload = JSON.stringify({
+      States: {
+        State1: {
+          Credentials: {
+            cred1: '$$.Credentials.credential_one',
+          },
+        },
+        State2: {
+          Credentials: {
+            cred2: '$$.Credentials.credential_two',
+          },
+        },
+      },
+    });
+
+    const result = parseWorkflowCredentials(payload);
+    
+    expect(result).toEqual({
+      credential_one: '$$.Credentials.credential_one',
+      credential_two: '$$.Credentials.credential_two',
+    });
+  });
+
+  it('should handle states without credentials', () => {
+    const payload = JSON.stringify({
+      States: {
+        State1: {
+          Type: 'Task',
+        },
+        State2: {
+          Credentials: {
+            cred1: '$$.Credentials.my_credential',
+          },
+        },
+      },
+    });
+
+    const result = parseWorkflowCredentials(payload);
+    
+    expect(result).toEqual({
+      my_credential: '$$.Credentials.my_credential',
+    });
+  });
+
+  it('should use placeholder name as fallback if JSONPath extraction fails', () => {
+    const payload = JSON.stringify({
+      States: {
+        ExecuteScript: {
+          Credentials: {
+            plain_credential: 'some_non_jsonpath_value',
+          },
+        },
+      },
+    });
+
+    const result = parseWorkflowCredentials(payload);
+    
+    expect(result).toEqual({
+      plain_credential: 'some_non_jsonpath_value',
+    });
+  });
+
+  it('should throw error for invalid JSON', () => {
+    expect(() => {
+      parseWorkflowCredentials('invalid json');
+    }).toThrow('Failed to parse workflow payload');
+  });
+
+  it('should throw error for missing States property', () => {
+    const payload = JSON.stringify({
+      SomethingElse: {},
+    });
+
+    expect(() => {
+      parseWorkflowCredentials(payload);
+    }).toThrow('Invalid payload structure: missing or invalid States property');
+  });
+
+  it('should throw error for invalid States property', () => {
+    const payload = JSON.stringify({
+      States: 'not an object',
+    });
+
+    expect(() => {
+      parseWorkflowCredentials(payload);
+    }).toThrow('Invalid payload structure: missing or invalid States property');
+  });
+
+  it('should throw error when no credentials are found', () => {
+    const payload = JSON.stringify({
+      States: {
+        State1: {
+          Type: 'Task',
+        },
+      },
+    });
+
+    expect(() => {
+      parseWorkflowCredentials(payload);
+    }).toThrow('Workflow does not have any credentials to map');
+  });
+
+  it('should handle duplicate credential references (last one wins)', () => {
+    const payload = JSON.stringify({
+      States: {
+        State1: {
+          Credentials: {
+            cred1: '$$.Credentials.shared_credential',
+          },
+        },
+        State2: {
+          Credentials: {
+            cred2: '$$.Credentials.shared_credential',
+          },
+        },
+      },
+    });
+
+    const result = parseWorkflowCredentials(payload);
+    
+    // Should only have one entry for shared_credential
+    expect(Object.keys(result)).toHaveLength(1);
+    expect(result.shared_credential).toBe('$$.Credentials.shared_credential');
+  });
+});
+
+describe('isValidCredentialReference', () => {
+  it('should return true for valid credential references', () => {
+    expect(isValidCredentialReference('my_credential')).toBe(true);
+    expect(isValidCredentialReference('credential-name')).toBe(true);
+    expect(isValidCredentialReference('Credential123')).toBe(true);
+    expect(isValidCredentialReference('a')).toBe(true);
+  });
+
+  it('should return false for invalid credential references', () => {
+    expect(isValidCredentialReference('')).toBe(false);
+    expect(isValidCredentialReference('has spaces')).toBe(false);
+    expect(isValidCredentialReference('has.dots')).toBe(false);
+    expect(isValidCredentialReference('has/slashes')).toBe(false);
+    expect(isValidCredentialReference('has$pecial')).toBe(false);
+  });
+
+  it('should return false for non-string values', () => {
+    expect(isValidCredentialReference(null)).toBe(false);
+    expect(isValidCredentialReference(undefined)).toBe(false);
+    expect(isValidCredentialReference(123)).toBe(false);
+    expect(isValidCredentialReference({})).toBe(false);
+  });
+});

--- a/app/javascript/components/workflow-credential-mapping-form/credential-utils.test.js
+++ b/app/javascript/components/workflow-credential-mapping-form/credential-utils.test.js
@@ -45,7 +45,7 @@ describe('parseWorkflowCredentials', () => {
     });
 
     const result = parseWorkflowCredentials(payload);
-    
+
     expect(result).toEqual({
       my_ssh_credential: '$$.Credentials.my_ssh_credential',
       my_api_token: '$$.Credentials.my_api_token',
@@ -64,7 +64,7 @@ describe('parseWorkflowCredentials', () => {
     });
 
     const result = parseWorkflowCredentials(payload);
-    
+
     expect(result).toEqual({
       my_ssh_credential: "$$['Credentials']['my_ssh_credential']",
     });
@@ -87,7 +87,7 @@ describe('parseWorkflowCredentials', () => {
     });
 
     const result = parseWorkflowCredentials(payload);
-    
+
     expect(result).toEqual({
       credential_one: '$$.Credentials.credential_one',
       credential_two: '$$.Credentials.credential_two',
@@ -109,7 +109,7 @@ describe('parseWorkflowCredentials', () => {
     });
 
     const result = parseWorkflowCredentials(payload);
-    
+
     expect(result).toEqual({
       my_credential: '$$.Credentials.my_credential',
     });
@@ -127,7 +127,7 @@ describe('parseWorkflowCredentials', () => {
     });
 
     const result = parseWorkflowCredentials(payload);
-    
+
     expect(result).toEqual({
       plain_credential: 'some_non_jsonpath_value',
     });
@@ -190,7 +190,7 @@ describe('parseWorkflowCredentials', () => {
     });
 
     const result = parseWorkflowCredentials(payload);
-    
+
     // Should only have one entry for shared_credential
     expect(Object.keys(result)).toHaveLength(1);
     expect(result.shared_credential).toBe('$$.Credentials.shared_credential');

--- a/app/javascript/components/workflow-credential-mapping-form/index.jsx
+++ b/app/javascript/components/workflow-credential-mapping-form/index.jsx
@@ -6,6 +6,7 @@ import { CredentialMapperComponent } from './helper';
 import componentMapper from '../../forms/mappers/componentMapper';
 import createSchema from './workflow-credential-mapping-form.schema';
 import miqRedirectBack from '../../helpers/miq-redirect-back';
+import { parseWorkflowCredentials } from './credential-utils';
 
 const WorkflowCredentialMappingForm = ({ recordId }) => {
   const [{
@@ -31,27 +32,17 @@ const WorkflowCredentialMappingForm = ({ recordId }) => {
     ).then(({ resources }) => {
       API.get(`/api/configuration_script_payloads/${recordId}`).then(({ name, payload, credentials }) => {
         const initialCredentials = credentials != null ? credentials : {};
-        /*
-          Creates the list of credential references from the workflow payload by parsing each state and saving them to payloadCredentials.
-          Duplicate references get overridden.
-        */
-        const jsonPayload = JSON.parse(payload).States;
-        let payloadCredentials = {};
 
-        Object.keys(jsonPayload).forEach((key1) => {
-          if (jsonPayload[key1].Credentials != null) {
-            Object.keys(jsonPayload[key1].Credentials).forEach((key2) => {
-              payloadCredentials = {
-                [key2]: jsonPayload[key1].Credentials[key2],
-                ...payloadCredentials,
-              };
-            });
-          }
-        });
-
-        // Returns the user to the show_list page if the workflow has no credential references in it's payload
-        if (Object.keys(payloadCredentials).length === 0) {
-          throw __('Workflow does not have any credentials to map.');
+        // Parse the workflow payload and extract credential references
+        // This now correctly extracts the actual credential names from JSONPath values
+        // (e.g., "my_ssh_credential" from "$.Credentials.my_ssh_credential")
+        let payloadCredentials;
+        try {
+          payloadCredentials = parseWorkflowCredentials(payload);
+        } catch (error) {
+          // If parsing fails, redirect back with error message
+          miqRedirectBack(error.message, 'error', '/workflow/show_list');
+          return;
         }
 
         /*

--- a/app/javascript/components/workflow-credential-mapping-form/index.jsx
+++ b/app/javascript/components/workflow-credential-mapping-form/index.jsx
@@ -26,7 +26,6 @@ const WorkflowCredentialMappingForm = ({ recordId }) => {
   };
 
   useEffect(() => {
-    // eslint-disable-next-line camelcase
     API.get(
       `/api/authentications?expand=resources&filter[]=type='ManageIQ::Providers::Workflows::AutomationManager::WorkflowCredential'`
     ).then(({ resources }) => {

--- a/app/javascript/components/workflow-credential-mapping-form/index.jsx
+++ b/app/javascript/components/workflow-credential-mapping-form/index.jsx
@@ -34,7 +34,7 @@ const WorkflowCredentialMappingForm = ({ recordId }) => {
 
         // Parse the workflow payload and extract credential references
         // This now correctly extracts the actual credential names from JSONPath values
-        // (e.g., "my_ssh_credential" from "$.Credentials.my_ssh_credential")
+        // (e.g., "my_ssh_credential" from "$$.Credentials.my_ssh_credential")
         let payloadCredentials;
         try {
           payloadCredentials = parseWorkflowCredentials(payload);

--- a/app/javascript/spec/workflow-credential-mapping-form/__snapshots__/workflow-credential-mapping-form.spec.js.snap
+++ b/app/javascript/spec/workflow-credential-mapping-form/__snapshots__/workflow-credential-mapping-form.spec.js.snap
@@ -90,9 +90,9 @@ exports[`Workflow Credential Form Component should render mapping credentials to
                   >
                     <span
                       class="cds--front-line"
-                      title="api_password"
+                      title="api_user"
                     >
-                      api_password
+                      api_user
                     </span>
                   </div>
                 </td>
@@ -102,9 +102,9 @@ exports[`Workflow Credential Form Component should render mapping credentials to
                   >
                     <span
                       class="cds--front-line"
-                      title="Test Credential"
+                      title="API Credential"
                     >
-                      Test Credential
+                      API Credential
                     </span>
                   </div>
                 </td>
@@ -114,9 +114,9 @@ exports[`Workflow Credential Form Component should render mapping credentials to
                   >
                     <span
                       class="cds--front-line"
-                      title="Password"
+                      title="Username"
                     >
-                      Password
+                      Username
                     </span>
                   </div>
                 </td>
@@ -158,9 +158,9 @@ exports[`Workflow Credential Form Component should render mapping credentials to
                   >
                     <span
                       class="cds--front-line"
-                      title="api_user"
+                      title="api_password"
                     >
-                      api_user
+                      api_password
                     </span>
                   </div>
                 </td>
@@ -170,9 +170,9 @@ exports[`Workflow Credential Form Component should render mapping credentials to
                   >
                     <span
                       class="cds--front-line"
-                      title="API Credential"
+                      title="Test Credential"
                     >
-                      API Credential
+                      Test Credential
                     </span>
                   </div>
                 </td>
@@ -182,9 +182,9 @@ exports[`Workflow Credential Form Component should render mapping credentials to
                   >
                     <span
                       class="cds--front-line"
-                      title="Username"
+                      title="Password"
                     >
-                      Username
+                      Password
                     </span>
                   </div>
                 </td>
@@ -251,17 +251,17 @@ exports[`Workflow Credential Form Component should render mapping credentials to
             </option>
             <option
               class="cds--select-option"
-              label="api_password"
-              value="api_password"
-            >
-              api_password
-            </option>
-            <option
-              class="cds--select-option"
               label="api_user"
               value="api_user"
             >
               api_user
+            </option>
+            <option
+              class="cds--select-option"
+              label="api_password"
+              value="api_password"
+            >
+              api_password
             </option>
           </select>
           <svg

--- a/app/javascript/spec/workflow-credential-mapping-form/__snapshots__/workflow-credential-mapping-form.spec.js.snap
+++ b/app/javascript/spec/workflow-credential-mapping-form/__snapshots__/workflow-credential-mapping-form.spec.js.snap
@@ -290,9 +290,9 @@ exports[`Workflow Credential Form Component should render mapping credentials to
                   >
                     <span
                       class="cds--front-line"
-                      title="api_password"
+                      title="api_user"
                     >
-                      api_password
+                      api_user
                     </span>
                   </div>
                 </td>
@@ -302,9 +302,9 @@ exports[`Workflow Credential Form Component should render mapping credentials to
                   >
                     <span
                       class="cds--front-line"
-                      title="Test Credential"
+                      title="API Credential"
                     >
-                      Test Credential
+                      API Credential
                     </span>
                   </div>
                 </td>
@@ -314,9 +314,9 @@ exports[`Workflow Credential Form Component should render mapping credentials to
                   >
                     <span
                       class="cds--front-line"
-                      title="Password"
+                      title="Username"
                     >
-                      Password
+                      Username
                     </span>
                   </div>
                 </td>
@@ -358,9 +358,9 @@ exports[`Workflow Credential Form Component should render mapping credentials to
                   >
                     <span
                       class="cds--front-line"
-                      title="api_user"
+                      title="api_password"
                     >
-                      api_user
+                      api_password
                     </span>
                   </div>
                 </td>
@@ -370,9 +370,9 @@ exports[`Workflow Credential Form Component should render mapping credentials to
                   >
                     <span
                       class="cds--front-line"
-                      title="API Credential"
+                      title="Test Credential"
                     >
-                      API Credential
+                      Test Credential
                     </span>
                   </div>
                 </td>
@@ -382,9 +382,9 @@ exports[`Workflow Credential Form Component should render mapping credentials to
                   >
                     <span
                       class="cds--front-line"
-                      title="Username"
+                      title="Password"
                     >
-                      Username
+                      Password
                     </span>
                   </div>
                 </td>
@@ -451,17 +451,17 @@ exports[`Workflow Credential Form Component should render mapping credentials to
             </option>
             <option
               class="cds--select-option"
-              label="api_password"
-              value="api_password"
-            >
-              api_password
-            </option>
-            <option
-              class="cds--select-option"
               label="api_user"
               value="api_user"
             >
               api_user
+            </option>
+            <option
+              class="cds--select-option"
+              label="api_password"
+              value="api_password"
+            >
+              api_password
             </option>
           </select>
           <svg

--- a/app/javascript/spec/workflow-credential-mapping-form/credential-utils.spec.js
+++ b/app/javascript/spec/workflow-credential-mapping-form/credential-utils.spec.js
@@ -1,8 +1,4 @@
-/**
- * Tests for credential utility functions
- */
-
-import { extractCredentialReference, parseWorkflowCredentials, isValidCredentialReference } from './credential-utils';
+import { extractCredentialReference, parseWorkflowCredentials } from '../../components/workflow-credential-mapping-form/credential-utils';
 
 describe('extractCredentialReference', () => {
   it('should extract credential reference from dot notation', () => {
@@ -194,29 +190,5 @@ describe('parseWorkflowCredentials', () => {
     // Should only have one entry for shared_credential
     expect(Object.keys(result)).toHaveLength(1);
     expect(result.shared_credential).toBe('$$.Credentials.shared_credential');
-  });
-});
-
-describe('isValidCredentialReference', () => {
-  it('should return true for valid credential references', () => {
-    expect(isValidCredentialReference('my_credential')).toBe(true);
-    expect(isValidCredentialReference('credential-name')).toBe(true);
-    expect(isValidCredentialReference('Credential123')).toBe(true);
-    expect(isValidCredentialReference('a')).toBe(true);
-  });
-
-  it('should return false for invalid credential references', () => {
-    expect(isValidCredentialReference('')).toBe(false);
-    expect(isValidCredentialReference('has spaces')).toBe(false);
-    expect(isValidCredentialReference('has.dots')).toBe(false);
-    expect(isValidCredentialReference('has/slashes')).toBe(false);
-    expect(isValidCredentialReference('has$pecial')).toBe(false);
-  });
-
-  it('should return false for non-string values', () => {
-    expect(isValidCredentialReference(null)).toBe(false);
-    expect(isValidCredentialReference(undefined)).toBe(false);
-    expect(isValidCredentialReference(123)).toBe(false);
-    expect(isValidCredentialReference({})).toBe(false);
   });
 });

--- a/app/javascript/spec/workflow-credential-mapping-form/workflow-credential-mapping-form.spec.js
+++ b/app/javascript/spec/workflow-credential-mapping-form/workflow-credential-mapping-form.spec.js
@@ -15,8 +15,8 @@ describe('Workflow Credential Form Component', () => {
     name: 'test-workflow.asl',
     payload: `{
       "States": {
-        "State1": { "Credentials": { "api_user": "$.api_user", "api_password": "$.api_password" } },
-        "State2": { "Credentials": { "api_user": "$.api_user", "api_password": "$.api_password" } }
+        "State1": { "Credentials": { "api_user": "$$.Credentials.api_user", "api_password": "$$.Credentials.api_password" } },
+        "State2": { "Credentials": { "api_user": "$$.Credentials.api_user", "api_password": "$$.Credentials.api_password" } }
       }
     }`,
     credentials: {


### PR DESCRIPTION
The previous Credential Mapping was considering the wrong field for replacement, it was looking at the target name and not the source name.

This meant if you had different two states that took a username and password field it wasn't possible to provide two different sets of values for these.

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/10091

Before
<img width="1081" height="434" alt="Screenshot From 2026-06-09 16-51-37" src="https://github.com/user-attachments/assets/2ec4f2e8-cb4a-4f4b-8256-6f6da628039d" />

After
<img width="1081" height="434" alt="Screenshot From 2026-06-10 07-43-43" src="https://github.com/user-attachments/assets/3622579f-99d3-4c6b-9505-f51cd5965ff6" />

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
