### PR TITLE
Convert Application Settings Region Zone Tabs to React

### DIFF
--- a/app/helpers/ops_helper.rb
+++ b/app/helpers/ops_helper.rb
@@ -13,6 +13,7 @@ module OpsHelper
   include SettingsTagsHelper
   include SettingsUsersHelper
   include SettingsZoneHelper
+  include SettingsZoneTabsHelper
   include SettingsRbacTagHelper
   include GroupRbacDetailsHelper
   include RoleRbacDetailsHelper

--- a/app/helpers/settings_zone_tabs_helper.rb
+++ b/app/helpers/settings_zone_tabs_helper.rb
@@ -1,0 +1,30 @@
+module SettingsZoneTabsHelper
+  def settings_zone_tab_configuration
+    [:evm_servers, :smartproxy_affinity, :advanced]
+  end
+
+  def settings_zone_tab_content(key_name, &)
+    if settings_zone_tabs_types[key_name]
+      tag.div(:id => "settings_#{key_name}", :class => 'tab_content', &)
+    end
+  end
+
+  def settings_zone_tab_index(active_tab)
+    tab_name = active_tab
+    return 0 unless tab_name
+
+    # Convert "settings_evm_servers" to :evm_servers
+    key = tab_name&.sub('settings_', '')&.to_sym
+    settings_zone_tab_configuration.index(key) || 0
+  end
+
+  private
+
+  def settings_zone_tabs_types
+    {
+      :evm_servers         => _('Zone'),
+      :smartproxy_affinity => _('SmartProxy Affinity'),
+      :advanced            => _('Advanced'),
+    }
+  end
+end

--- a/app/javascript/components/miq-custom-tab/helper.js
+++ b/app/javascript/components/miq-custom-tab/helper.js
@@ -46,6 +46,13 @@ const settingsTags = {
   map_tags: __('Map Tags'),
 };
 
+/** Tab labels used for settings zone tabs. */
+const settingsZone = {
+  evm_servers: __('Zone'),
+  smartproxy_affinity: __('SmartProxy Affinity'),
+  advanced: __('Advanced'),
+};
+
 /** Function to select the tab labels. */
 export const labelConfig = (type) => {
   const configMap = {
@@ -55,6 +62,7 @@ export const labelConfig = (type) => {
     CATALOG_REQUEST_INFO: requestInfo,
     SETTINGS: settings,
     SETTINGS_TAGS: settingsTags,
+    SETTINGS_ZONE: settingsZone,
   };
 
   return configMap[type];

--- a/app/javascript/components/miq-custom-tab/index.jsx
+++ b/app/javascript/components/miq-custom-tab/index.jsx
@@ -34,6 +34,7 @@ const MiqCustomTab = ({
         : `/ops/change_tab?tab_id=settings_${name}`,
     },
     { type: 'SETTINGS_TAGS', url: `/ops/change_tab?parent_tab_id=settings_tags&tab_id=settings_${name}` },
+    { type: 'SETTINGS_ZONE', url: `/ops/change_tab?tab_id=settings_${name}` },
   ];
 
   const configuration = (name) => tabConfigurations(name).find((item) => item.type === type);

--- a/app/views/ops/_all_tabs.html.haml
+++ b/app/views/ops/_all_tabs.html.haml
@@ -4,19 +4,17 @@
   - when :settings_tree
     - if selected?(x_node, "z")
       = render :partial => "layouts/flash_msg"
-      %ul.nav.nav-tabs{'role' => 'tablist'}
-        = miq_tab_header("settings_evm_servers", @sb[:active_tab]) do
-          = _("Zone")
-        = miq_tab_header("settings_smartproxy_affinity", @sb[:active_tab]) do
-          = _("SmartProxy Affinity")
-        = miq_tab_header("settings_advanced", @sb[:active_tab]) do
-          = _("Advanced")
-      .tab-content
-        = miq_tab_content("settings_smartproxy_affinity", @sb[:active_tab]) do
-          = render :partial => "settings_smartproxy_affinity_tab"
-        = miq_tab_content("settings_evm_servers", @sb[:active_tab]) do
+      #settings-zone-tabs-wrapper
+        = react('MiqCustomTab', {:containerId => 'settings-zone-tabs',
+                                 :tabLabels   => settings_zone_tab_configuration,
+                                 :type        => 'SETTINGS_ZONE',
+                                 :activeTab   => settings_zone_tab_index(@sb[:active_tab])})
+      #settings-zone-tabs
+        = settings_zone_tab_content(:evm_servers) do
           = render :partial => "settings_evm_servers_tab"
-        = miq_tab_content("settings_advanced", @sb[:active_tab]) do
+        = settings_zone_tab_content(:smartproxy_affinity) do
+          = render :partial => "settings_smartproxy_affinity_tab"
+        = settings_zone_tab_content(:advanced) do
           = render :partial => "settings_advanced_tab"
     - elsif selected?(x_node, "svr")
       = render :partial => "layouts/flash_msg"

--- a/cypress/e2e/ui/Settings/Application-Settings/settings-zone-tabs.cy.js
+++ b/cypress/e2e/ui/Settings/Application-Settings/settings-zone-tabs.cy.js
@@ -1,0 +1,45 @@
+describe('Settings Zone Tabs', () => {
+  beforeEach(() => {
+    cy.login();
+    cy.menu('Settings', 'Application Settings');
+    cy.accordion('Settings');
+    cy.selectAccordionItem([/^ManageIQ Region:/, 'Zones']);
+  });
+
+  it('displays zone tabs when zone node is selected', () => {
+    // Click on a zone node (default zone should exist)
+    cy.get('li.list-group-item').contains(/^Zone:/).first().click();
+
+    // Verify the MiqCustomTab component is rendered
+    cy.get('#settings-zone-tabs-wrapper').should('be.visible');
+    cy.get('.miq_custom_tabs').should('be.visible');
+
+    // Verify all three tabs are present
+    cy.contains('button', 'Zone').should('be.visible');
+    cy.contains('button', 'SmartProxy Affinity').should('be.visible');
+    cy.contains('button', 'Advanced').should('be.visible');
+  });
+
+  it('switches between zone tabs', () => {
+    // Click on a zone node
+    cy.get('li.list-group-item').contains(/^Zone:/).first().click();
+
+    // Verify explorer title shows zone
+    cy.expect_explorer_title('Zone');
+
+    // Click on SmartProxy Affinity tab - re-query each time to handle re-renders
+    cy.contains('button', 'SmartProxy Affinity').should('be.visible');
+    cy.contains('button', 'SmartProxy Affinity').click();
+
+    // Click on Advanced tab - re-query each time to handle re-renders
+    cy.contains('button', 'Advanced').should('be.visible');
+    cy.contains('button', 'Advanced').click();
+
+    // Click back to Zone tab - re-query each time to handle re-renders
+    cy.contains('button', 'Zone').should('be.visible');
+    cy.contains('button', 'Zone').click();
+
+    // Verify we're still on the zone page
+    cy.expect_explorer_title('Zone');
+  });
+});


### PR DESCRIPTION
Convert [Settings > Application Settings > Region > Zones > Zone] Tabs from HAML to React

Before:
<img width="1920" height="989" alt="image" src="https://github.com/user-attachments/assets/ed189148-63de-4478-b8f7-de8993875846" />

After:
<img width="1920" height="992" alt="image" src="https://github.com/user-attachments/assets/b8104646-b500-4a1e-8aaa-e86ee2202a8e" />

@miq-bot add-label enhancement
@miq-bot add-reviewer @GilbertCherrie 