### PR TITLE
Fix Storage Type ordering in UI

### DIFF
--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -143,9 +143,12 @@
             :prefix                     => "/miq_request/",
             :keys                       => keys})
   - when :hardware
-    - keys = [:instance_type, :sys_type,  :cloud_volumes, :storage_type, :number_of_cpus, :entitled_processors, :number_of_sockets, :cores_per_socket,
-              :vm_memory, :network_adapters, :disk_format, :allocated_disk_storage, :disk_sparsity, :guest_access_key_pair, :monitoring,
-              :vm_dynamic_memory, :vm_minimum_memory, :vm_maximum_memory, :boot_disk_size, :is_preemptible,
+    - keys = [:instance_type, :sys_type, :storage_type, :cloud_volumes,
+              :number_of_cpus, :entitled_processors, :number_of_sockets,
+              :cores_per_socket, :vm_memory, :network_adapters, :disk_format,
+              :allocated_disk_storage, :disk_sparsity, :guest_access_key_pair,
+              :monitoring, :vm_dynamic_memory, :vm_minimum_memory,
+              :vm_maximum_memory, :boot_disk_size, :is_preemptible,
               :cpu_hot_add, :cpu_hot_remove, :memory_hot_add, :ssh_public_key]
     - label = wf.kind_of?(ManageIQ::Providers::CloudManager::ProvisionWorkflow) ? _("Properties") : _("Hardware")
     = render(:partial => "/miq_request/prov_dialog_fieldset",


### PR DESCRIPTION
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

Fix Storage Type ordering in the UI. For PowerVS providers, volumes are created under a specific Storage Type, so users must select a Storage Type first before the associated volumes can be displayed.

Before Fix:
<img width="882" height="605" alt="Before" src="https://github.com/user-attachments/assets/76622bcd-41ea-48a7-807c-9cf7289f7d84" />

After Fix:
<img width="1507" height="811" alt="After Fix" src="https://github.com/user-attachments/assets/2291e4f3-5ec5-46f5-ba45-f48221906e9e" />

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
@miq-bot add-label bug