### PR TITLE
Convert Services Tabs to React

### DIFF
--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -1,5 +1,6 @@
 module ServiceHelper
   include TextualSummary
+  include ServiceTabsHelper
 
   def child_service_summary(child_services)
     rows = []

--- a/app/helpers/service_tabs_helper.rb
+++ b/app/helpers/service_tabs_helper.rb
@@ -1,0 +1,31 @@
+module ServiceTabsHelper
+  def service_tab_configuration(record_type, has_stack, has_retirement_job, has_job)
+    tabs = [:details]
+    tabs << :output if %w[ServiceTerraformTemplate ServiceEmbeddedTerraform].include?(record_type) && has_stack
+    if record_type == "ServiceAnsiblePlaybook"
+      tabs << :provisioning
+      tabs << :retirement if has_retirement_job
+    end
+    tabs << :tower_job if %w[ServiceAnsibleTower ServiceAwx].include?(record_type) && has_job
+    tabs
+  end
+
+  def service_tab_content(key_name, &)
+    if service_tabs_types[key_name]
+      class_name = key_name == :details ? 'tab_content active' : 'tab_content'
+      tag.div(:id => key_name, :class => class_name, &)
+    end
+  end
+
+  private
+
+  def service_tabs_types
+    {
+      :details      => _('Details'),
+      :output       => _('Output'),
+      :provisioning => _('Provisioning'),
+      :retirement   => _('Retirement'),
+      :tower_job    => _('Job'),
+    }
+  end
+end

--- a/app/javascript/components/miq-custom-tab/helper.js
+++ b/app/javascript/components/miq-custom-tab/helper.js
@@ -88,6 +88,15 @@ const diagnosticsRoot = {
   database: __('Database'),
 };
 
