### PR TITLE
[Bug] UI bug fix to rearrange the Storage Type above Attach Volumes

### DIFF
--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -143,7 +143,7 @@
             :prefix                     => "/miq_request/",
             :keys                       => keys})
   - when :hardware
-    - keys = [:instance_type, :sys_type,  :cloud_volumes, :storage_type, :number_of_cpus, :entitled_processors, :number_of_sockets, :cores_per_socket,
+    - keys = [:instance_type, :sys_type, :storage_type, :cloud_volumes, :number_of_cpus, :entitled_processors, :number_of_sockets, :cores_per_socket,
               :vm_memory, :network_adapters, :disk_format, :allocated_disk_storage, :disk_sparsity, :guest_access_key_pair, :monitoring,
               :vm_dynamic_memory, :vm_minimum_memory, :vm_maximum_memory, :boot_disk_size, :is_preemptible,
               :cpu_hot_add, :cpu_hot_remove, :memory_hot_add, :ssh_public_key]


### PR DESCRIPTION
# PowerVS Provisioning: Reorder Storage Type and Attach Volumes Fields

## Overview

This change improves the user experience in the IBM Cloud PowerVS provisioning workflow by reordering the "Storage Type" and "Attach Volumes" fields to create a more intuitive workflow.

## Problem Statement

### Before This Change

- **Confusing Field Order**: The "Attach Volumes" field appeared before the "Storage Type" field in the provisioning form
- **Poor UX**: Users had to scroll past "Attach Volumes" to find "Storage Type", which didn't match the logical workflow

### After This Change

- **Logical Field Order**: "Storage Type" now appears before "Attach Volumes"
- **Intuitive Workflow**: Clear progression: select storage type first → then attach volumes

## Changes Made

### UI Field Reordering

**File**: `manageiq-ui-classic/app/views/shared/views/_prov_dialog.html.haml`

**Line 146**: Reordered the keys array in the `:hardware` section

```ruby
# Before
- keys = [:instance_type, :sys_type, :cloud_volumes, :storage_type, ...]

# After
- keys = [:instance_type, :sys_type, :storage_type, :cloud_volumes, ...]
```

## Testing Instructions

1. Navigate to **Compute → Cloud → Instances → Provision Instances**
2. Select an **IBM Cloud PowerVS** provider
3. Proceed to the **Hardware/Properties** tab
4. Verify the following:
   - [ ] "Storage Type" field appears before "Attach Volumes" field
   - [ ] Field order matches the logical workflow

## Benefits

- ✅ **Improved User Experience**: Logical field ordering matches user workflow
- ✅ **Reduced Confusion**: Users see storage type selection before volume attachment
- ✅ **Better Usability**: Natural progression through the provisioning form

@miq-bot add-label enhancement
@miq-bot add-label ui
@miq-bot add-label providers/ibm_cloud
