### PR TITLE
Convert Diagnostic Tabs to React

### DIFF
--- a/app/helpers/diagnostics_tabs_helper.rb
+++ b/app/helpers/diagnostics_tabs_helper.rb
@@ -1,0 +1,130 @@
+module DiagnosticsTabsHelper
+  # Zone-level diagnostics tabs configuration
+  def diagnostics_zone_tab_configuration
+    [:roles_servers, :servers_roles, :server_list, :cu_repair]
+  end
+
+  def diagnostics_zone_tab_content(key_name, active_tab: nil, &)
+    if diagnostics_zone_tabs_types[key_name]
+      # Add 'active' class if this is the currently active tab
+      css_class = 'tab-pane tab_content'
+      css_class += ' active' if active_tab == "diagnostics_#{key_name}"
+      tag.div(:id => "diagnostics_zone_#{key_name}", :class => css_class, &)
+    end
+  end
+
+  def diagnostics_zone_tab_index(active_tab)
+    return 0 unless active_tab
+
+    # Convert "diagnostics_roles_servers" to :roles_servers
+    key = active_tab.sub('diagnostics_', '').to_sym
+
+    tabs = diagnostics_zone_tab_configuration
+    tabs.index(key) || 0
+  end
+
+  # Server-level diagnostics tabs configuration
+  def diagnostics_server_tab_configuration(selected_server_id, my_server_id, server_started, is_podified)
+    tabs = []
+
+    # Summary and Workers tabs shown if it's my server or server is started
+    if selected_server_id == my_server_id || server_started
+      tabs << :summary
+      tabs << :workers
+    end
+
+    # Log tabs only shown for my server and not podified
+    if selected_server_id == my_server_id && !is_podified
+      tabs << :evm_log
+      tabs << :audit_log
+      tabs << :production_log
+    end
+
+    tabs
+  end
+
+  def diagnostics_server_tab_content(key_name, active_tab: nil, &)
+    if diagnostics_server_tabs_types[key_name]
+      # Add 'active' class if this is the currently active tab
+      css_class = 'tab-pane tab_content'
+      css_class += ' active' if active_tab == "diagnostics_#{key_name}"
+      tag.div(:id => "diagnostics_#{key_name}", :class => css_class, &)
+    end
+  end
+
+  def diagnostics_server_tab_index(active_tab, selected_server_id, my_server_id, server_started, is_podified)
+    return 0 unless active_tab
+
+    # Convert "diagnostics_summary" to :summary
+    key = active_tab.sub('diagnostics_', '').to_sym
+
+    tabs = diagnostics_server_tab_configuration(selected_server_id, my_server_id, server_started, is_podified)
+    tabs.index(key) || 0
+  end
+
+  # Root-level diagnostics tabs configuration
+  def diagnostics_root_tab_configuration(is_super_admin)
+    tabs = [:zones]
+
+    if is_super_admin
+      tabs << :roles_servers
+      tabs << :servers_roles
+    end
+
+    tabs << :server_list
+
+    tabs << :database if is_super_admin
+
+    tabs
+  end
+
+  def diagnostics_root_tab_content(key_name, active_tab: nil, &)
+    if diagnostics_root_tabs_types[key_name]
+      # Add 'active' class if this is the currently active tab
+      css_class = 'tab-pane tab_content'
+      css_class += ' active' if active_tab == "diagnostics_#{key_name}"
+      tag.div(:id => "diagnostics_#{key_name}", :class => css_class, &)
+    end
+  end
+
+  def diagnostics_root_tab_index(active_tab, is_super_admin)
+    return 0 unless active_tab
+
+    # Convert "diagnostics_zones" to :zones
+    key = active_tab.sub('diagnostics_', '').to_sym
+
+    tabs = diagnostics_root_tab_configuration(is_super_admin)
+    tabs.index(key) || 0
+  end
+
+  private
+
+  def diagnostics_zone_tabs_types
+    {
+      :roles_servers => _('Roles by Servers'),
+      :servers_roles => _('Servers by Roles'),
+      :server_list   => _('Servers'),
+      :cu_repair     => _('C & U Gap Collection'),
+    }
+  end
+
+  def diagnostics_server_tabs_types
+    {
+      :summary        => _('Summary'),
+      :workers        => _('Workers'),
+      :evm_log        => _('%{product} Log') % {:product => Vmdb::Appliance.PRODUCT_NAME},
+      :audit_log      => _('Audit Log'),
+      :production_log => _('Production Log'),
+    }
+  end
+
+  def diagnostics_root_tabs_types
+    {
+      :zones         => _('Zones'),
+      :roles_servers => _('Roles by Servers'),
+      :servers_roles => _('Servers by Roles'),
+      :server_list   => _('Servers'),
+      :database      => _('Database'),
+    }
+  end
+end

