### PR TITLE
Fix add automation manager page

### DIFF
--- a/app/views/ems_automation/show_list.html.haml
+++ b/app/views/ems_automation/show_list.html.haml
@@ -1,2 +1,7 @@
 #main_div
-  = render :partial => 'layouts/gtl'
+  - if ManageIQ::Providers::ExternalAutomationManager.any?
+    = render :partial => "layouts/gtl"
+  - else
+    = render :partial => 'layouts/empty',
+             :locals => {:add_message   => _("Add a new Automation Provider"),
+                         :documentation => Settings.docs.automation_manager}


### PR DESCRIPTION
Depends on: https://github.com/ManageIQ/manageiq/pull/23593

Fixes the empty page for automation managers.

Before:
<img width="1187" height="364" alt="Screenshot 2026-06-24 at 1 13 39 PM" src="https://github.com/user-attachments/assets/6e9da53f-e277-40a6-bd72-6fa01fda1177" />

After:
<img width="1184" height="547" alt="Screenshot 2026-06-24 at 1 14 11 PM" src="https://github.com/user-attachments/assets/9ab33974-97c5-4869-b64b-c1ff5bd26524" />
