### PR TITLE
Update provider form cypress to verify validate/submit button behavior

### DIFF
--- a/cypress/e2e/ui/Compute/Clouds/Providers/provider-factory.js
+++ b/cypress/e2e/ui/Compute/Clouds/Providers/provider-factory.js
@@ -112,6 +112,7 @@ export const VALIDATION_MESSAGES = {
   FAILED: 'Validation failed',
   SUCCESSFUL: 'Validation successful',
   NAME_ALREADY_EXISTS: 'already exists',
+  VALIDATION_REQUIRED: 'Validation Required',
 };
 
 // Provider-specific validation error messages

--- a/cypress/support/commands/provider_helper_commands.js
+++ b/cypress/support/commands/provider_helper_commands.js
@@ -576,6 +576,10 @@ function assertNameAlreadyExistsError() {
 Cypress.Commands.add(
   'providerValidation',
   ({ stubErrorResponse, errorMessage }) => {
+    cy.contains(
+      '.ddorg__carbon-error-helper-text',
+      VALIDATION_MESSAGES.VALIDATION_REQUIRED
+    ).should('be.visible');
     let response = { state: 'Finished', status: 'Error' };
     if (stubErrorResponse) {
       response = {
@@ -651,11 +655,22 @@ function generateAddFormValidationTests(providerConfig, testOptions = {}) {
 
     it('Should show the error message from the task_results API upon validation failure and validate cancel button behavior', () => {
       cy.fillProviderForm(providerConfig);
+      // Verify submit button stays disabled after required fields are filled
+      // and before validation is triggered
+      cy.getFormButtonByTypeWithText({
+        buttonText: 'Add',
+        buttonType: 'submit',
+      }).should('be.disabled');
       cy.providerValidation({
         stubErrorResponse: true,
         errorMessage: providerConfig.validationError,
       });
       assertValidationFailureMessage();
+      // Verify submit button remains disabled when validation fails
+      cy.getFormButtonByTypeWithText({
+        buttonText: 'Add',
+        buttonType: 'submit',
+      }).should('be.disabled');
       cy.getFormButtonByTypeWithText({ buttonText: 'Cancel' }).click();
       cy.expect_flash(
         flashClassMap.success,
@@ -666,11 +681,22 @@ function generateAddFormValidationTests(providerConfig, testOptions = {}) {
     it(`Verify successful validate + add/${isAmazonEc2 ? 'refresh/' : ''}delete operations`, () => {
       const nameValue = providerConfig.formValues.common.name;
       cy.fillProviderForm(providerConfig);
+      // Verify submit button stays disabled after required fields are filled
+      // and before validation is triggered
+      cy.getFormButtonByTypeWithText({
+        buttonText: 'Add',
+        buttonType: 'submit',
+      }).should('be.disabled');
       //Add
       cy.providerValidation({
         stubErrorResponse: false,
       });
       assertValidationSuccessMessage();
+      // Verify submit button is enabled when validation succeeds
+      cy.getFormButtonByTypeWithText({
+        buttonText: 'Add',
+        buttonType: 'submit',
+      }).should('be.enabled');
       cy.interceptAddProviderApi({ isAzureStack });
       cy.expect_flash(flashClassMap.success, FLASH_MESSAGES.OPERATION_SAVED);
 
@@ -740,11 +766,22 @@ function generateEditFormValidationTests(providerConfig, testOptions = {}) {
       it("Should show the error message from the task_results API upon validation failure and validate reset & cancel buttons' behavior", () => {
         openEditFormForCreatedProvider(providerConfig, false);
         updateProviderFieldsForEdit(providerConfig.type);
+        // Verify submit button stays disabled after a required field is updated
+        // and before validation is triggered
+        cy.getFormButtonByTypeWithText({
+          buttonText: 'Save',
+          buttonType: 'submit',
+        }).should('be.disabled');
         cy.providerValidation({
           stubErrorResponse: true,
           errorMessage: providerConfig.validationError,
         });
         assertValidationFailureMessage();
+        // Verify submit button remains disabled when validation fails
+        cy.getFormButtonByTypeWithText({
+          buttonText: 'Save',
+          buttonType: 'submit',
+        }).should('be.disabled');
         cy.getFormButtonByTypeWithText({ buttonText: 'Reset' })
           .should('be.enabled')
           .click();
@@ -762,10 +799,21 @@ function generateEditFormValidationTests(providerConfig, testOptions = {}) {
       openEditFormForCreatedProvider(providerConfig, isAzureStack);
       // Update fields based on provider type
       updateProviderFieldsForEdit(providerConfig.type);
+      // Verify submit button stays disabled after a required field is updated
+      // and before validation is triggered
+      cy.getFormButtonByTypeWithText({
+        buttonText: 'Save',
+        buttonType: 'submit',
+      }).should('be.disabled');
       cy.providerValidation({
         stubErrorResponse: false,
       });
       assertValidationSuccessMessage();
+      // Verify submit button is enabled when validation succeeds
+      cy.getFormButtonByTypeWithText({
+        buttonText: 'Save',
+        buttonType: 'submit',
+      }).should('be.enabled');
       // Azure Stack needs to be handled differently, add similar cases if needed
       if (isAzureStack) {
         cy.interceptApi({


### PR DESCRIPTION
Follow-up to https://github.com/ManageIQ/manageiq-ui-classic/pull/10083 (since https://github.com/ManageIQ/manageiq-ui-classic/pull/10054 got merged)

PR to verify submit button behavior before and after validation (related to https://github.com/ManageIQ/manageiq-ui-classic/issues/10042)

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