--- a/app/helpers/ops_helper.rb
+++ b/app/helpers/ops_helper.rb
@@ -15,6 +15,7 @@ module OpsHelper
   include SettingsZoneHelper
   include SettingsZoneTabsHelper
   include SettingsServerTabsHelper
+  include DiagnosticsTabsHelper
   include SettingsRbacTagHelper
   include GroupRbacDetailsHelper
   include RoleRbacDetailsHelper

--- a/app/javascript/components/miq-custom-tab/helper.js
+++ b/app/javascript/components/miq-custom-tab/helper.js
@@ -62,6 +62,32 @@ const settingsServer = {
   advanced: __('Advanced'),
 };
 
+/** Tab labels used for diagnostics zone tabs. */
+const diagnosticsZone = {
+  roles_servers: __('Roles by Servers'),
+  servers_roles: __('Servers by Roles'),
+  server_list: __('Servers'),
+  cu_repair: __('C & U Gap Collection'),
+};
+
+/** Tab labels used for diagnostics server tabs. */
+const diagnosticsServer = {
+  summary: __('Summary'),
+  workers: __('Workers'),
+  evm_log: __('ManageIQ Log'),
+  audit_log: __('Audit Log'),
+  production_log: process.env.NODE_ENV === 'production' ? __('Production Log') : __('Development Log'),
+};
+
+/** Tab labels used for diagnostics root tabs. */
+const diagnosticsRoot = {
+  zones: __('Zones'),
+  roles_servers: __('Roles by Servers'),
+  servers_roles: __('Servers by Roles'),
+  server_list: __('Servers'),
+  database: __('Database'),
+};
+
 /** Function to select the tab labels. */
 export const labelConfig = (type) => {
   const configMap = {
@@ -73,6 +99,9 @@ export const labelConfig = (type) => {
     SETTINGS_TAGS: settingsTags,
     SETTINGS_ZONE: settingsZone,
     SETTINGS_SERVER: settingsServer,
+    DIAGNOSTICS_ZONE: diagnosticsZone,
+    DIAGNOSTICS_SERVER: diagnosticsServer,
+    DIAGNOSTICS_ROOT: diagnosticsRoot,
   };
 
   return configMap[type];

--- a/app/javascript/components/miq-custom-tab/index.jsx
+++ b/app/javascript/components/miq-custom-tab/index.jsx
@@ -36,6 +36,9 @@ const MiqCustomTab = ({
     { type: 'SETTINGS_TAGS', url: `/ops/change_tab?parent_tab_id=settings_tags&tab_id=settings_${name}` },
     { type: 'SETTINGS_ZONE', url: `/ops/change_tab?tab_id=settings_${name}` },
     { type: 'SETTINGS_SERVER', url: `/ops/change_tab?tab_id=settings_${name}` },
+    { type: 'DIAGNOSTICS_ZONE', url: `/ops/change_tab?tab_id=diagnostics_${name}` },
+    { type: 'DIAGNOSTICS_SERVER', url: `/ops/change_tab?tab_id=diagnostics_${name}` },
+    { type: 'DIAGNOSTICS_ROOT', url: `/ops/change_tab?tab_id=diagnostics_${name}` },
   ];
 
   const configuration = (name) => tabConfigurations(name).find((item) => item.type === type);
@@ -66,10 +69,26 @@ const MiqCustomTab = ({
   /** Function to load the tab contents which are already available within the page. */
   const staticContents = (name, config) => {
     const tabs = containerTabs();
+    // Construct the expected tab ID based on the type
+    let expectedId;
+    if (type === 'DIAGNOSTICS_ZONE') {
+      expectedId = `diagnostics_zone_${name}`;
+    } else if (type === 'DIAGNOSTICS_SERVER') {
+      expectedId = `diagnostics_${name}`;
+    } else if (type === 'DIAGNOSTICS_ROOT') {
+      expectedId = `diagnostics_${name}`;
+    } else if (type === 'SETTINGS_ZONE') {
+      expectedId = `settings_${name}`;
+    } else if (type === 'SETTINGS_SERVER') {
+      expectedId = `settings_${name}`;
+    } else {
+      expectedId = name;
+    }
+
     tabs.forEach((child) => {
       if (child.parentElement.id === containerId) {
         child.classList.remove('active');
-        if (child.id === `${name}`) {
+        if (child.id === expectedId) {
           child.classList.add('active');
           if (config.js) config.js();
         }

--- a/app/views/ops/_all_tabs.html.haml
+++ b/app/views/ops/_all_tabs.html.haml
@@ -85,82 +85,59 @@
     -# Diagnostics
   - when :diagnostics_tree
     - if x_node.split("-")[0] == "z"
-      %ul.nav.nav-tabs{'role' => 'tablist'}
-        = miq_tab_header("diagnostics_roles_servers", @sb[:active_tab]) do
-          = _("Roles by Servers")
-        = miq_tab_header("diagnostics_servers_roles", @sb[:active_tab]) do
-          = _("Servers by Roles")
-        = miq_tab_header("diagnostics_server_list", @sb[:active_tab]) do
-          = _("Servers")
-        = miq_tab_header("diagnostics_cu_repair", @sb[:active_tab]) do
-          = _("C & U Gap Collection")
-      .tab-content
-        = miq_tab_content("diagnostics_roles_servers", @sb[:active_tab]) do
+      #diagnostics-zone-tabs-wrapper
+        = react('MiqCustomTab', {:containerId => 'diagnostics-zone-tabs',
+                                 :tabLabels   => diagnostics_zone_tab_configuration,
+                                 :type        => 'DIAGNOSTICS_ZONE',
+                                 :activeTab   => diagnostics_zone_tab_index(@sb[:active_tab])})
+      .miq_custom_tabs_container#diagnostics-zone-tabs
+        = diagnostics_zone_tab_content(:roles_servers, :active_tab => @sb[:active_tab]) do
           = render :partial => "diagnostics_roles_servers_tab"
-        = miq_tab_content("diagnostics_servers_roles", @sb[:active_tab]) do
+        = diagnostics_zone_tab_content(:servers_roles, :active_tab => @sb[:active_tab]) do
           = render :partial => "diagnostics_servers_roles_tab"
-        = miq_tab_content("diagnostics_server_list", @sb[:active_tab]) do
+        = diagnostics_zone_tab_content(:server_list, :active_tab => @sb[:active_tab]) do
           = render :partial => "diagnostics_server_list_tab"
-        = miq_tab_content("diagnostics_cu_repair", @sb[:active_tab]) do
+        = diagnostics_zone_tab_content(:cu_repair, :active_tab => @sb[:active_tab]) do
           = render :partial => "diagnostics_cu_repair_tab"
     - elsif x_node.split("-")[0] == "svr"
-      %ul.nav.nav-tabs{'role' => 'tablist'}
+      #diagnostics-server-tabs-wrapper
+        = react('MiqCustomTab', {:containerId => 'diagnostics-server-tabs',
+                                 :tabLabels   => diagnostics_server_tab_configuration(@sb[:selected_server_id], my_server.id, @selected_server.started?, MiqEnvironment::Command.is_podified?),
+                                 :type        => 'DIAGNOSTICS_SERVER',
+                                 :activeTab   => diagnostics_server_tab_index(@sb[:active_tab], @sb[:selected_server_id], my_server.id, @selected_server.started?, MiqEnvironment::Command.is_podified?)})
+      .miq_custom_tabs_container#diagnostics-server-tabs
         - if @sb[:selected_server_id] == my_server.id || @selected_server.started?
-          = miq_tab_header("diagnostics_summary", @sb[:active_tab]) do
-            = _("Summary")
-          = miq_tab_header("diagnostics_workers", @sb[:active_tab]) do
-            = _("Workers")
-        - if @sb[:selected_server_id] == my_server.id && !MiqEnvironment::Command.is_podified?
-          = miq_tab_header("diagnostics_evm_log", @sb[:active_tab]) do
-            = _("%{product} Log") % {:product => Vmdb::Appliance.PRODUCT_NAME}
-          = miq_tab_header("diagnostics_audit_log", @sb[:active_tab]) do
-            = _("Audit Log")
-          = miq_tab_header("diagnostics_production_log", @sb[:active_tab]) do
-            = _(@sb[:rails_log])
-            = _("Log")
-      .tab-content
-        - if @sb[:selected_server_id] == my_server.id || @selected_server.started?
-          = miq_tab_content("diagnostics_summary", @sb[:active_tab]) do
+          = diagnostics_server_tab_content(:summary, :active_tab => @sb[:active_tab]) do
             = render :partial => "diagnostics_summary_tab"
-          = miq_tab_content("diagnostics_workers", @sb[:active_tab]) do
+          = diagnostics_server_tab_content(:workers, :active_tab => @sb[:active_tab]) do
             = render :partial => "diagnostics_workers_tab"
         - if @sb[:selected_server_id] == my_server.id && !MiqEnvironment::Command.is_podified?
-          = miq_tab_content("diagnostics_evm_log", @sb[:active_tab]) do
+          = diagnostics_server_tab_content(:evm_log, :active_tab => @sb[:active_tab]) do
             = render :partial => "diagnostics_evm_log_tab"
-          = miq_tab_content("diagnostics_audit_log", @sb[:active_tab]) do
+          = diagnostics_server_tab_content(:audit_log, :active_tab => @sb[:active_tab]) do
             = render :partial => "diagnostics_audit_log_tab"
-          = miq_tab_content("diagnostics_production_log", @sb[:active_tab]) do
+          = diagnostics_server_tab_content(:production_log, :active_tab => @sb[:active_tab]) do
             = render :partial => "diagnostics_production_log_tab"
     - else
-      %ul.nav.nav-tabs{'role' => 'tablist'}
-        = miq_tab_header("diagnostics_zones", @sb[:active_tab]) do
-          = _("Zones")
-        - if super_admin_user?
-          = miq_tab_header("diagnostics_roles_servers", @sb[:active_tab]) do
-            = _("Roles by Servers")
-          = miq_tab_header("diagnostics_servers_roles", @sb[:active_tab]) do
-            = _("Servers by Roles")
-        = miq_tab_header("diagnostics_server_list", @sb[:active_tab]) do
-          = _("Servers")
-        - if super_admin_user?
-          = miq_tab_header("diagnostics_database", @sb[:active_tab]) do
-            = _("Database")
-      .tab-content
-        = miq_tab_content("diagnostics_zones", @sb[:active_tab]) do
+      #diagnostics-root-tabs-wrapper
+        = react('MiqCustomTab', {:containerId => 'diagnostics-root-tabs',
+                                 :tabLabels   => diagnostics_root_tab_configuration(super_admin_user?),
+                                 :type        => 'DIAGNOSTICS_ROOT',
+                                 :activeTab   => diagnostics_root_tab_index(@sb[:active_tab], super_admin_user?)})
+      .miq_custom_tabs_container#diagnostics-root-tabs
+        = diagnostics_root_tab_content(:zones, :active_tab => @sb[:active_tab]) do
           = render :partial => "diagnostics_zones_tab"
         - if super_admin_user?
-          = miq_tab_content("diagnostics_roles_servers", @sb[:active_tab]) do
+          = diagnostics_root_tab_content(:roles_servers, :active_tab => @sb[:active_tab]) do
             = render :partial => "diagnostics_roles_servers_tab"
-          = miq_tab_content("diagnostics_servers_roles", @sb[:active_tab]) do
+          = diagnostics_root_tab_content(:servers_roles, :active_tab => @sb[:active_tab]) do
             = render :partial => "diagnostics_servers_roles_tab"
-        = miq_tab_content("diagnostics_server_list", @sb[:active_tab]) do
+        = diagnostics_root_tab_content(:server_list, :active_tab => @sb[:active_tab]) do
           = render :partial => "diagnostics_server_list_tab"
         - if super_admin_user?
-          = miq_tab_content("diagnostics_database", @sb[:active_tab]) do
+          = diagnostics_root_tab_content(:database, :active_tab => @sb[:active_tab]) do
             - if @sb[:active_tab] == "diagnostics_database"
               = render :partial => "diagnostics_database_tab"
   - when :rbac_tree
     #rbac_details
       = render :partial => "rbac_details_tab"
-:javascript
-  miq_tabs_init("#ops_tabs", "/ops/change_tab");

--- a/cypress/e2e/ui/Settings/Application-Settings/diagnostics.cy.js
+++ b/cypress/e2e/ui/Settings/Application-Settings/diagnostics.cy.js
@@ -1,41 +1,140 @@
 // Menu options
-const SETTINGS_MENU_OPTION = 'Settings';
-const APP_SETTINGS_MENU_OPTION = 'Application Settings';
+const SETTINGS_LABEL = 'Settings';
+const APP_SETTINGS_OPTION = 'Application Settings';
 
 // Accordion items
-const DIAGNOSTICS_ACCORDION_ITEM = 'Diagnostics';
+const DIAGNOSTICS_ACCORDION = 'Diagnostics';
 const MANAGEIQ_REGION_ACCORDION_ITEM = /^ManageIQ Region:/;
 
-// Tab names
-const DATABASE_TAB_LABEL = 'Database';
+// Tree node patterns
+const ZONE_NODE_PATTERN = /^Zone:/;
+const SERVER_NODE_PATTERN = /^Server:/;
 
-describe('Settings > Application Settings > Diagnostics', () => {
+// Tab wrapper IDs
+const DIAGNOSTICS_ROOT_TABS_WRAPPER = '#diagnostics-root-tabs-wrapper';
+const DIAGNOSTICS_ZONE_TABS_WRAPPER = '#diagnostics-zone-tabs-wrapper';
+const DIAGNOSTICS_SERVER_TABS_WRAPPER = '#diagnostics-server-tabs-wrapper';
+const MIQ_CUSTOM_TABS_CLASS = '.miq_custom_tabs';
+
+// Tab button labels
+const ZONES_TAB = 'Zones';
+const ROLES_BY_SERVERS_TAB = 'Roles by Servers';
+const SERVERS_BY_ROLES_TAB = 'Servers by Roles';
+const SERVERS_TAB = 'Servers';
+const CU_GAP_COLLECTION_TAB = 'C & U Gap Collection';
+const SUMMARY_TAB = 'Summary';
+const WORKERS_TAB = 'Workers';
+
+describe('Diagnostics Root Tabs', () => {
   beforeEach(() => {
     cy.login();
-    cy.menu(SETTINGS_MENU_OPTION, APP_SETTINGS_MENU_OPTION);
-    cy.accordion(DIAGNOSTICS_ACCORDION_ITEM);
+    cy.menu(SETTINGS_LABEL, APP_SETTINGS_OPTION);
+    cy.accordion(DIAGNOSTICS_ACCORDION);
+    cy.selectAccordionItem([MANAGEIQ_REGION_ACCORDION_ITEM]);
   });
 
-  describe('ManageIQ Region', () => {
-    beforeEach(() => {
-      cy.selectAccordionItem([MANAGEIQ_REGION_ACCORDION_ITEM]);
-    });
+  it('displays root-level diagnostics tabs and switches between them', () => {
+    // Verify tabs wrapper and container are visible
+    cy.get(DIAGNOSTICS_ROOT_TABS_WRAPPER).should('be.visible');
+    cy.get(MIQ_CUSTOM_TABS_CLASS).should('be.visible');
 
-    it('should navigate to the Database tab', () => {
-      // Intercept the API call when clicking on the Database tab
-      cy.interceptApi({
-        alias: 'getDatabaseTabInfo',
-        urlPattern: '/ops/change_tab?tab_id=diagnostics_database',
-        triggerFn: () => cy.tabs({ tabLabel: DATABASE_TAB_LABEL }),
-      });
+    cy.contains('button', SERVERS_TAB).should('be.visible');
+    cy.contains('button', SERVERS_TAB).click();
 
-      // Verify the Database tab content is loaded
-      cy.get(`@getDatabaseTabInfo`).then((getCall) => {
-        expect(getCall.state).to.equal('Complete');
-      });
+    cy.contains('button', ZONES_TAB).should('be.visible');
+    cy.contains('button', ZONES_TAB).click();
+  });
 
-      // Verify we're on the Database tab
-      cy.get('.tab-content').contains(DATABASE_TAB_LABEL).should('be.visible');
-    });
+  it('resets to default tab when navigating away and back', () => {
+    cy.contains('button', SERVERS_TAB).should('be.visible');
+    cy.contains('button', SERVERS_TAB).click();
+
+    cy.get('#diagnostics_accord.in li.list-group-item').contains(ZONE_NODE_PATTERN).first().click();
+
+    cy.accordion(DIAGNOSTICS_ACCORDION);
+    cy.selectAccordionItem([MANAGEIQ_REGION_ACCORDION_ITEM]);
+
+    cy.get(DIAGNOSTICS_ROOT_TABS_WRAPPER).should('be.visible');
+    cy.get(MIQ_CUSTOM_TABS_CLASS).should('be.visible');
+  });
+});
+
+describe('Diagnostics Zone Tabs', () => {
+  beforeEach(() => {
+    cy.login();
+    cy.menu(SETTINGS_LABEL, APP_SETTINGS_OPTION);
+    cy.accordion(DIAGNOSTICS_ACCORDION);
+    cy.selectAccordionItem([MANAGEIQ_REGION_ACCORDION_ITEM]);
+  });
+
+  it('displays zone-level diagnostics tabs and switches between them', () => {
+    cy.get('#diagnostics_accord.in li.list-group-item').contains(ZONE_NODE_PATTERN).first().click();
+
+    // Wait for page to fully load and tabs to be ready
+    cy.get(DIAGNOSTICS_ZONE_TABS_WRAPPER).should('be.visible');
+    cy.get(MIQ_CUSTOM_TABS_CLASS).should('be.visible');
+
+    // Wait for any error modals to clear and tabs to be interactive
+    cy.wait(1000);
+
+    cy.contains('button', SERVERS_BY_ROLES_TAB).should('be.visible').and('not.be.disabled');
+    cy.contains('button', SERVERS_BY_ROLES_TAB).click({ force: true });
+
+    cy.contains('button', CU_GAP_COLLECTION_TAB).should('be.visible').and('not.be.disabled');
+    cy.contains('button', CU_GAP_COLLECTION_TAB).click({ force: true });
+
+    cy.contains('button', ROLES_BY_SERVERS_TAB).should('be.visible').and('not.be.disabled');
+    cy.contains('button', ROLES_BY_SERVERS_TAB).click({ force: true });
+  });
+
+  it('resets to default tab when navigating away and back to zone', () => {
+    cy.get('#diagnostics_accord.in li.list-group-item').contains(ZONE_NODE_PATTERN).first().click();
+
+    cy.contains('button', SERVERS_TAB).should('be.visible');
+    cy.contains('button', SERVERS_TAB).click();
+
+    cy.get('#diagnostics_accord.in li.list-group-item').contains(SERVER_NODE_PATTERN).first().click();
+
+    cy.get('#diagnostics_accord.in li.list-group-item').contains(ZONE_NODE_PATTERN).first().click();
+
+    cy.get(DIAGNOSTICS_ZONE_TABS_WRAPPER).should('be.visible');
+    cy.get(MIQ_CUSTOM_TABS_CLASS).should('be.visible');
+  });
+});
+
+describe('Diagnostics Server Tabs', () => {
+  beforeEach(() => {
+    cy.login();
+    cy.menu(SETTINGS_LABEL, APP_SETTINGS_OPTION);
+    cy.accordion(DIAGNOSTICS_ACCORDION);
+    cy.selectAccordionItem([MANAGEIQ_REGION_ACCORDION_ITEM]);
+  });
+
+  it('displays server-level diagnostics tabs and switches between them', () => {
+    cy.get('#diagnostics_accord.in li.list-group-item').contains(SERVER_NODE_PATTERN).first().click();
+
+    // Verify tabs wrapper and container are visible
+    cy.get(DIAGNOSTICS_SERVER_TABS_WRAPPER).should('be.visible');
+    cy.get(MIQ_CUSTOM_TABS_CLASS).should('be.visible');
+
+    cy.contains('button', WORKERS_TAB).should('be.visible');
+    cy.contains('button', WORKERS_TAB).click();
+
+    cy.contains('button', SUMMARY_TAB).should('be.visible');
+    cy.contains('button', SUMMARY_TAB).click();
+  });
+
+  it('resets to default tab when navigating away and back to server', () => {
+    cy.get('#diagnostics_accord.in li.list-group-item').contains(SERVER_NODE_PATTERN).first().click();
+
+    cy.contains('button', WORKERS_TAB).should('be.visible');
+    cy.contains('button', WORKERS_TAB).click();
+
+    cy.get('#diagnostics_accord.in li.list-group-item').contains(ZONE_NODE_PATTERN).first().click();
+
+    cy.get('#diagnostics_accord.in li.list-group-item').contains(SERVER_NODE_PATTERN).first().click();
+
+    cy.get(DIAGNOSTICS_SERVER_TABS_WRAPPER).should('be.visible');
+    cy.get(MIQ_CUSTOM_TABS_CLASS).should('be.visible');
   });
 });


### PR DESCRIPTION
Convert Diagnostic Tabs to React. Fixes #8729 

## Before: ##
Root
<img width="1728" height="997" alt="image" src="https://github.com/user-attachments/assets/4dda79ad-fd1d-411c-9e6b-c3b08c7dbbe5" />

Zone
<img width="1728" height="995" alt="image" src="https://github.com/user-attachments/assets/2230c5e8-2190-4f44-97b0-d1be5b04809d" />

Server
<img width="1728" height="999" alt="image" src="https://github.com/user-attachments/assets/e0d735b7-1a80-47a8-95ff-01a8b9754123" />

## After: ## 
Root
<img width="1728" height="989" alt="image" src="https://github.com/user-attachments/assets/ba7de8fe-731f-4fd8-9b76-c9215695c288" />

Zone
<img width="1728" height="993" alt="image" src="https://github.com/user-attachments/assets/758f8b41-4eb7-4787-91f3-f705211e8b3c" />

Server
<img width="1726" height="995" alt="image" src="https://github.com/user-attachments/assets/c924bca5-75b0-49a3-8597-9c1edd6dbbd5" />



@miq-bot add-label enhancement
@miq-bot add-reviewer @GilbertCherrie 
@miq-bot assign @GilbertCherrie 