+/** Tab labels used for service show tabs. */
+const service = {
+  details: __('Details'),
+  output: __('Output'),
+  provisioning: __('Provisioning'),
+  retirement: __('Retirement'),
+  tower_job: __('Job'),
+};
+
 /** Function to select the tab labels. */
 export const labelConfig = (type) => {
   const configMap = {
@@ -102,6 +111,7 @@ export const labelConfig = (type) => {
     DIAGNOSTICS_ZONE: diagnosticsZone,
     DIAGNOSTICS_SERVER: diagnosticsServer,
     DIAGNOSTICS_ROOT: diagnosticsRoot,
+    SERVICE: service,
   };
 
   return configMap[type];

--- a/app/javascript/components/miq-custom-tab/index.jsx
+++ b/app/javascript/components/miq-custom-tab/index.jsx
@@ -39,6 +39,7 @@ const MiqCustomTab = ({
     { type: 'DIAGNOSTICS_ZONE', url: `/ops/change_tab?tab_id=diagnostics_${name}` },
     { type: 'DIAGNOSTICS_SERVER', url: `/ops/change_tab?tab_id=diagnostics_${name}` },
     { type: 'DIAGNOSTICS_ROOT', url: `/ops/change_tab?tab_id=diagnostics_${name}` },
+    { type: 'SERVICE' },
   ];
 
   const configuration = (name) => tabConfigurations(name).find((item) => item.type === type);

--- a/app/stylesheet/miq-custom-tab.scss
+++ b/app/stylesheet/miq-custom-tab.scss
@@ -12,6 +12,7 @@
     width: 100%;
     flex-direction: column;
     display: none;
+    margin-top: 1rem;
   }
 
   .active {

--- a/app/views/service/_svcs_show.html.haml
+++ b/app/views/service/_svcs_show.html.haml
@@ -1,61 +1,48 @@
+:ruby
+  record_type    = @record.type
+  stack          = %w[ServiceTerraformTemplate ServiceEmbeddedTerraform].include?(record_type) ? @record.try(:stack, "Provision") : nil
+  provision_job  = record_type == "ServiceAnsiblePlaybook" ? @record.try(:job, "Provision")  : nil
+  retirement_job = record_type == "ServiceAnsiblePlaybook" ? @record.try(:job, "Retirement") : nil
+  job            = %w[ServiceAnsibleTower ServiceAwx].include?(record_type) ? @record.try(:job) : nil
+  current_userid = User.current_user&.userid
+  tab_labels     = service_tab_configuration(record_type, stack, retirement_job, job)
+
 #service_details
-  #services_tab
-    %ul.nav.nav-tabs{'role' => 'tablist'}
-      = miq_tab_header("details") do
-        = _("Details")
-      - if ["ServiceTerraformTemplate", "ServiceEmbeddedTerraform"].include?(@record.type)
-        - stack = @record.try(:stack, "Provision")
-        - if stack
-          = miq_tab_header("output") do
-            = _("Output")
-      - if @record.type == "ServiceAnsiblePlaybook"
-        - provision_job = @record.try(:job, "Provision")
-        - retirement_job = @record.try(:job, "Retirement")
-        = miq_tab_header("provisioning") do
-          = _("Provisioning")
-        - if retirement_job
-          = miq_tab_header("retirement") do
-            = _("Retirement")
-      -if @record.type == "ServiceAnsibleTower" || @record.type == "ServiceAwx"
-        - job = @record.try(:job)
-        = miq_tab_header("tower_job") do
-          = _("Job")
-    .tab-content
-      = miq_tab_content("details", 'default', :class => 'cm-tab') do
-        = render :partial => "layouts/textual_groups_generic"
-        - child_services = @record.direct_service_children.select(&:display)
-        - unless child_services.blank?
-          .row
-            .col-md-12.col-lg-6
-              = child_service_summary(child_services)
+  #services-tabs-wrapper
+    = react('MiqCustomTab', {:containerId => 'services-tabs',
+                             :tabLabels   => tab_labels.map(&:to_s),
+                             :type        => 'SERVICE'})
+  .miq_custom_tabs_container#services-tabs
+    = service_tab_content(:details) do
+      = render :partial => "layouts/textual_groups_generic"
+      - child_services = @record.direct_service_children.select(&:display)
+      - if child_services.present?
         .row
-          .col-md-12
-            %h3
-              = _('VMs')
-            - if @view
-              = render :partial => "layouts/gtl", :locals => {:view => @view, :no_flash_div => true}
-      
-      - if ["ServiceTerraformTemplate", "ServiceEmbeddedTerraform"].include?(@record.type)
-        = miq_tab_content("output", 'default', :class => 'cm-tab') do
-          - if stack
-            = react('ServiceDetailStdout', { :taskid => stack.raw_stdout_via_worker(User.current_user&.userid, 'html')});
+          .col-md-12.col-lg-6
+            = child_service_summary(child_services)
+      .row
+        .col-md-12
+          %h3
+            = _('VMs')
+          - if @view
+            = render :partial => "layouts/gtl", :locals => {:view => @view, :no_flash_div => true}
 
-      - if @record.type == "ServiceAnsibleTower" || @record.type == "ServiceAwx"
-        = miq_tab_content("tower_job", 'default', :class => 'cm-tab') do
-          = render :partial => "layouts/textual_groups_tabs", :locals => {:textual_group_list => textual_tower_job_group_list, :tab_id => "tower_job"}
-          - if job && job.respond_to?(:raw_stdout_via_worker)
-            = react('ServiceDetailStdout', { :taskid => @record.job.raw_stdout_via_worker(User.current_user&.userid, 'html')})
+    - if stack
+      = service_tab_content(:output) do
+        = react('ServiceDetailStdout', {:taskid => stack.raw_stdout_via_worker(current_userid, 'html')})
 
-      - if @record.type == "ServiceAnsiblePlaybook"
-        = miq_tab_content("provisioning", 'default', :class => 'cm-tab') do
-          = render :partial => "layouts/textual_groups_tabs", :locals => {:textual_group_list => textual_provisioning_group_list, :tab_id => "provisioning"}
-          - if provision_job
-            = react('ServiceDetailStdout', { :taskid => provision_job.raw_stdout_via_worker(User.current_user&.userid, 'html')});
+    - if provision_job
+      = service_tab_content(:provisioning) do
+        = render :partial => "layouts/textual_groups_tabs", :locals => {:textual_group_list => textual_provisioning_group_list, :tab_id => "provisioning"}
+        = react('ServiceDetailStdout', {:taskid => provision_job.raw_stdout_via_worker(current_userid, 'html')})
 
-        - if retirement_job
-          = miq_tab_content("retirement", 'default', :class => 'cm-tab') do
-            = render :partial => "layouts/textual_groups_tabs", :locals => {:textual_group_list => textual_retirement_group_list, :tab_id => "retirement"}
-            = react('ServiceDetailStdout', { :taskid => retirement_job.raw_stdout_via_worker(User.current_user&.userid, 'html')})
+    - if retirement_job
+      = service_tab_content(:retirement) do
+        = render :partial => "layouts/textual_groups_tabs", :locals => {:textual_group_list => textual_retirement_group_list, :tab_id => "retirement"}
+        = react('ServiceDetailStdout', {:taskid => retirement_job.raw_stdout_via_worker(current_userid, 'html')})
 
-:javascript
-  miq_tabs_init('#services_tab');
+    - if job
+      = service_tab_content(:tower_job) do
+        = render :partial => "layouts/textual_groups_tabs", :locals => {:textual_group_list => textual_tower_job_group_list, :tab_id => "tower_job"}
+        - if job.respond_to?(:raw_stdout_via_worker)
+          = react('ServiceDetailStdout', {:taskid => job.raw_stdout_via_worker(current_userid, 'html')})

--- a/cypress/e2e/ui/Services/My-Services/service_tabs.cy.js
+++ b/cypress/e2e/ui/Services/My-Services/service_tabs.cy.js
@@ -1,0 +1,242 @@
+// Menu options
+const SERVICES_MENU    = 'Services';
+const MY_SERVICES_MENU = 'My Services';
+
+// Tab label text (matches SERVICE labelConfig in helper.js)
+const TAB_DETAILS      = 'Details';
+const TAB_PROVISIONING = 'Provisioning';
+const TAB_RETIREMENT   = 'Retirement';
+const TAB_JOB          = 'Job';
+
+// DOM selectors emitted by _svcs_show.html.haml
+const TABS_WRAPPER  = '#services-tabs-wrapper';
+const TABS_PANEL    = '.miq_custom_tabs';
+const DETAILS_PANEL = '#details';
+
+function visitMyServices() {
+  cy.menu(SERVICES_MENU, MY_SERVICES_MENU);
+}
+
+function clickServiceRow(name) {
+  cy.clickTableRowByText({ text: name, columnIndex: 1 });
+}
+
+// Generic Service — only Details tab
+describe('My Services — Generic Service Tabs', () => {
+  const SERVICE_NAME = 'cy-generic-service';
+
+  beforeEach(() => {
+    cy.appFactories([
+      ['create', 'service', { name: SERVICE_NAME, display: true }],
+    ]);
+    cy.login();
+    visitMyServices();
+    clickServiceRow(SERVICE_NAME);
+  });
+
+  afterEach(() => {
+    cy.appDbState('restore');
+  });
+
+  it('renders tabs wrapper and Details panel by default', () => {
+    cy.get(TABS_WRAPPER).should('be.visible');
+    cy.get(TABS_PANEL).should('be.visible');
+
+    cy.contains('button', TAB_DETAILS).should('be.visible');
+    cy.get(DETAILS_PANEL).should('be.visible');
+  });
+
+  it('Details panel stays active after explicitly clicking the Details tab', () => {
+    cy.tabs({ tabLabel: TAB_DETAILS });
+    cy.get(DETAILS_PANEL).should('be.visible');
+  });
+});
+
+// ServiceAnsiblePlaybook — Details + Provisioning + Retirement tabs
+describe('My Services — Ansible Playbook Service Tabs', () => {
+  const SERVICE_NAME = 'cy-ansible-playbook-service';
+
+  beforeEach(() => {
+    // 1. Create the service
+    cy.appFactories([
+      ['create', 'service_ansible_playbook', { name: SERVICE_NAME, display: true }],
+    ]).then(([service]) => {
+      // 2. Create EmbeddedAnsible jobs and link them directly via ServiceResource
+      cy.appEval(`
+        service = Service.find(${service.id})
+        provision_job  = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job.create!(
+          :name        => 'cy-provision-job',
+          :ems_ref     => 'cy-provision-job-ref',
+          :status      => 'create_complete',
+          :start_time  => Time.now.utc,
+          :finish_time => Time.now.utc,
+          :verbosity   => 0,
+          :hosts       => []
+        )
+        retirement_job = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job.create!(
+          :name        => 'cy-retirement-job',
+          :ems_ref     => 'cy-retirement-job-ref',
+          :status      => 'create_complete',
+          :start_time  => Time.now.utc,
+          :finish_time => Time.now.utc,
+          :verbosity   => 0,
+          :hosts       => []
+        )
+        service.service_resources.create!(
+          :resource_type => 'OrchestrationStack',
+          :resource_id   => provision_job.id,
+          :name          => 'Provision'
+        )
+        service.service_resources.create!(
+          :resource_type => 'OrchestrationStack',
+          :resource_id   => retirement_job.id,
+          :name          => 'Retirement'
+        )
+      `);
+    });
+    cy.login();
+    visitMyServices();
+    clickServiceRow(SERVICE_NAME);
+  });
+
+  afterEach(() => {
+    cy.appDbState('restore');
+  });
+
+  it('renders Details, Provisioning, and Retirement tabs with correct panels', () => {
+    cy.get(TABS_WRAPPER).should('be.visible');
+    cy.get(TABS_PANEL).should('be.visible');
+
+    cy.contains('button', TAB_DETAILS).should('be.visible');
+    cy.get(DETAILS_PANEL).should('be.visible');
+
+    cy.contains('button', TAB_PROVISIONING).should('be.visible');
+    cy.tabs({ tabLabel: TAB_PROVISIONING });
+    cy.get('#provisioning').should('be.visible');
+    cy.get(DETAILS_PANEL).should('not.have.class', 'active');
+
+    cy.contains('button', TAB_RETIREMENT).should('be.visible');
+    cy.tabs({ tabLabel: TAB_RETIREMENT });
+    cy.get('#retirement').should('be.visible');
+  });
+
+  it('resets to Details tab when navigating away and back', () => {
+    cy.tabs({ tabLabel: TAB_PROVISIONING });
+    cy.get('#provisioning').should('be.visible');
+    visitMyServices();
+    clickServiceRow(SERVICE_NAME);
+
+    // Details panel should be active again (fresh page load resets state)
+    cy.get(TABS_WRAPPER).should('be.visible');
+    cy.get(DETAILS_PANEL).should('be.visible');
+  });
+});
+
+// ServiceEmbeddedTerraform — Details + Output tabs
+describe('My Services — Embedded Terraform Service Tabs', () => {
+  const SERVICE_NAME = 'cy-terraform-service';
+
+  beforeEach(() => {
+    cy.appFactories([
+      ['create', 'service_embedded_terraform', { name: SERVICE_NAME, display: true }],
+    ]).then(([service]) => {
+      cy.appEval(`
+        service = Service.find(${service.id})
+        stack   = FactoryBot.create(:terraform_stack)
+        service.add_resource!(stack, :name => 'Provision')
+      `);
+    });
+    cy.login();
+    visitMyServices();
+    clickServiceRow(SERVICE_NAME);
+  });
+
+  afterEach(() => {
+    cy.appDbState('restore');
+  });
+
+  it('renders Details and Output tabs with correct panels', () => {
+    cy.get(TABS_WRAPPER).should('be.visible');
+    cy.get(TABS_PANEL).should('be.visible');
+
+    // Details tab — active by default
+    cy.contains('button', 'Details').should('be.visible');
+    cy.get(DETAILS_PANEL).should('be.visible');
+
+    // Output tab
+    cy.contains('button', 'Output').should('be.visible');
+    cy.tabs({ tabLabel: 'Output' });
+    cy.get('#output').should('be.visible');
+    cy.get(DETAILS_PANEL).should('not.have.class', 'active');
+  });
+
+  it('resets to Details tab when navigating away and back', () => {
+    cy.tabs({ tabLabel: 'Output' });
+    cy.get('#output').should('be.visible');
+
+    visitMyServices();
+    clickServiceRow(SERVICE_NAME);
+
+    cy.get(TABS_WRAPPER).should('be.visible');
+    cy.get(DETAILS_PANEL).should('be.visible');
+  });
+});
+
+// ServiceAnsibleTower — Details + Job tabs
+describe('My Services — Ansible Tower Service Tabs', () => {
+  const SERVICE_NAME = 'cy-ansible-tower-service';
+
+  beforeEach(() => {
+    cy.appFactories([
+      ['create', 'service_ansible_tower', { name: SERVICE_NAME, display: true }],
+    ]).then(([service]) => {
+      // Create the AnsibleTower job and link it via ServiceResource with explicit
+      cy.appEval(`
+        service = Service.find(${service.id})
+        job = ManageIQ::Providers::AnsibleTower::AutomationManager::Job.create!(
+          :name        => 'cy-tower-job',
+          :ems_ref     => 'cy-tower-job-ref',
+          :status      => 'create_complete',
+          :start_time  => Time.now.utc,
+          :finish_time => Time.now.utc,
+          :verbosity   => 0
+        )
+        service.service_resources.create!(
+          :resource_type => 'OrchestrationStack',
+          :resource_id   => job.id
+        )
+      `);
+    });
+    cy.login();
+    visitMyServices();
+    clickServiceRow(SERVICE_NAME);
+  });
+
+  afterEach(() => {
+    cy.appDbState('restore');
+  });
+
+  it('renders Details and Job tabs with correct panels', () => {
+    cy.get(TABS_WRAPPER).should('be.visible');
+    cy.get(TABS_PANEL).should('be.visible');
+
+    cy.contains('button', TAB_DETAILS).should('be.visible');
+    cy.get(DETAILS_PANEL).should('be.visible');
+
+    cy.contains('button', TAB_JOB).should('be.visible');
+    cy.tabs({ tabLabel: TAB_JOB });
+    cy.get('#tower_job').should('be.visible');
+    cy.get(DETAILS_PANEL).should('not.have.class', 'active');
+  });
+
+  it('resets to Details tab when navigating away and back', () => {
+    cy.tabs({ tabLabel: TAB_JOB });
+    cy.get('#tower_job').should('be.visible');
+    visitMyServices();
+    clickServiceRow(SERVICE_NAME);
+
+    // Details panel should be active again
+    cy.get(TABS_WRAPPER).should('be.visible');
+    cy.get(DETAILS_PANEL).should('be.visible');
+  });
+});


### PR DESCRIPTION
Fixes #8729 
Convert Services Tabs to React.

## Before: ##
<img width="1728" height="998" alt="image" src="https://github.com/user-attachments/assets/9251c41a-ad7e-4658-91ed-0246c041b61d" />
<img width="1728" height="996" alt="image" src="https://github.com/user-attachments/assets/3da6a887-1b06-4a7b-98a5-05f407ea1e05" />
<img width="1728" height="997" alt="image" src="https://github.com/user-attachments/assets/5ef9a634-e987-47e0-a7f7-8f18836020df" />

## After: ##
<img width="1728" height="995" alt="image" src="https://github.com/user-attachments/assets/cada70f6-b625-4097-8f77-611054be206d" />
<img width="1728" height="996" alt="Screenshot 2026-06-26 at 9 57 58 AM" src="https://github.com/user-attachments/assets/03892c51-4dd2-4f3f-9e61-ea4150cc41fd" />
<img width="1728" height="997" alt="image" src="https://github.com/user-attachments/assets/87ed2213-0d4c-4205-8a2b-a4e441169a72" />


@miq-bot add-label enhancement
@miq-bot add-reviewer @GilbertCherrie
@miq-bot assign @GilbertCherrie