### PR TITLE
No Output Tab for EmbeddedTerraform, if OrchestrationStack record is not available

### DIFF
--- a/app/views/service/_svcs_show.html.haml
+++ b/app/views/service/_svcs_show.html.haml
@@ -5,8 +5,9 @@
         = _("Details")
       - if ["ServiceTerraformTemplate", "ServiceEmbeddedTerraform"].include?(@record.type)
         - stack = @record.try(:stack, "Provision")
-        = miq_tab_header("output") do
-          = _("Output")
+        - if stack
+          = miq_tab_header("output") do
+            = _("Output")
       - if @record.type == "ServiceAnsiblePlaybook"
         - provision_job = @record.try(:job, "Provision")
         - retirement_job = @record.try(:job, "Retirement")


### PR DESCRIPTION
When ServiceEmbeddedTerraform is retired, the corresponding OrchestrationStack record is deleted, which means we cannot fetch the Terraform stdout. Therefore, do not add an empty output to the UI.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
