### PR TITLE
Fix request table time zone

### DIFF
--- a/app/javascript/components/data-tables/requests-table/index.jsx
+++ b/app/javascript/components/data-tables/requests-table/index.jsx
@@ -1,6 +1,7 @@
-/* eslint-disable no-undef */
+
 import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import moment from 'moment-timezone';
 import MiqDataTable from '../../miq-data-table';
 
 const RequestsTable = ({
@@ -35,15 +36,23 @@ const RequestsTable = ({
       case 'severity':
         if (direction === 'DESC') {
           temp.sort((x, y) => {
-            if (x.severity.text.toLowerCase() < y.severity.text.toLowerCase()) { return -1; }
-            if (x.severity.text.toLowerCase() > y.severity.text.toLowerCase()) { return 1; }
+            if (x.severity.text.toLowerCase() < y.severity.text.toLowerCase()) {
+              return -1;
+            }
+            if (x.severity.text.toLowerCase() > y.severity.text.toLowerCase()) {
+              return 1;
+            }
             return 0;
           });
           direction = 'ASC';
         } else if (direction === 'ASC') {
           temp.reverse((x, y) => {
-            if (x.severity.text.toLowerCase() < y.severity.text.toLowerCase()) { return -1; }
-            if (x.severity.text.toLowerCase() > y.severity.text.toLowerCase()) { return 1; }
+            if (x.severity.text.toLowerCase() < y.severity.text.toLowerCase()) {
+              return -1;
+            }
+            if (x.severity.text.toLowerCase() > y.severity.text.toLowerCase()) {
+              return 1;
+            }
             return 0;
           });
           direction = 'DESC';
@@ -57,15 +66,23 @@ const RequestsTable = ({
       case 'message':
         if (direction === 'DESC') {
           temp.sort((x, y) => {
-            if (x.message.text.toLowerCase() < y.message.text.toLowerCase()) { return -1; }
-            if (x.message.text.toLowerCase() > y.message.text.toLowerCase()) { return 1; }
+            if (x.message.text.toLowerCase() < y.message.text.toLowerCase()) {
+              return -1;
+            }
+            if (x.message.text.toLowerCase() > y.message.text.toLowerCase()) {
+              return 1;
+            }
             return 0;
           });
           direction = 'ASC';
         } else if (direction === 'ASC') {
           temp.reverse((x, y) => {
-            if (x.message.text.toLowerCase() < y.message.text.toLowerCase()) { return -1; }
-            if (x.message.text.toLowerCase() > y.message.text.toLowerCase()) { return 1; }
+            if (x.message.text.toLowerCase() < y.message.text.toLowerCase()) {
+              return -1;
+            }
+            if (x.message.text.toLowerCase() > y.message.text.toLowerCase()) {
+              return 1;
+            }
             return 0;
           });
           direction = 'DESC';
@@ -87,11 +104,16 @@ const RequestsTable = ({
     const rows = [];
     // const timeNow = Date.now();
     initialData.forEach((object, index) => {
+      // Format timestamp using ManageIQ timezone to match the "Created On" field
+      const timezone = ManageIQ.timezone || 'UTC';
+      const formattedTime = object.created_at
+        ? moment(object.created_at).tz(timezone).format('MM/DD/YYYY HH:mm:ss z')
+        : 'unknown';
+
       rows[index] = {
         id: index.toString(),
         clickable: null,
-        // TODO: Discuss Converting Time to x seconds/minutes/hours ago
-        time: { text: object.created_at ? new Date(object.created_at).toLocaleString() : 'unknown' },
+        time: { text: formattedTime },
         severity: { text: object.severity ? object.severity : 'unknown' },
         message: { text: object.message ? object.message : '' },
       };
@@ -117,7 +139,11 @@ const RequestsTable = ({
 };
 
 RequestsTable.propTypes = {
-  initialData: PropTypes.arrayOf(PropTypes.any),
+  initialData: PropTypes.arrayOf(PropTypes.shape({
+    created_at: PropTypes.string,
+    severity: PropTypes.string,
+    message: PropTypes.string,
+  })),
 };
 
 export default RequestsTable;

--- a/app/javascript/components/data-tables/requests-table/index.jsx
+++ b/app/javascript/components/data-tables/requests-table/index.jsx
@@ -1,11 +1,11 @@
-
 import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment-timezone';
 import MiqDataTable from '../../miq-data-table';
 
 const RequestsTable = ({
-  initialData = [],
+  initialData,
+  locale,
 }) => {
   const [tableHeaders, setTableHeaders] = useState([
     { key: 'time', header: __('Time'), sortData: { isFilteredBy: false } },
@@ -102,18 +102,24 @@ const RequestsTable = ({
 
   useEffect(() => {
     const rows = [];
-    // const timeNow = Date.now();
+    const timezone = ManageIQ.timezone || 'UTC';
+    moment.locale(locale || 'en');
+
     initialData.forEach((object, index) => {
-      // Format timestamp using ManageIQ timezone to match the "Created On" field
-      const timezone = ManageIQ.timezone || 'UTC';
       const formattedTime = object.created_at
-        ? moment(object.created_at).tz(timezone).format('MM/DD/YYYY HH:mm:ss z')
+        ? moment(object.created_at).tz(timezone).format('L HH:mm:ss z')
         : 'unknown';
+      const relativeTime = object.created_at
+        ? moment(object.created_at).tz(timezone).fromNow()
+        : '';
 
       rows[index] = {
         id: index.toString(),
         clickable: null,
-        time: { text: formattedTime },
+        time: {
+          text: formattedTime,
+          title: relativeTime,
+        },
         severity: { text: object.severity ? object.severity : 'unknown' },
         message: { text: object.message ? object.message : '' },
       };
@@ -144,6 +150,7 @@ RequestsTable.propTypes = {
     severity: PropTypes.string,
     message: PropTypes.string,
   })),
+  locale: PropTypes.string,
 };
 
 export default RequestsTable;

--- a/app/javascript/components/data-tables/requests-table/index.jsx
+++ b/app/javascript/components/data-tables/requests-table/index.jsx
@@ -4,15 +4,31 @@ import moment from 'moment-timezone';
 import MiqDataTable from '../../miq-data-table';
 
 const RequestsTable = ({
-  initialData,
-  locale,
+  initialData = [],
+  userId,
 }) => {
+  const [userLocale, setUserLocale] = useState('en');
   const [tableHeaders, setTableHeaders] = useState([
     { key: 'time', header: __('Time'), sortData: { isFilteredBy: false } },
     { key: 'severity', header: __('Severity'), sortData: { isFilteredBy: false } },
     { key: 'message', header: __('Message'), sortData: { isFilteredBy: false } },
   ]);
   const [tableRows, setTableRows] = useState([]);
+
+  // Fetch user's locale setting from API
+  useEffect(() => {
+    if (userId) {
+      API.get(`/api/users/${userId}?attributes=settings`).then(({ settings }) => {
+        if (settings?.display?.locale && settings.display.locale !== 'default') {
+          // Convert underscore format (e.g., 'zh_CN') to hyphen format (e.g., 'zh-CN') for moment.js
+          setUserLocale(settings.display.locale.replace('_', '-'));
+        }
+      }).catch(() => {
+        // If API call fails, keep default locale
+        setUserLocale('en');
+      });
+    }
+  }, [userId]);
 
   const onSort = ({ key, sortData: { sortDirection } }) => {
     const temp = [...tableRows];
@@ -103,7 +119,7 @@ const RequestsTable = ({
   useEffect(() => {
     const rows = [];
     const timezone = ManageIQ.timezone || 'UTC';
-    moment.locale(locale || 'en');
+    moment.locale(userLocale);
 
     initialData.forEach((object, index) => {
       const formattedTime = object.created_at
@@ -125,7 +141,7 @@ const RequestsTable = ({
       };
     });
     setTableRows(() => (rows));
-  }, [initialData]);
+  }, [initialData, userLocale]);
 
   return (
     tableRows.length > 0 && (
@@ -150,7 +166,7 @@ RequestsTable.propTypes = {
     severity: PropTypes.string,
     message: PropTypes.string,
   })),
-  locale: PropTypes.string,
+  userId: PropTypes.string,
 };
 
 export default RequestsTable;

--- a/app/views/miq_request/_request.html.haml
+++ b/app/views/miq_request/_request.html.haml
@@ -115,7 +115,7 @@
 - if role_allows?(:feature => 'miq_request_show_logs') && @miq_request.request_logs.any?
   %h3
     = _("Request Logs")
-    = react('RequestsTable', {:initialData => @miq_request.request_logs, :locale => FastGettext.locale.to_s.tr('_', '-')})
+    = react('RequestsTable', {:initialData => @miq_request.request_logs, :userId => current_user.id.to_s})
   %br
 - if @miq_request.workflow_class
   = render :partial => "prov_wf", :locals => {:wf => @miq_request.workflow_class.new({:src_vm_id => @miq_request.source_id}, current_user), :show => true}

--- a/app/views/miq_request/_request.html.haml
+++ b/app/views/miq_request/_request.html.haml
@@ -115,7 +115,7 @@
 - if role_allows?(:feature => 'miq_request_show_logs') && @miq_request.request_logs.any?
   %h3
     = _("Request Logs")
-    = react('RequestsTable', {:initialData => @miq_request.request_logs})
+    = react('RequestsTable', {:initialData => @miq_request.request_logs, :locale => FastGettext.locale.to_s.tr('_', '-')})
   %br
 - if @miq_request.workflow_class
   = render :partial => "prov_wf", :locals => {:wf => @miq_request.workflow_class.new({:src_vm_id => @miq_request.source_id}, current_user), :show => true}


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/10105

Before:
<img width="1177" height="795" alt="Screenshot 2026-06-16 at 9 14 54 AM" src="https://github.com/user-attachments/assets/bde929ee-7b3c-43cd-b4e3-dc006f277f1f" />

After:
<img width="1190" height="714" alt="Screenshot 2026-06-16 at 9 17 02 AM" src="https://github.com/user-attachments/assets/ac19f5a3-6b58-4cfd-a35a-9dcc4f97b45e" />

Example with non-English locale:
<img width="1165" height="661" alt="Screenshot 2026-06-16 at 1 27 08 PM" src="https://github.com/user-attachments/assets/a1b5b42d-168a-4f17-a5b8-2784315ea24d" />

Relative time tooltip:
<img width="1167" height="152" alt="Screenshot 2026-06-16 at 1 31 36 PM" src="https://github.com/user-attachments/assets/9b57790e-e2ae-4b30-b54d-46544b2063e6" />