### PR TITLE
Convert Automate Class Tabs to React

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -20,18 +20,11 @@ class MiqAeClassController < ApplicationController
 
   def change_tab
     assert_privileges("miq_ae_class")
-    # resetting flash array so messages don't get displayed when tab is changed
-    @flash_array = []
     @explorer = true
+    @flash_array = nil
     @record = @ae_class = MiqAeClass.find(x_node.split('-').last)
     @sb[:active_tab] = params[:tab_id]
-    render :update do |page|
-      page << javascript_prologue
-      page.replace("flash_msg_div", :partial => "layouts/flash_msg")
-      page << "miqScrollTop();" if @flash_array.present?
-      page << javascript_reload_toolbars
-      page << "miqSparkle(false);"
-    end
+    replace_right_cell
   end
 
   AE_X_BUTTON_ALLOWED_ACTIONS = {
@@ -306,7 +299,8 @@ class MiqAeClassController < ApplicationController
     reload_trees_by_presenter(presenter, trees)
 
     if @sb[:action] == "miq_ae_field_seq"
-      presenter.update(:class_fields_div, r[:partial => "fields_seq_form"])
+      @sb[:active_tab] = 'schema'
+      presenter.update(:main_div, r[:partial => 'all_tabs'])
 
     elsif @sb[:action] == "miq_ae_domain_priority_edit"
       @domain_order = ordered_domains_for_priority_edit_screen
@@ -2874,7 +2868,7 @@ class MiqAeClassController < ApplicationController
   end
 
   def get_class_node_info(node_id)
-    @sb[:active_tab] = "instances" if !@in_a_form && !params[:button] && !params[:pressed]
+    @sb[:active_tab] = "instances" if !@in_a_form && !params[:button] && !params[:pressed] && params[:action] != "change_tab"
     begin
       @record = @ae_class = MiqAeClass.find(node_id)
     rescue ActiveRecord::RecordNotFound

--- a/app/helpers/miq_ae_class_helper.rb
+++ b/app/helpers/miq_ae_class_helper.rb
@@ -1,8 +1,28 @@
 module MiqAeClassHelper
+  AE_CLASS_TAB_IDS = %w[instances methods props schema].freeze
+
   DATASTORE_TYPES = {
     :list => 'ns_list', :details => 'ns_details', :instances => 'class_instances', :methods => 'class_methods',
     :domain => 'domain_overrides', :schema => 'class_fields', :fields => 'instant_fields'
   }.freeze
+
+  def ae_class_tab_configuration
+    [:instances, :methods, :props, :schema]
+  end
+
+  def ae_class_tab_content(key_name, active_tab: nil, &)
+    if ae_class_tab_configuration.include?(key_name)
+      css_class = 'tab-pane tab_content'
+      css_class += ' active' if active_tab == key_name.to_s
+      tag.div(:id => key_name, :class => css_class, &)
+    end
+  end
+
+  def ae_class_tab_index(active_tab)
+    return 0 unless active_tab
+
+    AE_CLASS_TAB_IDS.index(active_tab) || 0
+  end
 
   def editable_domain?(record)
     record.editable?

--- a/app/javascript/components/miq-custom-tab/helper.js
+++ b/app/javascript/components/miq-custom-tab/helper.js
@@ -103,6 +103,13 @@ const report = {
   saved_reports: __('Saved Reports'),
 };
 
+const aeClass = {
+  instances: __('Instances'),
+  methods: __('Methods'),
+  props: __('Properties'),
+  schema: __('Schema'),
+};
+
 /** Function to select the tab labels. */
 export const labelConfig = (type) => {
   const configMap = {
@@ -119,6 +126,7 @@ export const labelConfig = (type) => {
     DIAGNOSTICS_ROOT: diagnosticsRoot,
     SERVICE: service,
     REPORT: report,
+    AE_CLASS: aeClass,
   };
 
   return configMap[type];

--- a/app/javascript/components/miq-custom-tab/index.jsx
+++ b/app/javascript/components/miq-custom-tab/index.jsx
@@ -6,7 +6,7 @@ import { miqCustomTabActions } from '../../miq-redux/actions/miq-custom-tab-acti
 import { labelConfig, tabText } from './helper';
 
 const MiqCustomTab = ({
-  containerId, tabLabels, type, activeTab, subtab, tabLength,
+  containerId, tabLabels, type, activeTab, subtab, tabLength, disableInactive,
 }) => {
   const dispatch = useDispatch();
   const [data, setData] = useState({ loading: false });
@@ -41,6 +41,7 @@ const MiqCustomTab = ({
     { type: 'DIAGNOSTICS_ROOT', url: `/ops/change_tab?tab_id=diagnostics_${name}` },
     { type: 'SERVICE' },
     { type: 'REPORT', url: `/report/rep_change_tab?tab_id=${name}` },
+    { type: 'AE_CLASS', url: `/miq_ae_class/change_tab?tab_id=${name}` },
   ];
 
   const configuration = (name) => tabConfigurations(name).find((item) => item.type === type);
@@ -122,8 +123,12 @@ const MiqCustomTab = ({
   };
 
   /** Function to render the tabs from the tabLabels props */
-  const renderTabs = () => tabLabels.map((label) => (
-    <Tab key={`tab${label}`} onClick={() => onTabSelect(label)}>
+  const renderTabs = () => tabLabels.map((label, index) => (
+    <Tab
+      key={`tab${label}`}
+      disabled={disableInactive && index !== activeTab}
+      onClick={() => (disableInactive && index === activeTab ? undefined : onTabSelect(label))}
+    >
       {tabText(selectedLabels, label)}
     </Tab>
   ));
@@ -162,10 +167,12 @@ MiqCustomTab.propTypes = {
   activeTab: PropTypes.number,
   subtab: PropTypes.number,
   tabLength: PropTypes.number,
+  disableInactive: PropTypes.bool,
 };
 
 MiqCustomTab.defaultProps = {
   activeTab: undefined,
   subtab: undefined,
   tabLength: undefined,
+  disableInactive: false,
 };

--- a/app/javascript/spec/miq-custom-tab/__snapshots__/miq-custom-tab.spec.js.snap
+++ b/app/javascript/spec/miq-custom-tab/__snapshots__/miq-custom-tab.spec.js.snap
@@ -35,6 +35,7 @@ exports[`MiqCustomTab component should render tabs for catalog edit page 1`] = `
     >
       <button
         aria-controls="ccs-3-tabpanel-0"
+        aria-disabled="false"
         aria-selected="true"
         class="cds--tabs__nav-item cds--tabs__nav-link cds--tabs__nav-item--selected"
         id="ccs-3-tab-0"
@@ -57,6 +58,7 @@ exports[`MiqCustomTab component should render tabs for catalog edit page 1`] = `
         class="cds--tabs__nav-item--close--hidden"
       >
         <button
+          aria-disabled="false"
           aria-hidden="true"
           class="cds--visually-hidden cds--tabs__nav-item--close-icon--selected"
           tabindex="-1"
@@ -83,6 +85,7 @@ exports[`MiqCustomTab component should render tabs for catalog edit page 1`] = `
       </div>
       <button
         aria-controls="ccs-3-tabpanel-1"
+        aria-disabled="false"
         aria-selected="false"
         class="cds--tabs__nav-item cds--tabs__nav-link"
         id="ccs-3-tab-1"
@@ -105,6 +108,7 @@ exports[`MiqCustomTab component should render tabs for catalog edit page 1`] = `
         class="cds--tabs__nav-item--close--hidden"
       >
         <button
+          aria-disabled="false"
           aria-hidden="true"
           class="cds--visually-hidden"
           tabindex="-1"
@@ -131,6 +135,7 @@ exports[`MiqCustomTab component should render tabs for catalog edit page 1`] = `
       </div>
       <button
         aria-controls="ccs-3-tabpanel-2"
+        aria-disabled="false"
         aria-selected="false"
         class="cds--tabs__nav-item cds--tabs__nav-link"
         id="ccs-3-tab-2"
@@ -153,6 +158,7 @@ exports[`MiqCustomTab component should render tabs for catalog edit page 1`] = `
         class="cds--tabs__nav-item--close--hidden"
       >
         <button
+          aria-disabled="false"
           aria-hidden="true"
           class="cds--visually-hidden"
           tabindex="-1"
@@ -239,6 +245,7 @@ exports[`MiqCustomTab component should render tabs for catalog summary page 1`] 
     >
       <button
         aria-controls="ccs-1-tabpanel-0"
+        aria-disabled="false"
         aria-selected="true"
         class="cds--tabs__nav-item cds--tabs__nav-link cds--tabs__nav-item--selected"
         id="ccs-1-tab-0"
@@ -261,6 +268,7 @@ exports[`MiqCustomTab component should render tabs for catalog summary page 1`] 
         class="cds--tabs__nav-item--close--hidden"
       >
         <button
+          aria-disabled="false"
           aria-hidden="true"
           class="cds--visually-hidden cds--tabs__nav-item--close-icon--selected"
           tabindex="-1"
@@ -287,6 +295,7 @@ exports[`MiqCustomTab component should render tabs for catalog summary page 1`] 
       </div>
       <button
         aria-controls="ccs-1-tabpanel-1"
+        aria-disabled="false"
         aria-selected="false"
         class="cds--tabs__nav-item cds--tabs__nav-link"
         id="ccs-1-tab-1"
@@ -309,6 +318,7 @@ exports[`MiqCustomTab component should render tabs for catalog summary page 1`] 
         class="cds--tabs__nav-item--close--hidden"
       >
         <button
+          aria-disabled="false"
           aria-hidden="true"
           class="cds--visually-hidden"
           tabindex="-1"
@@ -335,6 +345,7 @@ exports[`MiqCustomTab component should render tabs for catalog summary page 1`] 
       </div>
       <button
         aria-controls="ccs-1-tabpanel-2"
+        aria-disabled="false"
         aria-selected="false"
         class="cds--tabs__nav-item cds--tabs__nav-link"
         id="ccs-1-tab-2"
@@ -357,6 +368,7 @@ exports[`MiqCustomTab component should render tabs for catalog summary page 1`] 
         class="cds--tabs__nav-item--close--hidden"
       >
         <button
+          aria-disabled="false"
           aria-hidden="true"
           class="cds--visually-hidden"
           tabindex="-1"
@@ -443,6 +455,7 @@ exports[`MiqCustomTab component should render tabs for request info page under c
     >
       <button
         aria-controls="ccs-2-tabpanel-0"
+        aria-disabled="false"
         aria-selected="true"
         class="cds--tabs__nav-item cds--tabs__nav-link cds--tabs__nav-item--selected"
         id="ccs-2-tab-0"
@@ -465,6 +478,7 @@ exports[`MiqCustomTab component should render tabs for request info page under c
         class="cds--tabs__nav-item--close--hidden"
       >
         <button
+          aria-disabled="false"
           aria-hidden="true"
           class="cds--visually-hidden cds--tabs__nav-item--close-icon--selected"
           tabindex="-1"
@@ -491,6 +505,7 @@ exports[`MiqCustomTab component should render tabs for request info page under c
       </div>
       <button
         aria-controls="ccs-2-tabpanel-1"
+        aria-disabled="false"
         aria-selected="false"
         class="cds--tabs__nav-item cds--tabs__nav-link"
         id="ccs-2-tab-1"
@@ -513,6 +528,7 @@ exports[`MiqCustomTab component should render tabs for request info page under c
         class="cds--tabs__nav-item--close--hidden"
       >
         <button
+          aria-disabled="false"
           aria-hidden="true"
           class="cds--visually-hidden"
           tabindex="-1"
@@ -539,6 +555,7 @@ exports[`MiqCustomTab component should render tabs for request info page under c
       </div>
       <button
         aria-controls="ccs-2-tabpanel-2"
+        aria-disabled="false"
         aria-selected="false"
         class="cds--tabs__nav-item cds--tabs__nav-link"
         id="ccs-2-tab-2"
@@ -561,6 +578,7 @@ exports[`MiqCustomTab component should render tabs for request info page under c
         class="cds--tabs__nav-item--close--hidden"
       >
         <button
+          aria-disabled="false"
           aria-hidden="true"
           class="cds--visually-hidden"
           tabindex="-1"
@@ -587,6 +605,7 @@ exports[`MiqCustomTab component should render tabs for request info page under c
       </div>
       <button
         aria-controls="ccs-2-tabpanel-3"
+        aria-disabled="false"
         aria-selected="false"
         class="cds--tabs__nav-item cds--tabs__nav-link"
         id="ccs-2-tab-3"
@@ -609,6 +628,7 @@ exports[`MiqCustomTab component should render tabs for request info page under c
         class="cds--tabs__nav-item--close--hidden"
       >
         <button
+          aria-disabled="false"
           aria-hidden="true"
           class="cds--visually-hidden"
           tabindex="-1"
@@ -635,6 +655,7 @@ exports[`MiqCustomTab component should render tabs for request info page under c
       </div>
       <button
         aria-controls="ccs-2-tabpanel-4"
+        aria-disabled="false"
         aria-selected="false"
         class="cds--tabs__nav-item cds--tabs__nav-link"
         id="ccs-2-tab-4"
@@ -657,6 +678,7 @@ exports[`MiqCustomTab component should render tabs for request info page under c
         class="cds--tabs__nav-item--close--hidden"
       >
         <button
+          aria-disabled="false"
           aria-hidden="true"
           class="cds--visually-hidden"
           tabindex="-1"
@@ -683,6 +705,7 @@ exports[`MiqCustomTab component should render tabs for request info page under c
       </div>
       <button
         aria-controls="ccs-2-tabpanel-5"
+        aria-disabled="false"
         aria-selected="false"
         class="cds--tabs__nav-item cds--tabs__nav-link"
         id="ccs-2-tab-5"
@@ -705,6 +728,7 @@ exports[`MiqCustomTab component should render tabs for request info page under c
         class="cds--tabs__nav-item--close--hidden"
       >
         <button
+          aria-disabled="false"
           aria-hidden="true"
           class="cds--visually-hidden"
           tabindex="-1"
@@ -731,6 +755,7 @@ exports[`MiqCustomTab component should render tabs for request info page under c
       </div>
       <button
         aria-controls="ccs-2-tabpanel-6"
+        aria-disabled="false"
         aria-selected="false"
         class="cds--tabs__nav-item cds--tabs__nav-link"
         id="ccs-2-tab-6"
@@ -753,6 +778,7 @@ exports[`MiqCustomTab component should render tabs for request info page under c
         class="cds--tabs__nav-item--close--hidden"
       >
         <button
+          aria-disabled="false"
           aria-hidden="true"
           class="cds--visually-hidden"
           tabindex="-1"

--- a/app/views/miq_ae_class/_all_tabs.html.haml
+++ b/app/views/miq_ae_class/_all_tabs.html.haml
@@ -4,24 +4,21 @@
   - nodes = x_node.split('-')
   - case nodes.first
   - when "aec"
-    %ul.nav.nav-tabs{'role' => 'tablist'}
-      = miq_tab_header("instances", @sb[:active_tab]) do
-        = _('Instances')
-      = miq_tab_header("methods", @sb[:active_tab]) do
-        = _('Methods')
-      = miq_tab_header("props", @sb[:active_tab]) do
-        = _('Properties')
-      = miq_tab_header("schema", @sb[:active_tab]) do
-        = _('Schema')
-    .tab-content
-      = miq_tab_content("instances", @sb[:active_tab]) do
+    #ae-class-tabs-wrapper
+      = react('MiqCustomTab', {:containerId     => 'ae-class-tabs',
+                               :tabLabels       => ae_class_tab_configuration,
+                               :type            => 'AE_CLASS',
+                               :activeTab       => ae_class_tab_index(@sb[:active_tab]),
+                               :disableInactive => @in_a_form || @angular_form})
+    .miq_custom_tabs_container#ae-class-tabs
+      = ae_class_tab_content(:instances, :active_tab => @sb[:active_tab]) do
         = render :partial => "class_instances"
-      = miq_tab_content("methods", @sb[:active_tab]) do
+      = ae_class_tab_content(:methods, :active_tab => @sb[:active_tab]) do
         #class_methods_div
           = render :partial => "class_methods"
-      = miq_tab_content("props", @sb[:active_tab]) do
+      = ae_class_tab_content(:props, :active_tab => @sb[:active_tab]) do
         = render :partial => "class_props"
-      = miq_tab_content("schema", @sb[:active_tab]) do
+      = ae_class_tab_content(:schema, :active_tab => @sb[:active_tab]) do
         = render :partial => "class_fields"
   - when "aei"
     = render :partial => "instance_fields"
@@ -39,12 +36,4 @@
     = render :partial => "ns_list"
 
 :javascript
-  // method takes hash that can have 4 keys: tabs div id, active_tab label,
-  // url to go to when tab is changed, and whether to check for abandon changes or not
-  miq_tabs_init("#ae_tabs", "/miq_ae_class/change_tab");
   if (ManageIQ.editor !== null) ManageIQ.editor.refresh();
-
--# disable any other tabs on screen when in edit
-- if @in_a_form || @angular_form
-  :javascript
-    miq_tabs_disable_inactive('#ae_tabs');

--- a/app/views/miq_ae_class/_class_fields.html.haml
+++ b/app/views/miq_ae_class/_class_fields.html.haml
@@ -1,6 +1,8 @@
 #class_fields_div
   - if x_node.split('-')[0] == "aec" || params[:pressed] || %w(field_select field_accept field_delete).include?(params[:action])
-    - if !@in_a_form_fields
+    - if @sb[:action] == 'miq_ae_field_seq'
+      = render :partial => 'fields_seq_form'
+    - elsif !@in_a_form_fields
       / Show Schema
       %h3= _('Schema')
       - if @ae_class.ae_fields.present?

--- a/app/views/miq_ae_class/_fields_seq_form.html.haml
+++ b/app/views/miq_ae_class/_fields_seq_form.html.haml
@@ -14,6 +14,3 @@
                         :button_action => 'fields_seq_field_changed',
                         :id            => 'seq'}
 
-:javascript
-  // disable any other tabs on screen when in edit
-  miq_tabs_disable_inactive('#ae_tabs');

--- a/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/class.cy.js
+++ b/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/class.cy.js
@@ -219,4 +219,67 @@ describe('Automation > Embedded Automate > Explorer', () => {
       cy.expect_flash(flashClassMap.info, 'empty');
     });
   });
+
+  describe('Class Tabs', () => {
+    beforeEach(() => {
+      // Creates a class to use across tab tests
+      cy.selectAccordionItem(['Datastore', 'TestDomain', 'TestNameSpace']);
+      cy.toolbar('Configuration', 'Add a New Class');
+      cy.getFormInputFieldByIdAndType({ inputId: 'name' }).type('TestClass');
+      cy.getFormInputFieldByIdAndType({ inputId: 'display_name' }).type('Test Class 0');
+      cy.getFormInputFieldByIdAndType({ inputId: 'description' }).type('This is a test class description');
+      cy.getFormButtonByTypeWithText({ buttonText: 'Add', buttonType: 'submit' }).click();
+      cy.expect_flash(flashClassMap.success, 'added');
+      cy.selectAccordionItem(['Datastore', 'TestDomain', 'TestNameSpace', /Test Class 0/]);
+    });
+
+    it('displays AE class tabs and switches between them with correct content', () => {
+      // Verify the tabs wrapper and tablist are rendered
+      cy.get('#ae-class-tabs-wrapper').should('be.visible');
+      cy.get('.miq_custom_tabs').should('be.visible');
+      cy.expect_explorer_title('Automate Class "Test Class 0"');
+
+      // Default tab is Instances
+      cy.get('#instances').should('be.visible');
+
+      // Switch to Methods tab and verify its content
+      cy.contains('button', 'Methods').should('be.visible').click();
+      cy.get('#methods').should('be.visible');
+      cy.contains('No methods found').should('be.visible');
+
+      // Switch to Properties tab and verify its content
+      cy.contains('button', 'Properties').should('be.visible').click();
+      cy.get('#props').should('be.visible');
+      cy.get('.label_header').contains('Name');
+      cy.get('.content_value').contains('TestClass');
+      cy.get('.label_header').contains('Description');
+      cy.get('.content_value').contains('This is a test class description');
+
+      // Switch to Schema tab and verify its content
+      cy.contains('button', 'Schema').should('be.visible').click();
+      cy.get('#schema').should('be.visible');
+      cy.contains('No schema found').should('be.visible');
+
+      // Switch back to Instances tab
+      cy.contains('button', 'Instances').should('be.visible').click();
+      cy.get('#instances').should('be.visible');
+    });
+
+    it('resets to default tab when navigating away and back to the class', () => {
+      // Switch to a non-default tab
+      cy.contains('button', 'Properties').should('be.visible').click();
+      cy.get('#props').should('be.visible');
+
+      // Navigate away to the namespace node
+      cy.selectAccordionItem(['Datastore', 'TestDomain', 'TestNameSpace']);
+
+      // Navigate back to the class
+      cy.selectAccordionItem(['Datastore', 'TestDomain', 'TestNameSpace', /Test Class 0/]);
+
+      // Tabs wrapper should be visible and default (Instances) tab content shown
+      cy.get('#ae-class-tabs-wrapper').should('be.visible');
+      cy.get('.miq_custom_tabs').should('be.visible');
+      cy.get('#instances').should('be.visible');
+    });
+  });
 });

--- a/spec/views/miq_ae_class/_fields_seq_form.html.haml_spec.rb
+++ b/spec/views/miq_ae_class/_fields_seq_form.html.haml_spec.rb
@@ -6,8 +6,9 @@ describe "miq_ae_class/_fields_seq_form.html.haml" do
            })
   end
 
-  it "Check links in the list view", :js => true do
+  it "renders the schema sequencing form" do
     render :template => "miq_ae_class/_fields_seq_form"
-    expect(response).to have_text("miq_tabs_disable_inactive('#ae_tabs')")
+    expect(rendered).to have_text("Class Schema Sequencing")
+    expect(rendered).to have_selector("select#seq_fields")
   end
 end


### PR DESCRIPTION
Fixes #8729 
Convert the Embedded Automate Class Tabs to React. 

Before:
<img width="1728" height="995" alt="image" src="https://github.com/user-attachments/assets/a7183985-934f-44b9-a2b4-4459692d9531" />

After:
<img width="1728" height="997" alt="image" src="https://github.com/user-attachments/assets/1b2593aa-e27e-426d-9f4a-398a7a2ef421" />


@miq-bot add-label enhancement
@miq-bot add-reviewer @GilbertCherrie
@miq-bot assign @GilbertCherrie