### PR TITLE
Remove uuid package resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,7 +175,6 @@
     "path-to-regexp": "~8.4.0",
     "patternfly": "~3.59.5",
     "serialize-javascript": "~7.0.5",
-    "tar": "~7.5.13",
-    "uuid": "~14.0.0"
+    "tar": "~7.5.13"
   }
 }


### PR DESCRIPTION
Removing `uuid` resolution added in https://github.com/ManageIQ/manageiq-ui-classic/pull/10021, as the reasons for adding it have been addressed:

- `cypress` no longer depends on uuid as of v15 - [cypress#33765](https://github.com/cypress-io/cypress/pull/33765)
- `webpack-dev-server` has been removed since it's not currently used - https://github.com/ManageIQ/manageiq-ui-classic/pull/10104
- Jest has been upgraded to v30 - https://github.com/ManageIQ/manageiq-ui-classic/pull/10115
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
