### PR TITLE
Fix non sortable tables

### DIFF
--- a/app/javascript/components/miq-data-table/index.jsx
+++ b/app/javascript/components/miq-data-table/index.jsx
@@ -88,7 +88,7 @@ const MiqDataTable = ({
   /** Function to render the header cells. */
   const renderHeaders = (getHeaderProps) => (headers.map((header) => {
     const { sortHeader, sortDirection } = headerSortingData(header);
-    let isSortable = true;
+    let isSortable = sortable;
     if (header.header.split('_')[0] === DefaultKey) {
       isSortable = false;
     }

--- a/app/javascript/spec/chart-card/__snapshots__/chart-card.spec.js.snap
+++ b/app/javascript/spec/chart-card/__snapshots__/chart-card.spec.js.snap
@@ -102,256 +102,56 @@ exports[`Chart Card component should render the pods table card 1`] = `
               <thead>
                 <tr>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-1"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Name header in ascending order
+                      Name
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-1"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Name
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-2"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Status header in ascending order
+                      Status
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-2"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Status
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-3"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Ready Status header in ascending order
+                      Ready Status
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-3"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Ready Status
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-4"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Ready Containers header in ascending order
+                      Ready Containers
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-4"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Ready Containers
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                 </tr>
               </thead>

--- a/app/javascript/spec/miq-data-table/__snapshots__/miq-data-table.spec.js.snap
+++ b/app/javascript/spec/miq-data-table/__snapshots__/miq-data-table.spec.js.snap
@@ -649,130 +649,30 @@ exports[`Data table component should render a simple non-clickable data table 1`
         <thead>
           <tr>
             <th
-              aria-sort="none"
-              class="miq-data-table-header cds--table-sort__header"
+              class="miq-data-table-header"
               scope="col"
             >
               <div
-                class="cds--table-sort__description"
-                id="table-sort-1"
+                class="cds--table-header-label"
               >
-                Click to sort rows by Name header in ascending order
+                Name
+                <div
+                  class="cds--table-header-label--decorator-inner"
+                />
               </div>
-              <button
-                aria-describedby="table-sort-1"
-                class="miq-data-table-header cds--table-sort"
-                type="button"
-              >
-                <span
-                  class="cds--table-sort__flex"
-                >
-                  <div
-                    class="cds--table-header-label"
-                  >
-                    Name
-                  </div>
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                    />
-                  </svg>
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon-unsorted"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                    />
-                    <path
-                      d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                    />
-                  </svg>
-                  <div
-                    class="cds--table-header-label--decorator-inner"
-                  />
-                </span>
-              </button>
             </th>
             <th
-              aria-sort="none"
-              class="miq-data-table-header cds--table-sort__header"
+              class="miq-data-table-header"
               scope="col"
             >
               <div
-                class="cds--table-sort__description"
-                id="table-sort-2"
+                class="cds--table-header-label"
               >
-                Click to sort rows by Title header in ascending order
+                Title
+                <div
+                  class="cds--table-header-label--decorator-inner"
+                />
               </div>
-              <button
-                aria-describedby="table-sort-2"
-                class="miq-data-table-header cds--table-sort"
-                type="button"
-              >
-                <span
-                  class="cds--table-sort__flex"
-                >
-                  <div
-                    class="cds--table-header-label"
-                  >
-                    Title
-                  </div>
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                    />
-                  </svg>
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon-unsorted"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                    />
-                    <path
-                      d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                    />
-                  </svg>
-                  <div
-                    class="cds--table-header-label--decorator-inner"
-                  />
-                </span>
-              </button>
             </th>
           </tr>
         </thead>

--- a/app/javascript/spec/pxe-template-folders/__snapshots__/pxe-template-folders.spec.js.snap
+++ b/app/javascript/spec/pxe-template-folders/__snapshots__/pxe-template-folders.spec.js.snap
@@ -17,67 +17,17 @@ exports[`PxeTemplateFolders Component should render with empty folders array 1`]
           <thead>
             <tr>
               <th
-                aria-sort="none"
-                class="miq-data-table-header cds--table-sort__header"
+                class="miq-data-table-header"
                 scope="col"
               >
                 <div
-                  class="cds--table-sort__description"
-                  id="table-sort-1"
+                  class="cds--table-header-label"
                 >
-                  Click to sort rows by Name header in ascending order
+                  Name
+                  <div
+                    class="cds--table-header-label--decorator-inner"
+                  />
                 </div>
-                <button
-                  aria-describedby="table-sort-1"
-                  class="miq-data-table-header cds--table-sort"
-                  type="button"
-                >
-                  <span
-                    class="cds--table-sort__flex"
-                  >
-                    <div
-                      class="cds--table-header-label"
-                    >
-                      Name
-                    </div>
-                    <svg
-                      aria-hidden="true"
-                      class="cds--table-sort__icon"
-                      fill="currentColor"
-                      focusable="false"
-                      height="20"
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 32 32"
-                      width="20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden="true"
-                      class="cds--table-sort__icon-unsorted"
-                      fill="currentColor"
-                      focusable="false"
-                      height="20"
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 32 32"
-                      width="20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                      />
-                      <path
-                        d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                      />
-                    </svg>
-                    <div
-                      class="cds--table-header-label--decorator-inner"
-                    />
-                  </span>
-                </button>
               </th>
             </tr>
           </thead>
@@ -144,67 +94,17 @@ exports[`PxeTemplateFolders Component should render with folders data 1`] = `
           <thead>
             <tr>
               <th
-                aria-sort="none"
-                class="miq-data-table-header cds--table-sort__header"
+                class="miq-data-table-header"
                 scope="col"
               >
                 <div
-                  class="cds--table-sort__description"
-                  id="table-sort-3"
+                  class="cds--table-header-label"
                 >
-                  Click to sort rows by Name header in ascending order
+                  Name
+                  <div
+                    class="cds--table-header-label--decorator-inner"
+                  />
                 </div>
-                <button
-                  aria-describedby="table-sort-3"
-                  class="miq-data-table-header cds--table-sort"
-                  type="button"
-                >
-                  <span
-                    class="cds--table-sort__flex"
-                  >
-                    <div
-                      class="cds--table-header-label"
-                    >
-                      Name
-                    </div>
-                    <svg
-                      aria-hidden="true"
-                      class="cds--table-sort__icon"
-                      fill="currentColor"
-                      focusable="false"
-                      height="20"
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 32 32"
-                      width="20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden="true"
-                      class="cds--table-sort__icon-unsorted"
-                      fill="currentColor"
-                      focusable="false"
-                      height="20"
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 32 32"
-                      width="20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                      />
-                      <path
-                        d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                      />
-                    </svg>
-                    <div
-                      class="cds--table-header-label--decorator-inner"
-                    />
-                  </span>
-                </button>
               </th>
             </tr>
           </thead>

--- a/app/javascript/spec/reconfigure-vm-form/__snapshots__/reconfigure-vm-form.spec.js.snap
+++ b/app/javascript/spec/reconfigure-vm-form/__snapshots__/reconfigure-vm-form.spec.js.snap
@@ -80,256 +80,56 @@ exports[`Reconfigure VM form component should render form with only fields it ha
                 <thead>
                   <tr>
                     <th
-                      aria-sort="none"
-                      class="miq-data-table-header cds--table-sort__header"
+                      class="miq-data-table-header"
                       scope="col"
                     >
                       <div
-                        class="cds--table-sort__description"
-                        id="table-sort-309"
+                        class="cds--table-header-label"
                       >
-                        Click to sort rows by Name header in ascending order
+                        Name
+                        <div
+                          class="cds--table-header-label--decorator-inner"
+                        />
                       </div>
-                      <button
-                        aria-describedby="table-sort-309"
-                        class="miq-data-table-header cds--table-sort"
-                        type="button"
-                      >
-                        <span
-                          class="cds--table-sort__flex"
-                        >
-                          <div
-                            class="cds--table-header-label"
-                          >
-                            Name
-                          </div>
-                          <svg
-                            aria-hidden="true"
-                            class="cds--table-sort__icon"
-                            fill="currentColor"
-                            focusable="false"
-                            height="20"
-                            preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
-                            width="20"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                            />
-                          </svg>
-                          <svg
-                            aria-hidden="true"
-                            class="cds--table-sort__icon-unsorted"
-                            fill="currentColor"
-                            focusable="false"
-                            height="20"
-                            preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
-                            width="20"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                            />
-                            <path
-                              d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                            />
-                          </svg>
-                          <div
-                            class="cds--table-header-label--decorator-inner"
-                          />
-                        </span>
-                      </button>
                     </th>
                     <th
-                      aria-sort="none"
-                      class="miq-data-table-header cds--table-sort__header"
+                      class="miq-data-table-header"
                       scope="col"
                     >
                       <div
-                        class="cds--table-sort__description"
-                        id="table-sort-310"
+                        class="cds--table-header-label"
                       >
-                        Click to sort rows by Host File header in ascending order
+                        Host File
+                        <div
+                          class="cds--table-header-label--decorator-inner"
+                        />
                       </div>
-                      <button
-                        aria-describedby="table-sort-310"
-                        class="miq-data-table-header cds--table-sort"
-                        type="button"
-                      >
-                        <span
-                          class="cds--table-sort__flex"
-                        >
-                          <div
-                            class="cds--table-header-label"
-                          >
-                            Host File
-                          </div>
-                          <svg
-                            aria-hidden="true"
-                            class="cds--table-sort__icon"
-                            fill="currentColor"
-                            focusable="false"
-                            height="20"
-                            preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
-                            width="20"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                            />
-                          </svg>
-                          <svg
-                            aria-hidden="true"
-                            class="cds--table-sort__icon-unsorted"
-                            fill="currentColor"
-                            focusable="false"
-                            height="20"
-                            preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
-                            width="20"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                            />
-                            <path
-                              d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                            />
-                          </svg>
-                          <div
-                            class="cds--table-header-label--decorator-inner"
-                          />
-                        </span>
-                      </button>
                     </th>
                     <th
-                      aria-sort="none"
-                      class="miq-data-table-header cds--table-sort__header"
+                      class="miq-data-table-header"
                       scope="col"
                     >
                       <div
-                        class="cds--table-sort__description"
-                        id="table-sort-311"
+                        class="cds--table-header-label"
                       >
-                        Click to sort rows by Disconnect header in ascending order
+                        Disconnect
+                        <div
+                          class="cds--table-header-label--decorator-inner"
+                        />
                       </div>
-                      <button
-                        aria-describedby="table-sort-311"
-                        class="miq-data-table-header cds--table-sort"
-                        type="button"
-                      >
-                        <span
-                          class="cds--table-sort__flex"
-                        >
-                          <div
-                            class="cds--table-header-label"
-                          >
-                            Disconnect
-                          </div>
-                          <svg
-                            aria-hidden="true"
-                            class="cds--table-sort__icon"
-                            fill="currentColor"
-                            focusable="false"
-                            height="20"
-                            preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
-                            width="20"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                            />
-                          </svg>
-                          <svg
-                            aria-hidden="true"
-                            class="cds--table-sort__icon-unsorted"
-                            fill="currentColor"
-                            focusable="false"
-                            height="20"
-                            preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
-                            width="20"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                            />
-                            <path
-                              d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                            />
-                          </svg>
-                          <div
-                            class="cds--table-header-label--decorator-inner"
-                          />
-                        </span>
-                      </button>
                     </th>
                     <th
-                      aria-sort="none"
-                      class="miq-data-table-header cds--table-sort__header"
+                      class="miq-data-table-header"
                       scope="col"
                     >
                       <div
-                        class="cds--table-sort__description"
-                        id="table-sort-312"
+                        class="cds--table-header-label"
                       >
-                        Click to sort rows by Actions header in ascending order
+                        Actions
+                        <div
+                          class="cds--table-header-label--decorator-inner"
+                        />
                       </div>
-                      <button
-                        aria-describedby="table-sort-312"
-                        class="miq-data-table-header cds--table-sort"
-                        type="button"
-                      >
-                        <span
-                          class="cds--table-sort__flex"
-                        >
-                          <div
-                            class="cds--table-header-label"
-                          >
-                            Actions
-                          </div>
-                          <svg
-                            aria-hidden="true"
-                            class="cds--table-sort__icon"
-                            fill="currentColor"
-                            focusable="false"
-                            height="20"
-                            preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
-                            width="20"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                            />
-                          </svg>
-                          <svg
-                            aria-hidden="true"
-                            class="cds--table-sort__icon-unsorted"
-                            fill="currentColor"
-                            focusable="false"
-                            height="20"
-                            preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
-                            width="20"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                            />
-                            <path
-                              d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                            />
-                          </svg>
-                          <div
-                            class="cds--table-header-label--decorator-inner"
-                          />
-                        </span>
-                      </button>
                     </th>
                   </tr>
                 </thead>
@@ -492,697 +292,147 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
               <thead>
                 <tr>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-281"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Name header in ascending order
+                      Name
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-281"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Name
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-282"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Type header in ascending order
+                      Type
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-282"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Type
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-283"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Size header in ascending order
+                      Size
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-283"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Size
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-284"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Unit header in ascending order
+                      Unit
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-284"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Unit
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-285"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Mode header in ascending order
+                      Mode
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-285"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Mode
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-286"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Controller Type header in ascending order
+                      Controller Type
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-286"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Controller Type
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-287"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Dependent header in ascending order
+                      Dependent
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-287"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Dependent
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-288"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Delete Backing header in ascending order
+                      Delete Backing
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-288"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Delete Backing
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-289"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Bootable header in ascending order
+                      Bootable
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-289"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Bootable
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-290"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Resize header in ascending order
+                      Resize
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-290"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Resize
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header header-button cds--table-sort__header"
+                    class="miq-data-table-header header-button"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-291"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Action header in ascending order
+                      Action
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-291"
-                      class="miq-data-table-header header-button cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Action
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                 </tr>
               </thead>
@@ -1410,319 +660,69 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
               <thead>
                 <tr>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-295"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Name header in ascending order
+                      Name
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-295"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Name
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-296"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by MAC address header in ascending order
+                      MAC address
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-296"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          MAC address
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-297"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by vLan header in ascending order
+                      vLan
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-297"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          vLan
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header header-button cds--table-sort__header"
+                    class="miq-data-table-header header-button"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-298"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Edit header in ascending order
+                      Edit
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-298"
-                      class="miq-data-table-header header-button cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Edit
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header header-button cds--table-sort__header"
+                    class="miq-data-table-header header-button"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-299"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Action header in ascending order
+                      Action
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-299"
-                      class="miq-data-table-header header-button cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Action
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                 </tr>
               </thead>
@@ -1756,256 +756,56 @@ exports[`Reconfigure VM form component should render reconfigure form and click 
               <thead>
                 <tr>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-300"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Name header in ascending order
+                      Name
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-300"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Name
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-301"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Host File header in ascending order
+                      Host File
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-301"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Host File
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-302"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Disconnect header in ascending order
+                      Disconnect
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-302"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Disconnect
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-303"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Actions header in ascending order
+                      Actions
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-303"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Actions
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                 </tr>
               </thead>
@@ -4051,697 +2851,147 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
               <thead>
                 <tr>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-2"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Name header in ascending order
+                      Name
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-2"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Name
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-3"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Type header in ascending order
+                      Type
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-3"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Type
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-4"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Size header in ascending order
+                      Size
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-4"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Size
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-5"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Unit header in ascending order
+                      Unit
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-5"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Unit
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-6"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Mode header in ascending order
+                      Mode
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-6"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Mode
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-7"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Controller Type header in ascending order
+                      Controller Type
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-7"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Controller Type
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-8"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Dependent header in ascending order
+                      Dependent
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-8"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Dependent
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-9"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Delete Backing header in ascending order
+                      Delete Backing
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-9"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Delete Backing
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-10"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Bootable header in ascending order
+                      Bootable
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-10"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Bootable
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-11"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Resize header in ascending order
+                      Resize
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-11"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Resize
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header header-button cds--table-sort__header"
+                    class="miq-data-table-header header-button"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-12"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Action header in ascending order
+                      Action
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-12"
-                      class="miq-data-table-header header-button cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Action
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                 </tr>
               </thead>
@@ -4969,319 +3219,69 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
               <thead>
                 <tr>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-16"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Name header in ascending order
+                      Name
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-16"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Name
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-17"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by MAC address header in ascending order
+                      MAC address
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-17"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          MAC address
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-18"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by vLan header in ascending order
+                      vLan
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-18"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          vLan
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header header-button cds--table-sort__header"
+                    class="miq-data-table-header header-button"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-19"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Edit header in ascending order
+                      Edit
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-19"
-                      class="miq-data-table-header header-button cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Edit
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header header-button cds--table-sort__header"
+                    class="miq-data-table-header header-button"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-20"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Action header in ascending order
+                      Action
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-20"
-                      class="miq-data-table-header header-button cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Action
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                 </tr>
               </thead>
@@ -5399,256 +3399,56 @@ exports[`Reconfigure VM form component should render reconfigure form with datat
                 <thead>
                   <tr>
                     <th
-                      aria-sort="none"
-                      class="miq-data-table-header cds--table-sort__header"
+                      class="miq-data-table-header"
                       scope="col"
                     >
                       <div
-                        class="cds--table-sort__description"
-                        id="table-sort-23"
+                        class="cds--table-header-label"
                       >
-                        Click to sort rows by Name header in ascending order
+                        Name
+                        <div
+                          class="cds--table-header-label--decorator-inner"
+                        />
                       </div>
-                      <button
-                        aria-describedby="table-sort-23"
-                        class="miq-data-table-header cds--table-sort"
-                        type="button"
-                      >
-                        <span
-                          class="cds--table-sort__flex"
-                        >
-                          <div
-                            class="cds--table-header-label"
-                          >
-                            Name
-                          </div>
-                          <svg
-                            aria-hidden="true"
-                            class="cds--table-sort__icon"
-                            fill="currentColor"
-                            focusable="false"
-                            height="20"
-                            preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
-                            width="20"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                            />
-                          </svg>
-                          <svg
-                            aria-hidden="true"
-                            class="cds--table-sort__icon-unsorted"
-                            fill="currentColor"
-                            focusable="false"
-                            height="20"
-                            preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
-                            width="20"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                            />
-                            <path
-                              d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                            />
-                          </svg>
-                          <div
-                            class="cds--table-header-label--decorator-inner"
-                          />
-                        </span>
-                      </button>
                     </th>
                     <th
-                      aria-sort="none"
-                      class="miq-data-table-header cds--table-sort__header"
+                      class="miq-data-table-header"
                       scope="col"
                     >
                       <div
-                        class="cds--table-sort__description"
-                        id="table-sort-24"
+                        class="cds--table-header-label"
                       >
-                        Click to sort rows by Host File header in ascending order
+                        Host File
+                        <div
+                          class="cds--table-header-label--decorator-inner"
+                        />
                       </div>
-                      <button
-                        aria-describedby="table-sort-24"
-                        class="miq-data-table-header cds--table-sort"
-                        type="button"
-                      >
-                        <span
-                          class="cds--table-sort__flex"
-                        >
-                          <div
-                            class="cds--table-header-label"
-                          >
-                            Host File
-                          </div>
-                          <svg
-                            aria-hidden="true"
-                            class="cds--table-sort__icon"
-                            fill="currentColor"
-                            focusable="false"
-                            height="20"
-                            preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
-                            width="20"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                            />
-                          </svg>
-                          <svg
-                            aria-hidden="true"
-                            class="cds--table-sort__icon-unsorted"
-                            fill="currentColor"
-                            focusable="false"
-                            height="20"
-                            preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
-                            width="20"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                            />
-                            <path
-                              d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                            />
-                          </svg>
-                          <div
-                            class="cds--table-header-label--decorator-inner"
-                          />
-                        </span>
-                      </button>
                     </th>
                     <th
-                      aria-sort="none"
-                      class="miq-data-table-header cds--table-sort__header"
+                      class="miq-data-table-header"
                       scope="col"
                     >
                       <div
-                        class="cds--table-sort__description"
-                        id="table-sort-25"
+                        class="cds--table-header-label"
                       >
-                        Click to sort rows by Disconnect header in ascending order
+                        Disconnect
+                        <div
+                          class="cds--table-header-label--decorator-inner"
+                        />
                       </div>
-                      <button
-                        aria-describedby="table-sort-25"
-                        class="miq-data-table-header cds--table-sort"
-                        type="button"
-                      >
-                        <span
-                          class="cds--table-sort__flex"
-                        >
-                          <div
-                            class="cds--table-header-label"
-                          >
-                            Disconnect
-                          </div>
-                          <svg
-                            aria-hidden="true"
-                            class="cds--table-sort__icon"
-                            fill="currentColor"
-                            focusable="false"
-                            height="20"
-                            preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
-                            width="20"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                            />
-                          </svg>
-                          <svg
-                            aria-hidden="true"
-                            class="cds--table-sort__icon-unsorted"
-                            fill="currentColor"
-                            focusable="false"
-                            height="20"
-                            preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
-                            width="20"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                            />
-                            <path
-                              d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                            />
-                          </svg>
-                          <div
-                            class="cds--table-header-label--decorator-inner"
-                          />
-                        </span>
-                      </button>
                     </th>
                     <th
-                      aria-sort="none"
-                      class="miq-data-table-header cds--table-sort__header"
+                      class="miq-data-table-header"
                       scope="col"
                     >
                       <div
-                        class="cds--table-sort__description"
-                        id="table-sort-26"
+                        class="cds--table-header-label"
                       >
-                        Click to sort rows by Actions header in ascending order
+                        Actions
+                        <div
+                          class="cds--table-header-label--decorator-inner"
+                        />
                       </div>
-                      <button
-                        aria-describedby="table-sort-26"
-                        class="miq-data-table-header cds--table-sort"
-                        type="button"
-                      >
-                        <span
-                          class="cds--table-sort__flex"
-                        >
-                          <div
-                            class="cds--table-header-label"
-                          >
-                            Actions
-                          </div>
-                          <svg
-                            aria-hidden="true"
-                            class="cds--table-sort__icon"
-                            fill="currentColor"
-                            focusable="false"
-                            height="20"
-                            preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
-                            width="20"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                            />
-                          </svg>
-                          <svg
-                            aria-hidden="true"
-                            class="cds--table-sort__icon-unsorted"
-                            fill="currentColor"
-                            focusable="false"
-                            height="20"
-                            preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
-                            width="20"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                            />
-                            <path
-                              d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                            />
-                          </svg>
-                          <div
-                            class="cds--table-header-label--decorator-inner"
-                          />
-                        </span>
-                      </button>
                     </th>
                   </tr>
                 </thead>
@@ -6283,697 +4083,147 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
               <thead>
                 <tr>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-223"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Name header in ascending order
+                      Name
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-223"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Name
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-224"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Type header in ascending order
+                      Type
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-224"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Type
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-225"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Size header in ascending order
+                      Size
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-225"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Size
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-226"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Unit header in ascending order
+                      Unit
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-226"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Unit
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-227"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Mode header in ascending order
+                      Mode
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-227"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Mode
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-228"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Controller Type header in ascending order
+                      Controller Type
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-228"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Controller Type
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-229"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Dependent header in ascending order
+                      Dependent
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-229"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Dependent
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-230"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Delete Backing header in ascending order
+                      Delete Backing
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-230"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Delete Backing
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-231"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Bootable header in ascending order
+                      Bootable
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-231"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Bootable
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-232"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Resize header in ascending order
+                      Resize
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-232"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Resize
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header header-button cds--table-sort__header"
+                    class="miq-data-table-header header-button"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-233"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Action header in ascending order
+                      Action
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-233"
-                      class="miq-data-table-header header-button cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Action
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                 </tr>
               </thead>
@@ -7203,319 +4453,69 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
               <thead>
                 <tr>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-237"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Name header in ascending order
+                      Name
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-237"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Name
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-238"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by MAC address header in ascending order
+                      MAC address
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-238"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          MAC address
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-239"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by vLan header in ascending order
+                      vLan
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-239"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          vLan
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header header-button cds--table-sort__header"
+                    class="miq-data-table-header header-button"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-240"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Edit header in ascending order
+                      Edit
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-240"
-                      class="miq-data-table-header header-button cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Edit
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header header-button cds--table-sort__header"
+                    class="miq-data-table-header header-button"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-241"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Action header in ascending order
+                      Action
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-241"
-                      class="miq-data-table-header header-button cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Action
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                 </tr>
               </thead>
@@ -7549,256 +4549,56 @@ exports[`Reconfigure VM form component should render reconfigure sub form and cl
               <thead>
                 <tr>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-242"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Name header in ascending order
+                      Name
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-242"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Name
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-243"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Host File header in ascending order
+                      Host File
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-243"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Host File
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-244"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Disconnect header in ascending order
+                      Disconnect
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-244"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Disconnect
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                   <th
-                    aria-sort="none"
-                    class="miq-data-table-header cds--table-sort__header"
+                    class="miq-data-table-header"
                     scope="col"
                   >
                     <div
-                      class="cds--table-sort__description"
-                      id="table-sort-245"
+                      class="cds--table-header-label"
                     >
-                      Click to sort rows by Actions header in ascending order
+                      Actions
+                      <div
+                        class="cds--table-header-label--decorator-inner"
+                      />
                     </div>
-                    <button
-                      aria-describedby="table-sort-245"
-                      class="miq-data-table-header cds--table-sort"
-                      type="button"
-                    >
-                      <span
-                        class="cds--table-sort__flex"
-                      >
-                        <div
-                          class="cds--table-header-label"
-                        >
-                          Actions
-                        </div>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="cds--table-sort__icon-unsorted"
-                          fill="currentColor"
-                          focusable="false"
-                          height="20"
-                          preserveAspectRatio="xMidYMid meet"
-                          viewBox="0 0 32 32"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                          />
-                          <path
-                            d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                          />
-                        </svg>
-                        <div
-                          class="cds--table-header-label--decorator-inner"
-                        />
-                      </span>
-                    </button>
                   </th>
                 </tr>
               </thead>

--- a/app/javascript/spec/settings-compan-categories/__snapshots__/settings-company-categories.spec.js.snap
+++ b/app/javascript/spec/settings-compan-categories/__snapshots__/settings-company-categories.spec.js.snap
@@ -36,431 +36,88 @@ exports[`SettingsCompanyCategories component should render a SettingsCompanyCate
         <thead>
           <tr>
             <th
-              aria-sort="none"
-              class="miq-data-table-header cds--table-sort__header"
+              class="miq-data-table-header"
               scope="col"
             >
               <div
-                class="cds--table-sort__description"
-                id="table-sort-2"
+                class="cds--table-header-label"
               >
-                Click to sort rows by Name header in ascending order
+                <div
+                  class="cds--table-header-label--decorator-inner"
+                />
               </div>
-              <button
-                aria-describedby="table-sort-2"
-                class="miq-data-table-header cds--table-sort"
-                type="button"
-              >
-                <span
-                  class="cds--table-sort__flex"
-                >
-                  <div
-                    class="cds--table-header-label"
-                  />
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                    />
-                  </svg>
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon-unsorted"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                    />
-                    <path
-                      d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                    />
-                  </svg>
-                  <div
-                    class="cds--table-header-label--decorator-inner"
-                  />
-                </span>
-              </button>
             </th>
             <th
-              aria-sort="none"
-              class="miq-data-table-header cds--table-sort__header"
+              class="miq-data-table-header"
               scope="col"
             >
               <div
-                class="cds--table-sort__description"
-                id="table-sort-3"
+                class="cds--table-header-label"
               >
-                Click to sort rows by Description header in ascending order
+                <div
+                  class="cds--table-header-label--decorator-inner"
+                />
               </div>
-              <button
-                aria-describedby="table-sort-3"
-                class="miq-data-table-header cds--table-sort"
-                type="button"
-              >
-                <span
-                  class="cds--table-sort__flex"
-                >
-                  <div
-                    class="cds--table-header-label"
-                  />
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                    />
-                  </svg>
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon-unsorted"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                    />
-                    <path
-                      d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                    />
-                  </svg>
-                  <div
-                    class="cds--table-header-label--decorator-inner"
-                  />
-                </span>
-              </button>
             </th>
             <th
-              aria-sort="none"
-              class="miq-data-table-header cds--table-sort__header"
+              class="miq-data-table-header"
               scope="col"
             >
               <div
-                class="cds--table-sort__description"
-                id="table-sort-4"
+                class="cds--table-header-label"
               >
-                Click to sort rows by Show in Console header in ascending order
+                <div
+                  class="cds--table-header-label--decorator-inner"
+                />
               </div>
-              <button
-                aria-describedby="table-sort-4"
-                class="miq-data-table-header cds--table-sort"
-                type="button"
-              >
-                <span
-                  class="cds--table-sort__flex"
-                >
-                  <div
-                    class="cds--table-header-label"
-                  />
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                    />
-                  </svg>
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon-unsorted"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                    />
-                    <path
-                      d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                    />
-                  </svg>
-                  <div
-                    class="cds--table-header-label--decorator-inner"
-                  />
-                </span>
-              </button>
             </th>
             <th
-              aria-sort="none"
-              class="miq-data-table-header cds--table-sort__header"
+              class="miq-data-table-header"
               scope="col"
             >
               <div
-                class="cds--table-sort__description"
-                id="table-sort-5"
+                class="cds--table-header-label"
               >
-                Click to sort rows by Single Value header in ascending order
+                <div
+                  class="cds--table-header-label--decorator-inner"
+                />
               </div>
-              <button
-                aria-describedby="table-sort-5"
-                class="miq-data-table-header cds--table-sort"
-                type="button"
-              >
-                <span
-                  class="cds--table-sort__flex"
-                >
-                  <div
-                    class="cds--table-header-label"
-                  />
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                    />
-                  </svg>
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon-unsorted"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                    />
-                    <path
-                      d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                    />
-                  </svg>
-                  <div
-                    class="cds--table-header-label--decorator-inner"
-                  />
-                </span>
-              </button>
             </th>
             <th
-              aria-sort="none"
-              class="miq-data-table-header cds--table-sort__header"
+              class="miq-data-table-header"
               scope="col"
             >
               <div
-                class="cds--table-sort__description"
-                id="table-sort-6"
+                class="cds--table-header-label"
               >
-                Click to sort rows by Capture C & U Data header in ascending order
+                <div
+                  class="cds--table-header-label--decorator-inner"
+                />
               </div>
-              <button
-                aria-describedby="table-sort-6"
-                class="miq-data-table-header cds--table-sort"
-                type="button"
-              >
-                <span
-                  class="cds--table-sort__flex"
-                >
-                  <div
-                    class="cds--table-header-label"
-                  />
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                    />
-                  </svg>
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon-unsorted"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                    />
-                    <path
-                      d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                    />
-                  </svg>
-                  <div
-                    class="cds--table-header-label--decorator-inner"
-                  />
-                </span>
-              </button>
             </th>
             <th
-              aria-sort="none"
-              class="miq-data-table-header cds--table-sort__header"
+              class="miq-data-table-header"
               scope="col"
             >
               <div
-                class="cds--table-sort__description"
-                id="table-sort-7"
+                class="cds--table-header-label"
               >
-                Click to sort rows by Default header in ascending order
+                <div
+                  class="cds--table-header-label--decorator-inner"
+                />
               </div>
-              <button
-                aria-describedby="table-sort-7"
-                class="miq-data-table-header cds--table-sort"
-                type="button"
-              >
-                <span
-                  class="cds--table-sort__flex"
-                >
-                  <div
-                    class="cds--table-header-label"
-                  />
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                    />
-                  </svg>
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon-unsorted"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                    />
-                    <path
-                      d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                    />
-                  </svg>
-                  <div
-                    class="cds--table-header-label--decorator-inner"
-                  />
-                </span>
-              </button>
             </th>
             <th
-              aria-sort="none"
-              class="miq-data-table-header cds--table-sort__header"
+              class="miq-data-table-header"
               scope="col"
             >
               <div
-                class="cds--table-sort__description"
-                id="table-sort-8"
+                class="cds--table-header-label"
               >
-                Click to sort rows by Actions header in ascending order
+                <div
+                  class="cds--table-header-label--decorator-inner"
+                />
               </div>
-              <button
-                aria-describedby="table-sort-8"
-                class="miq-data-table-header cds--table-sort"
-                type="button"
-              >
-                <span
-                  class="cds--table-sort__flex"
-                >
-                  <div
-                    class="cds--table-header-label"
-                  />
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                    />
-                  </svg>
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon-unsorted"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                    />
-                    <path
-                      d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                    />
-                  </svg>
-                  <div
-                    class="cds--table-header-label--decorator-inner"
-                  />
-                </span>
-              </button>
             </th>
           </tr>
         </thead>

--- a/app/javascript/spec/settings-label-tag-mapping/__snapshots__/settings-label-tag-mapping.spec.js.snap
+++ b/app/javascript/spec/settings-label-tag-mapping/__snapshots__/settings-label-tag-mapping.spec.js.snap
@@ -50,256 +50,56 @@ exports[`SettingsLabelTagMapping component should render a SettingsLabelTagMappi
         <thead>
           <tr>
             <th
-              aria-sort="none"
-              class="miq-data-table-header cds--table-sort__header"
+              class="miq-data-table-header"
               scope="col"
             >
               <div
-                class="cds--table-sort__description"
-                id="table-sort-11"
+                class="cds--table-header-label"
               >
-                Click to sort rows by Resource Entity header in ascending order
+                Resource Entity
+                <div
+                  class="cds--table-header-label--decorator-inner"
+                />
               </div>
-              <button
-                aria-describedby="table-sort-11"
-                class="miq-data-table-header cds--table-sort"
-                type="button"
-              >
-                <span
-                  class="cds--table-sort__flex"
-                >
-                  <div
-                    class="cds--table-header-label"
-                  >
-                    Resource Entity
-                  </div>
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                    />
-                  </svg>
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon-unsorted"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                    />
-                    <path
-                      d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                    />
-                  </svg>
-                  <div
-                    class="cds--table-header-label--decorator-inner"
-                  />
-                </span>
-              </button>
             </th>
             <th
-              aria-sort="none"
-              class="miq-data-table-header cds--table-sort__header"
+              class="miq-data-table-header"
               scope="col"
             >
               <div
-                class="cds--table-sort__description"
-                id="table-sort-12"
+                class="cds--table-header-label"
               >
-                Click to sort rows by Resource Label header in ascending order
+                Resource Label
+                <div
+                  class="cds--table-header-label--decorator-inner"
+                />
               </div>
-              <button
-                aria-describedby="table-sort-12"
-                class="miq-data-table-header cds--table-sort"
-                type="button"
-              >
-                <span
-                  class="cds--table-sort__flex"
-                >
-                  <div
-                    class="cds--table-header-label"
-                  >
-                    Resource Label
-                  </div>
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                    />
-                  </svg>
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon-unsorted"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                    />
-                    <path
-                      d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                    />
-                  </svg>
-                  <div
-                    class="cds--table-header-label--decorator-inner"
-                  />
-                </span>
-              </button>
             </th>
             <th
-              aria-sort="none"
-              class="miq-data-table-header cds--table-sort__header"
+              class="miq-data-table-header"
               scope="col"
             >
               <div
-                class="cds--table-sort__description"
-                id="table-sort-13"
+                class="cds--table-header-label"
               >
-                Click to sort rows by Tag Category header in ascending order
+                Tag Category
+                <div
+                  class="cds--table-header-label--decorator-inner"
+                />
               </div>
-              <button
-                aria-describedby="table-sort-13"
-                class="miq-data-table-header cds--table-sort"
-                type="button"
-              >
-                <span
-                  class="cds--table-sort__flex"
-                >
-                  <div
-                    class="cds--table-header-label"
-                  >
-                    Tag Category
-                  </div>
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                    />
-                  </svg>
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon-unsorted"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                    />
-                    <path
-                      d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                    />
-                  </svg>
-                  <div
-                    class="cds--table-header-label--decorator-inner"
-                  />
-                </span>
-              </button>
             </th>
             <th
-              aria-sort="none"
-              class="miq-data-table-header cds--table-sort__header"
+              class="miq-data-table-header"
               scope="col"
             >
               <div
-                class="cds--table-sort__description"
-                id="table-sort-14"
+                class="cds--table-header-label"
               >
-                Click to sort rows by Actions header in ascending order
+                Actions
+                <div
+                  class="cds--table-header-label--decorator-inner"
+                />
               </div>
-              <button
-                aria-describedby="table-sort-14"
-                class="miq-data-table-header cds--table-sort"
-                type="button"
-              >
-                <span
-                  class="cds--table-sort__flex"
-                >
-                  <div
-                    class="cds--table-header-label"
-                  >
-                    Actions
-                  </div>
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                    />
-                  </svg>
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon-unsorted"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                    />
-                    <path
-                      d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                    />
-                  </svg>
-                  <div
-                    class="cds--table-header-label--decorator-inner"
-                  />
-                </span>
-              </button>
             </th>
           </tr>
         </thead>
@@ -621,256 +421,56 @@ exports[`SettingsLabelTagMapping component should render a SettingsLabelTagMappi
         <thead>
           <tr>
             <th
-              aria-sort="none"
-              class="miq-data-table-header cds--table-sort__header"
+              class="miq-data-table-header"
               scope="col"
             >
               <div
-                class="cds--table-sort__description"
-                id="table-sort-2"
+                class="cds--table-header-label"
               >
-                Click to sort rows by Resource Entity header in ascending order
+                Resource Entity
+                <div
+                  class="cds--table-header-label--decorator-inner"
+                />
               </div>
-              <button
-                aria-describedby="table-sort-2"
-                class="miq-data-table-header cds--table-sort"
-                type="button"
-              >
-                <span
-                  class="cds--table-sort__flex"
-                >
-                  <div
-                    class="cds--table-header-label"
-                  >
-                    Resource Entity
-                  </div>
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                    />
-                  </svg>
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon-unsorted"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                    />
-                    <path
-                      d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                    />
-                  </svg>
-                  <div
-                    class="cds--table-header-label--decorator-inner"
-                  />
-                </span>
-              </button>
             </th>
             <th
-              aria-sort="none"
-              class="miq-data-table-header cds--table-sort__header"
+              class="miq-data-table-header"
               scope="col"
             >
               <div
-                class="cds--table-sort__description"
-                id="table-sort-3"
+                class="cds--table-header-label"
               >
-                Click to sort rows by Resource Label header in ascending order
+                Resource Label
+                <div
+                  class="cds--table-header-label--decorator-inner"
+                />
               </div>
-              <button
-                aria-describedby="table-sort-3"
-                class="miq-data-table-header cds--table-sort"
-                type="button"
-              >
-                <span
-                  class="cds--table-sort__flex"
-                >
-                  <div
-                    class="cds--table-header-label"
-                  >
-                    Resource Label
-                  </div>
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                    />
-                  </svg>
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon-unsorted"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                    />
-                    <path
-                      d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                    />
-                  </svg>
-                  <div
-                    class="cds--table-header-label--decorator-inner"
-                  />
-                </span>
-              </button>
             </th>
             <th
-              aria-sort="none"
-              class="miq-data-table-header cds--table-sort__header"
+              class="miq-data-table-header"
               scope="col"
             >
               <div
-                class="cds--table-sort__description"
-                id="table-sort-4"
+                class="cds--table-header-label"
               >
-                Click to sort rows by Tag Category header in ascending order
+                Tag Category
+                <div
+                  class="cds--table-header-label--decorator-inner"
+                />
               </div>
-              <button
-                aria-describedby="table-sort-4"
-                class="miq-data-table-header cds--table-sort"
-                type="button"
-              >
-                <span
-                  class="cds--table-sort__flex"
-                >
-                  <div
-                    class="cds--table-header-label"
-                  >
-                    Tag Category
-                  </div>
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                    />
-                  </svg>
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon-unsorted"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                    />
-                    <path
-                      d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                    />
-                  </svg>
-                  <div
-                    class="cds--table-header-label--decorator-inner"
-                  />
-                </span>
-              </button>
             </th>
             <th
-              aria-sort="none"
-              class="miq-data-table-header cds--table-sort__header"
+              class="miq-data-table-header"
               scope="col"
             >
               <div
-                class="cds--table-sort__description"
-                id="table-sort-5"
+                class="cds--table-header-label"
               >
-                Click to sort rows by Actions header in ascending order
+                Actions
+                <div
+                  class="cds--table-header-label--decorator-inner"
+                />
               </div>
-              <button
-                aria-describedby="table-sort-5"
-                class="miq-data-table-header cds--table-sort"
-                type="button"
-              >
-                <span
-                  class="cds--table-sort__flex"
-                >
-                  <div
-                    class="cds--table-header-label"
-                  >
-                    Actions
-                  </div>
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                    />
-                  </svg>
-                  <svg
-                    aria-hidden="true"
-                    class="cds--table-sort__icon-unsorted"
-                    fill="currentColor"
-                    focusable="false"
-                    height="20"
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                    />
-                    <path
-                      d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                    />
-                  </svg>
-                  <div
-                    class="cds--table-header-label--decorator-inner"
-                  />
-                </span>
-              </button>
             </th>
           </tr>
         </thead>

--- a/app/javascript/spec/tenant-quota-form/__snapshots__/tenant-quota-form.spec.js.snap
+++ b/app/javascript/spec/tenant-quota-form/__snapshots__/tenant-quota-form.spec.js.snap
@@ -17,256 +17,56 @@ exports[`Tenant Quota Form Component should render the manage quotas form for a 
           <thead>
             <tr>
               <th
-                aria-sort="none"
-                class="miq-data-table-header cds--table-sort__header"
+                class="miq-data-table-header"
                 scope="col"
               >
                 <div
-                  class="cds--table-sort__description"
-                  id="table-sort-1"
+                  class="cds--table-header-label"
                 >
-                  Click to sort rows by Enforced header in ascending order
+                  Enforced
+                  <div
+                    class="cds--table-header-label--decorator-inner"
+                  />
                 </div>
-                <button
-                  aria-describedby="table-sort-1"
-                  class="miq-data-table-header cds--table-sort"
-                  type="button"
-                >
-                  <span
-                    class="cds--table-sort__flex"
-                  >
-                    <div
-                      class="cds--table-header-label"
-                    >
-                      Enforced
-                    </div>
-                    <svg
-                      aria-hidden="true"
-                      class="cds--table-sort__icon"
-                      fill="currentColor"
-                      focusable="false"
-                      height="20"
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 32 32"
-                      width="20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden="true"
-                      class="cds--table-sort__icon-unsorted"
-                      fill="currentColor"
-                      focusable="false"
-                      height="20"
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 32 32"
-                      width="20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                      />
-                      <path
-                        d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                      />
-                    </svg>
-                    <div
-                      class="cds--table-header-label--decorator-inner"
-                    />
-                  </span>
-                </button>
               </th>
               <th
-                aria-sort="none"
-                class="miq-data-table-header cds--table-sort__header"
+                class="miq-data-table-header"
                 scope="col"
               >
                 <div
-                  class="cds--table-sort__description"
-                  id="table-sort-2"
+                  class="cds--table-header-label"
                 >
-                  Click to sort rows by Description header in ascending order
+                  Description
+                  <div
+                    class="cds--table-header-label--decorator-inner"
+                  />
                 </div>
-                <button
-                  aria-describedby="table-sort-2"
-                  class="miq-data-table-header cds--table-sort"
-                  type="button"
-                >
-                  <span
-                    class="cds--table-sort__flex"
-                  >
-                    <div
-                      class="cds--table-header-label"
-                    >
-                      Description
-                    </div>
-                    <svg
-                      aria-hidden="true"
-                      class="cds--table-sort__icon"
-                      fill="currentColor"
-                      focusable="false"
-                      height="20"
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 32 32"
-                      width="20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden="true"
-                      class="cds--table-sort__icon-unsorted"
-                      fill="currentColor"
-                      focusable="false"
-                      height="20"
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 32 32"
-                      width="20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                      />
-                      <path
-                        d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                      />
-                    </svg>
-                    <div
-                      class="cds--table-header-label--decorator-inner"
-                    />
-                  </span>
-                </button>
               </th>
               <th
-                aria-sort="none"
-                class="miq-data-table-header cds--table-sort__header"
+                class="miq-data-table-header"
                 scope="col"
               >
                 <div
-                  class="cds--table-sort__description"
-                  id="table-sort-3"
+                  class="cds--table-header-label"
                 >
-                  Click to sort rows by Value header in ascending order
+                  Value
+                  <div
+                    class="cds--table-header-label--decorator-inner"
+                  />
                 </div>
-                <button
-                  aria-describedby="table-sort-3"
-                  class="miq-data-table-header cds--table-sort"
-                  type="button"
-                >
-                  <span
-                    class="cds--table-sort__flex"
-                  >
-                    <div
-                      class="cds--table-header-label"
-                    >
-                      Value
-                    </div>
-                    <svg
-                      aria-hidden="true"
-                      class="cds--table-sort__icon"
-                      fill="currentColor"
-                      focusable="false"
-                      height="20"
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 32 32"
-                      width="20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden="true"
-                      class="cds--table-sort__icon-unsorted"
-                      fill="currentColor"
-                      focusable="false"
-                      height="20"
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 32 32"
-                      width="20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                      />
-                      <path
-                        d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                      />
-                    </svg>
-                    <div
-                      class="cds--table-header-label--decorator-inner"
-                    />
-                  </span>
-                </button>
               </th>
               <th
-                aria-sort="none"
-                class="miq-data-table-header cds--table-sort__header"
+                class="miq-data-table-header"
                 scope="col"
               >
                 <div
-                  class="cds--table-sort__description"
-                  id="table-sort-4"
+                  class="cds--table-header-label"
                 >
-                  Click to sort rows by Units header in ascending order
+                  Units
+                  <div
+                    class="cds--table-header-label--decorator-inner"
+                  />
                 </div>
-                <button
-                  aria-describedby="table-sort-4"
-                  class="miq-data-table-header cds--table-sort"
-                  type="button"
-                >
-                  <span
-                    class="cds--table-sort__flex"
-                  >
-                    <div
-                      class="cds--table-header-label"
-                    >
-                      Units
-                    </div>
-                    <svg
-                      aria-hidden="true"
-                      class="cds--table-sort__icon"
-                      fill="currentColor"
-                      focusable="false"
-                      height="20"
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 32 32"
-                      width="20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden="true"
-                      class="cds--table-sort__icon-unsorted"
-                      fill="currentColor"
-                      focusable="false"
-                      height="20"
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 32 32"
-                      width="20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                      />
-                      <path
-                        d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                      />
-                    </svg>
-                    <div
-                      class="cds--table-header-label--decorator-inner"
-                    />
-                  </span>
-                </button>
               </th>
             </tr>
           </thead>
@@ -581,256 +381,56 @@ exports[`Tenant Quota Form Component should render the manage quotas form for a 
           <thead>
             <tr>
               <th
-                aria-sort="none"
-                class="miq-data-table-header cds--table-sort__header"
+                class="miq-data-table-header"
                 scope="col"
               >
                 <div
-                  class="cds--table-sort__description"
-                  id="table-sort-8"
+                  class="cds--table-header-label"
                 >
-                  Click to sort rows by Enforced header in ascending order
+                  Enforced
+                  <div
+                    class="cds--table-header-label--decorator-inner"
+                  />
                 </div>
-                <button
-                  aria-describedby="table-sort-8"
-                  class="miq-data-table-header cds--table-sort"
-                  type="button"
-                >
-                  <span
-                    class="cds--table-sort__flex"
-                  >
-                    <div
-                      class="cds--table-header-label"
-                    >
-                      Enforced
-                    </div>
-                    <svg
-                      aria-hidden="true"
-                      class="cds--table-sort__icon"
-                      fill="currentColor"
-                      focusable="false"
-                      height="20"
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 32 32"
-                      width="20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden="true"
-                      class="cds--table-sort__icon-unsorted"
-                      fill="currentColor"
-                      focusable="false"
-                      height="20"
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 32 32"
-                      width="20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                      />
-                      <path
-                        d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                      />
-                    </svg>
-                    <div
-                      class="cds--table-header-label--decorator-inner"
-                    />
-                  </span>
-                </button>
               </th>
               <th
-                aria-sort="none"
-                class="miq-data-table-header cds--table-sort__header"
+                class="miq-data-table-header"
                 scope="col"
               >
                 <div
-                  class="cds--table-sort__description"
-                  id="table-sort-9"
+                  class="cds--table-header-label"
                 >
-                  Click to sort rows by Description header in ascending order
+                  Description
+                  <div
+                    class="cds--table-header-label--decorator-inner"
+                  />
                 </div>
-                <button
-                  aria-describedby="table-sort-9"
-                  class="miq-data-table-header cds--table-sort"
-                  type="button"
-                >
-                  <span
-                    class="cds--table-sort__flex"
-                  >
-                    <div
-                      class="cds--table-header-label"
-                    >
-                      Description
-                    </div>
-                    <svg
-                      aria-hidden="true"
-                      class="cds--table-sort__icon"
-                      fill="currentColor"
-                      focusable="false"
-                      height="20"
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 32 32"
-                      width="20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden="true"
-                      class="cds--table-sort__icon-unsorted"
-                      fill="currentColor"
-                      focusable="false"
-                      height="20"
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 32 32"
-                      width="20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                      />
-                      <path
-                        d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                      />
-                    </svg>
-                    <div
-                      class="cds--table-header-label--decorator-inner"
-                    />
-                  </span>
-                </button>
               </th>
               <th
-                aria-sort="none"
-                class="miq-data-table-header cds--table-sort__header"
+                class="miq-data-table-header"
                 scope="col"
               >
                 <div
-                  class="cds--table-sort__description"
-                  id="table-sort-10"
+                  class="cds--table-header-label"
                 >
-                  Click to sort rows by Value header in ascending order
+                  Value
+                  <div
+                    class="cds--table-header-label--decorator-inner"
+                  />
                 </div>
-                <button
-                  aria-describedby="table-sort-10"
-                  class="miq-data-table-header cds--table-sort"
-                  type="button"
-                >
-                  <span
-                    class="cds--table-sort__flex"
-                  >
-                    <div
-                      class="cds--table-header-label"
-                    >
-                      Value
-                    </div>
-                    <svg
-                      aria-hidden="true"
-                      class="cds--table-sort__icon"
-                      fill="currentColor"
-                      focusable="false"
-                      height="20"
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 32 32"
-                      width="20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden="true"
-                      class="cds--table-sort__icon-unsorted"
-                      fill="currentColor"
-                      focusable="false"
-                      height="20"
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 32 32"
-                      width="20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                      />
-                      <path
-                        d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                      />
-                    </svg>
-                    <div
-                      class="cds--table-header-label--decorator-inner"
-                    />
-                  </span>
-                </button>
               </th>
               <th
-                aria-sort="none"
-                class="miq-data-table-header cds--table-sort__header"
+                class="miq-data-table-header"
                 scope="col"
               >
                 <div
-                  class="cds--table-sort__description"
-                  id="table-sort-11"
+                  class="cds--table-header-label"
                 >
-                  Click to sort rows by Units header in ascending order
+                  Units
+                  <div
+                    class="cds--table-header-label--decorator-inner"
+                  />
                 </div>
-                <button
-                  aria-describedby="table-sort-11"
-                  class="miq-data-table-header cds--table-sort"
-                  type="button"
-                >
-                  <span
-                    class="cds--table-sort__flex"
-                  >
-                    <div
-                      class="cds--table-header-label"
-                    >
-                      Units
-                    </div>
-                    <svg
-                      aria-hidden="true"
-                      class="cds--table-sort__icon"
-                      fill="currentColor"
-                      focusable="false"
-                      height="20"
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 32 32"
-                      width="20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                      />
-                    </svg>
-                    <svg
-                      aria-hidden="true"
-                      class="cds--table-sort__icon-unsorted"
-                      fill="currentColor"
-                      focusable="false"
-                      height="20"
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 32 32"
-                      width="20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                      />
-                      <path
-                        d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                      />
-                    </svg>
-                    <div
-                      class="cds--table-header-label--decorator-inner"
-                    />
-                  </span>
-                </button>
               </th>
             </tr>
           </thead>

--- a/app/javascript/spec/workflow-credential-mapping-form/__snapshots__/workflow-credential-mapping-form.spec.js.snap
+++ b/app/javascript/spec/workflow-credential-mapping-form/__snapshots__/workflow-credential-mapping-form.spec.js.snap
@@ -23,256 +23,56 @@ exports[`Workflow Credential Form Component should render mapping credentials to
             <thead>
               <tr>
                 <th
-                  aria-sort="none"
-                  class="miq-data-table-header cds--table-sort__header"
+                  class="miq-data-table-header"
                   scope="col"
                 >
                   <div
-                    class="cds--table-sort__description"
-                    id="table-sort-1"
+                    class="cds--table-header-label"
                   >
-                    Click to sort rows by Credentials Identifier header in ascending order
+                    Credentials Identifier
+                    <div
+                      class="cds--table-header-label--decorator-inner"
+                    />
                   </div>
-                  <button
-                    aria-describedby="table-sort-1"
-                    class="miq-data-table-header cds--table-sort"
-                    type="button"
-                  >
-                    <span
-                      class="cds--table-sort__flex"
-                    >
-                      <div
-                        class="cds--table-header-label"
-                      >
-                        Credentials Identifier
-                      </div>
-                      <svg
-                        aria-hidden="true"
-                        class="cds--table-sort__icon"
-                        fill="currentColor"
-                        focusable="false"
-                        height="20"
-                        preserveAspectRatio="xMidYMid meet"
-                        viewBox="0 0 32 32"
-                        width="20"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                        />
-                      </svg>
-                      <svg
-                        aria-hidden="true"
-                        class="cds--table-sort__icon-unsorted"
-                        fill="currentColor"
-                        focusable="false"
-                        height="20"
-                        preserveAspectRatio="xMidYMid meet"
-                        viewBox="0 0 32 32"
-                        width="20"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                        />
-                        <path
-                          d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                        />
-                      </svg>
-                      <div
-                        class="cds--table-header-label--decorator-inner"
-                      />
-                    </span>
-                  </button>
                 </th>
                 <th
-                  aria-sort="none"
-                  class="miq-data-table-header cds--table-sort__header"
+                  class="miq-data-table-header"
                   scope="col"
                 >
                   <div
-                    class="cds--table-sort__description"
-                    id="table-sort-2"
+                    class="cds--table-header-label"
                   >
-                    Click to sort rows by Credential Record header in ascending order
+                    Credential Record
+                    <div
+                      class="cds--table-header-label--decorator-inner"
+                    />
                   </div>
-                  <button
-                    aria-describedby="table-sort-2"
-                    class="miq-data-table-header cds--table-sort"
-                    type="button"
-                  >
-                    <span
-                      class="cds--table-sort__flex"
-                    >
-                      <div
-                        class="cds--table-header-label"
-                      >
-                        Credential Record
-                      </div>
-                      <svg
-                        aria-hidden="true"
-                        class="cds--table-sort__icon"
-                        fill="currentColor"
-                        focusable="false"
-                        height="20"
-                        preserveAspectRatio="xMidYMid meet"
-                        viewBox="0 0 32 32"
-                        width="20"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                        />
-                      </svg>
-                      <svg
-                        aria-hidden="true"
-                        class="cds--table-sort__icon-unsorted"
-                        fill="currentColor"
-                        focusable="false"
-                        height="20"
-                        preserveAspectRatio="xMidYMid meet"
-                        viewBox="0 0 32 32"
-                        width="20"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                        />
-                        <path
-                          d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                        />
-                      </svg>
-                      <div
-                        class="cds--table-header-label--decorator-inner"
-                      />
-                    </span>
-                  </button>
                 </th>
                 <th
-                  aria-sort="none"
-                  class="miq-data-table-header cds--table-sort__header"
+                  class="miq-data-table-header"
                   scope="col"
                 >
                   <div
-                    class="cds--table-sort__description"
-                    id="table-sort-3"
+                    class="cds--table-header-label"
                   >
-                    Click to sort rows by Credential Field header in ascending order
+                    Credential Field
+                    <div
+                      class="cds--table-header-label--decorator-inner"
+                    />
                   </div>
-                  <button
-                    aria-describedby="table-sort-3"
-                    class="miq-data-table-header cds--table-sort"
-                    type="button"
-                  >
-                    <span
-                      class="cds--table-sort__flex"
-                    >
-                      <div
-                        class="cds--table-header-label"
-                      >
-                        Credential Field
-                      </div>
-                      <svg
-                        aria-hidden="true"
-                        class="cds--table-sort__icon"
-                        fill="currentColor"
-                        focusable="false"
-                        height="20"
-                        preserveAspectRatio="xMidYMid meet"
-                        viewBox="0 0 32 32"
-                        width="20"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                        />
-                      </svg>
-                      <svg
-                        aria-hidden="true"
-                        class="cds--table-sort__icon-unsorted"
-                        fill="currentColor"
-                        focusable="false"
-                        height="20"
-                        preserveAspectRatio="xMidYMid meet"
-                        viewBox="0 0 32 32"
-                        width="20"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                        />
-                        <path
-                          d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                        />
-                      </svg>
-                      <div
-                        class="cds--table-header-label--decorator-inner"
-                      />
-                    </span>
-                  </button>
                 </th>
                 <th
-                  aria-sort="none"
-                  class="miq-data-table-header cds--table-sort__header"
+                  class="miq-data-table-header"
                   scope="col"
                 >
                   <div
-                    class="cds--table-sort__description"
-                    id="table-sort-4"
+                    class="cds--table-header-label"
                   >
-                    Click to sort rows by Delete header in ascending order
+                    Delete
+                    <div
+                      class="cds--table-header-label--decorator-inner"
+                    />
                   </div>
-                  <button
-                    aria-describedby="table-sort-4"
-                    class="miq-data-table-header cds--table-sort"
-                    type="button"
-                  >
-                    <span
-                      class="cds--table-sort__flex"
-                    >
-                      <div
-                        class="cds--table-header-label"
-                      >
-                        Delete
-                      </div>
-                      <svg
-                        aria-hidden="true"
-                        class="cds--table-sort__icon"
-                        fill="currentColor"
-                        focusable="false"
-                        height="20"
-                        preserveAspectRatio="xMidYMid meet"
-                        viewBox="0 0 32 32"
-                        width="20"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M16 4 6 14 7.41 15.41 15 7.83 15 28 17 28 17 7.83 24.59 15.41 26 14 16 4z"
-                        />
-                      </svg>
-                      <svg
-                        aria-hidden="true"
-                        class="cds--table-sort__icon-unsorted"
-                        fill="currentColor"
-                        focusable="false"
-                        height="20"
-                        preserveAspectRatio="xMidYMid meet"
-                        viewBox="0 0 32 32"
-                        width="20"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M27.6 20.6 24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22z"
-                        />
-                        <path
-                          d="M9 4 3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
-                        />
-                      </svg>
-                      <div
-                        class="cds--table-header-label--decorator-inner"
-                      />
-                    </span>
-                  </button>
                 </th>
               </tr>
             </thead>


### PR DESCRIPTION
Fixes a bug where even when a table is set not to be sortable, the sorting arrow icons still appear in the headers.

Before:
<img width="825" height="186" alt="Screenshot 2026-06-17 at 11 07 15 AM" src="https://github.com/user-attachments/assets/f39353be-501b-4a8e-86d5-e26c549dd2ed" />

After:
<img width="822" height="165" alt="Screenshot 2026-06-17 at 11 09 34 AM" src="https://github.com/user-attachments/assets/23f1ac20-765e-4b29-8efd-006b719052c1" />
