### PR TITLE
Add Provider button loading state fix  while option changes in dropdown

### DIFF
--- a/app/javascript/components/provider-form/index.jsx
+++ b/app/javascript/components/provider-form/index.jsx
@@ -26,7 +26,7 @@ const ProviderForm = ({
 }) => {
   const edit = !!providerId;
   const [{ fields, initialValues }, setState] = useState({});
-
+  const [providerOptionloading, setProviderOptionloading] = useState(false);
   const submitLabel = edit ? __('Save') : __('Add');
 
   const commonFields = [
@@ -81,10 +81,15 @@ const ProviderForm = ({
     isRequired: true,
     options: providers,
     onChange: (value) => {
-      if (value !== '-1') {
-        loadProviderFields(value).then((fields) => setState(({ fields: [firstField] }) => ({
-          fields: [firstField, ...fields],
-        })));
+     if (value !== '-1') {
+      setProviderOptionloading(true);
+      loadProviderFields(value)
+        .then((fields) =>
+          setState(({ fields: [firstField] }) => ({
+            fields: [firstField, ...fields],
+          }))
+        )
+        .finally(() => setProviderOptionloading(false));
       } else {
         setState(({ fields: [firstField] }) => ({
           fields: [firstField,
@@ -151,6 +156,8 @@ const ProviderForm = ({
   };
 
   const onSubmit = ({ type, ..._data }, { getState }) => {
+    // safety check to stop user from submitting during loading of provider
+    if (providerOptionloading) return;
     if (type !== '-1') {
       miqSparkleOn();
 
@@ -210,6 +217,7 @@ const ProviderForm = ({
             canReset={edit}
             clearOnUnmount
             keepDirtyOnReinitilize
+            isProviderOptionLoading={providerOptionloading}
           />
         </EditingContext.Provider>
       ) }

--- a/app/javascript/forms/data-driven-form.jsx
+++ b/app/javascript/forms/data-driven-form.jsx
@@ -48,6 +48,7 @@ const MiqFormRenderer = ({
   schema: { fields, ...schema },
   initialize,
   onSubmit,
+  isProviderOptionLoading,
   ...props
 }) => {
   const { current: MiqFormTemplate } = useRef((props) => (
@@ -69,6 +70,12 @@ const MiqFormRenderer = ({
       schema={{ fields: [...fields, { component: 'spy-field', name: 'spy-field', initialize }], ...schema }}
       onSubmit={submitWrapper(onSubmit)}
       onReset={() => add_flash(__('All changes have been reset'), 'warn')}
+      validate={(_) => {
+        // simulating a rule to disable button when select dropdown option changes.
+        if (isProviderOptionLoading) {
+          return { _error: 'Loading...' };
+        }
+      }}
       {...props}
     />
   );
@@ -99,7 +106,7 @@ MiqFormRenderer.defaultProps = {
   schema: {
     fields: [],
   },
-  disableSubmit: ['pristine', 'invalid'],
+  disableSubmit: ['pristine', 'invalid', 'submitting'],
   canReset: false,
   showFormControls: true,
   initialize: undefined,


### PR DESCRIPTION
### Summary
Fixes an issue on `/ems_infra/new#/` where the "Add Provider" button becomes enabled prematurely when the provider option is changed.

### Problem
When the user changes the provider type from the dropdown, an API call is triggered to fetch provider-specific data. However, during this fetch:
- The "Add Provider" button becomes enabled before the API call completes
- If the user clicks the button at this time, the UI gets stuck in a loading state

### Steps to Reproduce
1. Navigate to the **Add Provider** page (`/ems_infra/new#/`)
2. Change the provider using the provider dropdown
3. Immediately click the **Add Provider** button before the API call completes
4. Observe that the screen gets stuck in a loading state

<img width="490" height="263" alt="image" src="https://github.com/user-attachments/assets/a14b63a7-7575-44e9-97a4-f0cac7b49c5a" />
<img width="469" height="262" alt="image" src="https://github.com/user-attachments/assets/c2f5eef8-ac54-4a37-8c30-07ad464e3b04" />


### Root Cause
The button state was not correctly tied to the API loading state, leading to unintended user interaction while data was still being fetched.

### Fix
The "Add Provider" button is now disabled while the API call is in progress and only enabled once the response is received.

### Testing
- Changed provider options multiple times
- Verified that the button remains disabled during API calls
- Confirmed that the loading state no longer gets stuck

Before: 
<img width="499" height="266" alt="Add Provider Issue1" src="https://github.com/user-attachments/assets/e4f4d4fd-8215-4381-be0a-625cf046c2ed" />

After:
<img width="754" height="256" alt="Add Provider fix" src="https://github.com/user-attachments/assets/b0b2b766-dbd0-4fda-b9bd-9d9d690d510a" />


