### PR TITLE
Convert the git domain refresh form to use API

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -1795,20 +1795,6 @@ class MiqAeClassController < ApplicationController
     tree_select
   end
 
-  def refresh_git_domain
-    assert_privileges("miq_ae_git_refresh")
-    if params[:button] == "save"
-      begin
-        git_based_domain_import_service.import(params[:git_repo_id], params[:git_branch_or_tag], current_tenant.id)
-        render :json => {:message => _("Successfully refreshed!"), :level => "success"}
-      rescue => err
-        render :json => {:message => err.message, :level => "error"}, :status => 400
-      end
-    else
-      render :json => {:message => _("Git based refresh canceled"), :level => "warning"}
-    end
-  end
-
   def namespace
     assert_privileges("miq_ae_namespace_edit")
     render :json => find_record_with_rbac(MiqAeNamespace, params[:id]).attributes.slice('name', 'description', 'enabled')
@@ -2805,6 +2791,7 @@ class MiqAeClassController < ApplicationController
     presenter.update(update_partial_div, r[
       :partial => update_partial,
       :locals  => {
+        :domain_id    => params[:id],
         :git_repo_id  => @git_repo_id,
         :ref_type     => @ref_type,
         :ref_name     => @ref_name,

--- a/app/javascript/components/git-domain-refresh-form/index.jsx
+++ b/app/javascript/components/git-domain-refresh-form/index.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import MiqFormRenderer from '@@ddf';
-import { http } from '../../http_api';
 import miqRedirectBack from '../../helpers/miq-redirect-back';
 import createSchema from './git-domain-refresh-form.schema';
 
@@ -11,6 +10,7 @@ const REF_TYPES = {
 const DEFAULT_BRANCH = 'origin/master';
 
 const GitDomainRefreshForm = ({
+  domainId,
   gitRepoId,
   refType: initialRefType,
   refName: initialRefName,
@@ -30,22 +30,37 @@ const GitDomainRefreshForm = ({
 
     const gitBranchOrTag = values.ref_type === REF_TYPES.BRANCH ? values.branch_name : values.tag_name;
 
-    const params = {
-      git_repo_id: gitRepoId,
-      git_branch_or_tag: gitBranchOrTag,
-      button: 'save',
+    const payload = {
+      action: 'refresh_from_source',
+      resource: {
+        ref_type: values.ref_type,
+        ref: gitBranchOrTag,
+      },
     };
 
-    return http.post('/miq_ae_class/refresh_git_domain', params, { skipErrors: [400] })
+    return API.post(`/api/automate_domains/${domainId}`, payload, { skipErrors: [400] })
       .then((response) => {
-        const message = response.message || __('Successfully refreshed!');
-        const level = response.level || 'success';
-        miqRedirectBack(message, level, '/miq_ae_class/explorer');
+        const { task_id: taskId, success, message } = response;
+        if (success && taskId) {
+          // Wait for the async task to complete before redirecting
+          return API.wait_for_task(taskId)
+            .then(() => {
+              const successMessage = message || __('Successfully refreshed!');
+              miqRedirectBack(successMessage, 'success', '/miq_ae_class/explorer');
+            })
+            .catch((error) => {
+              const errorMessage = error.data?.error?.message || error.message || __('Failed to refresh domain');
+              miqRedirectBack(errorMessage, 'error', '/miq_ae_class/explorer');
+            });
+        }
+        // If no taskId or not successful, handle as error
+        const errorMessage = message || __('Failed to refresh domain');
+        miqRedirectBack(errorMessage, 'error', '/miq_ae_class/explorer');
+        return Promise.reject(new Error(errorMessage));
       })
       .catch((error) => {
-        const message = error.data?.message || error.message;
-        const level = error.data?.level || 'error';
-        miqRedirectBack(message, level, '/miq_ae_class/explorer');
+        const message = error.data?.error?.message || error.message || __('Failed to refresh domain');
+        miqRedirectBack(message, 'error', '/miq_ae_class/explorer');
       });
   };
 
@@ -72,6 +87,7 @@ const GitDomainRefreshForm = ({
 };
 
 GitDomainRefreshForm.propTypes = {
+  domainId: PropTypes.string.isRequired,
   gitRepoId: PropTypes.string.isRequired,
   refType: PropTypes.string,
   refName: PropTypes.string,

--- a/app/javascript/spec/git-domain-refresh-form/git-domain-refresh-form.spec.js
+++ b/app/javascript/spec/git-domain-refresh-form/git-domain-refresh-form.spec.js
@@ -4,13 +4,11 @@ import fetchMock from 'fetch-mock';
 
 import GitDomainRefreshForm from '../../components/git-domain-refresh-form';
 import { renderWithRedux } from '../helpers/mountForm';
-import { http } from '../../http_api';
 
 import miqRedirectBack from '../../helpers/miq-redirect-back';
 import '../helpers/miqSparkle';
 
 jest.mock('../../helpers/miq-redirect-back', () => jest.fn());
-jest.mock('../../http_api');
 
 describe('GitDomainRefreshForm component', () => {
   let initialProps;
@@ -18,6 +16,7 @@ describe('GitDomainRefreshForm component', () => {
 
   beforeEach(() => {
     initialProps = {
+      domainId: '123',
       gitRepoId: '789',
       branchNames: ['origin/main', 'origin/develop', 'origin/feature/test'],
       tagNames: ['v1.0.0', 'v1.1.0', 'v2.0.0'],
@@ -119,9 +118,15 @@ describe('GitDomainRefreshForm component', () => {
   it('should call correct API endpoint on submit with branch', async() => {
     const user = userEvent.setup();
 
-    http.post = jest.fn().mockResolvedValue({
-      message: 'Successfully Refreshed!',
-      level: 'success',
+    API.post = jest.fn().mockResolvedValue({
+      task_id: '123',
+      success: true,
+      message: 'Refreshing Automate Domain',
+    });
+
+    API.wait_for_task = jest.fn().mockResolvedValue({
+      state: 'Finished',
+      status: 'Ok',
     });
 
     renderWithRedux(<GitDomainRefreshForm {...initialProps} />);
@@ -137,20 +142,26 @@ describe('GitDomainRefreshForm component', () => {
     await user.click(submitButton);
 
     await waitFor(() => {
-      expect(http.post).toHaveBeenCalledWith(
-        '/miq_ae_class/refresh_git_domain',
+      expect(API.post).toHaveBeenCalledWith(
+        '/api/automate_domains/123',
         expect.objectContaining({
-          git_repo_id: '789',
-          git_branch_or_tag: 'origin/develop',
-          button: 'save',
+          action: 'refresh_from_source',
+          resource: {
+            ref_type: 'branch',
+            ref: 'origin/develop',
+          },
         }),
         { skipErrors: [400] }
       );
     });
 
+    await waitFor(() => {
+      expect(API.wait_for_task).toHaveBeenCalledWith('123');
+    });
+
     expect(miqSparkleOn).toHaveBeenCalled();
     expect(miqRedirectBack).toHaveBeenCalledWith(
-      'Successfully Refreshed!',
+      'Refreshing Automate Domain',
       'success',
       '/miq_ae_class/explorer'
     );
@@ -159,9 +170,15 @@ describe('GitDomainRefreshForm component', () => {
   it('should call correct API endpoint on submit with tag', async() => {
     const user = userEvent.setup();
 
-    http.post = jest.fn().mockResolvedValue({
-      message: 'Successfully Refreshed!',
-      level: 'success',
+    API.post = jest.fn().mockResolvedValue({
+      task_id: '456',
+      success: true,
+      message: 'Refreshing Automate Domain',
+    });
+
+    API.wait_for_task = jest.fn().mockResolvedValue({
+      state: 'Finished',
+      status: 'Ok',
     });
 
     renderWithRedux(<GitDomainRefreshForm {...initialProps} />);
@@ -180,20 +197,26 @@ describe('GitDomainRefreshForm component', () => {
     await user.click(submitButton);
 
     await waitFor(() => {
-      expect(http.post).toHaveBeenCalledWith(
-        '/miq_ae_class/refresh_git_domain',
+      expect(API.post).toHaveBeenCalledWith(
+        '/api/automate_domains/123',
         expect.objectContaining({
-          git_repo_id: '789',
-          git_branch_or_tag: 'v2.0.0',
-          button: 'save',
+          action: 'refresh_from_source',
+          resource: {
+            ref_type: 'tag',
+            ref: 'v2.0.0',
+          },
         }),
         { skipErrors: [400] }
       );
     });
 
+    await waitFor(() => {
+      expect(API.wait_for_task).toHaveBeenCalledWith('456');
+    });
+
     expect(miqSparkleOn).toHaveBeenCalled();
     expect(miqRedirectBack).toHaveBeenCalledWith(
-      'Successfully Refreshed!',
+      'Refreshing Automate Domain',
       'success',
       '/miq_ae_class/explorer'
     );

--- a/app/views/miq_ae_class/_git_domain_refresh.html.haml
+++ b/app/views/miq_ae_class/_git_domain_refresh.html.haml
@@ -1,5 +1,6 @@
 = render :partial => "layouts/flash_msg"
 = react('GitDomainRefreshForm',
+        :domainId    => domain_id.to_s,
         :gitRepoId   => git_repo_id.to_s,
         :refType     => ref_type || 'branch',
         :refName     => ref_name || 'origin/master',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1942,7 +1942,6 @@ Rails.application.routes.draw do
         form_field_changed
         form_instance_field_changed
         form_method_field_changed
-        refresh_git_domain
         reload
         tree_select
         tree_autoload

--- a/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/git-domain-refresh-form.cy.js
+++ b/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/git-domain-refresh-form.cy.js
@@ -122,8 +122,8 @@ describe('Automation > Embedded Automate > Explorer > Git Domain Refresh', () =>
     it('Refreshes git domain with a new branch', () => {
       cy.toolbar('Configuration', 'Refresh with a new branch or tag');
 
-      // Intercept the POST request
-      cy.intercept('POST', '/miq_ae_class/refresh_git_domain').as('refreshGitDomain');
+      // Intercept the API POST request
+      cy.intercept('POST', '/api/automate_domains/*').as('refreshGitDomain');
 
       // Verify initial branch is selected
       cy.getFormSelectFieldById({ selectId: 'ref_type' }).should('have.value', 'branch');
@@ -144,13 +144,17 @@ describe('Automation > Embedded Automate > Explorer > Git Domain Refresh', () =>
 
           // Verify the request was made with correct body including the selected branch
           cy.wait('@refreshGitDomain').then((interception) => {
-            expect(interception.request.body).to.have.property('git_repo_id');
-            expect(interception.request.body).to.have.property('git_branch_or_tag', selectedBranch);
-            expect(interception.request.body).to.have.property('button', 'save');
+            const body = typeof interception.request.body === 'string'
+              ? JSON.parse(interception.request.body)
+              : interception.request.body;
+            expect(body).to.have.property('action', 'refresh_from_source');
+            expect(body).to.have.property('resource');
+            expect(body.resource).to.have.property('ref_type', 'branch');
+            expect(body.resource).to.have.property('ref', selectedBranch);
           });
 
           // Verify success flash message appears
-          cy.expect_flash(flashClassMap.success, 'Successfully refreshed');
+          cy.expect_flash(flashClassMap.success, 'Refreshing Automate Domain');
 
           // Verify the explorer title shows the updated branch
           cy.get('#explorer_title_text').should('contain', selectedBranch);
@@ -162,8 +166,8 @@ describe('Automation > Embedded Automate > Explorer > Git Domain Refresh', () =>
     it('Refreshes git domain with a tag', () => {
       cy.toolbar('Configuration', 'Refresh with a new branch or tag');
 
-      // Intercept the POST request
-      cy.intercept('POST', '/miq_ae_class/refresh_git_domain').as('refreshGitDomain');
+      // Intercept the API POST request
+      cy.intercept('POST', '/api/automate_domains/*').as('refreshGitDomain');
 
       // Switch to tag type
       cy.getFormSelectFieldById({ selectId: 'ref_type' }).select('tag');
@@ -185,13 +189,17 @@ describe('Automation > Embedded Automate > Explorer > Git Domain Refresh', () =>
 
         // Verify the request was made with correct body including the selected tag
         cy.wait('@refreshGitDomain').then((interception) => {
-          expect(interception.request.body).to.have.property('git_repo_id');
-          expect(interception.request.body).to.have.property('git_branch_or_tag', selectedTag);
-          expect(interception.request.body).to.have.property('button', 'save');
+          const body = typeof interception.request.body === 'string'
+            ? JSON.parse(interception.request.body)
+            : interception.request.body;
+          expect(body).to.have.property('action', 'refresh_from_source');
+          expect(body).to.have.property('resource');
+          expect(body.resource).to.have.property('ref_type', 'tag');
+          expect(body.resource).to.have.property('ref', selectedTag);
         });
 
         // Verify success flash message appears
-        cy.expect_flash(flashClassMap.success, 'Successfully refreshed');
+        cy.expect_flash(flashClassMap.success, 'Refreshing Automate Domain');
 
         // Verify the explorer title shows the updated tag
         cy.get('#explorer_title_text').should('contain', selectedTag);


### PR DESCRIPTION
Follow up to: #10062 

Convert the git domain refresh form to use API instead of ruby controller. 

@miq-bot add-label enhancement
@miq-bot add-reviewer @GilbertCherrie 
