### PR TITLE
Convert Report Summary Tabs to React

### DIFF
--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -3,6 +3,7 @@ module ReportHelper
   include ReportInformationHelper
   include ReportDashboardWidgetHelper
   include ReportScheduleHelper
+  include ReportTabsHelper
   include DataTableHelper
 
   STYLE_CLASSES = {

--- a/app/helpers/report_tabs_helper.rb
+++ b/app/helpers/report_tabs_helper.rb
@@ -1,0 +1,20 @@
+module ReportTabsHelper
+  REPORT_TAB_LABELS = %w[report_info saved_reports].freeze
+
+  def report_tab_configuration
+    REPORT_TAB_LABELS
+  end
+
+  def report_tab_content(key_name, active_tab: nil, &)
+    return unless REPORT_TAB_LABELS.include?(key_name.to_s)
+
+    css_class = 'tab_content'
+    css_class += ' active' if active_tab.to_s == key_name.to_s
+    tag.div(:id => key_name.to_s, :class => css_class, &)
+  end
+
+  def report_tab_index(active_tab)
+    idx = REPORT_TAB_LABELS.index(active_tab.to_s)
+    idx || 0
+  end
+end

--- a/app/javascript/components/miq-custom-tab/helper.js
+++ b/app/javascript/components/miq-custom-tab/helper.js
@@ -97,6 +97,12 @@ const service = {
   tower_job: __('Job'),
 };
 
+/** Tab labels used for report info / saved reports tabs. */
+const report = {
+  report_info: __('Report Info'),
+  saved_reports: __('Saved Reports'),
+};
+
 /** Function to select the tab labels. */
 export const labelConfig = (type) => {
   const configMap = {
@@ -112,6 +118,7 @@ export const labelConfig = (type) => {
     DIAGNOSTICS_SERVER: diagnosticsServer,
     DIAGNOSTICS_ROOT: diagnosticsRoot,
     SERVICE: service,
+    REPORT: report,
   };
 
   return configMap[type];

--- a/app/javascript/components/miq-custom-tab/index.jsx
+++ b/app/javascript/components/miq-custom-tab/index.jsx
@@ -40,6 +40,7 @@ const MiqCustomTab = ({
     { type: 'DIAGNOSTICS_SERVER', url: `/ops/change_tab?tab_id=diagnostics_${name}` },
     { type: 'DIAGNOSTICS_ROOT', url: `/ops/change_tab?tab_id=diagnostics_${name}` },
     { type: 'SERVICE' },
+    { type: 'REPORT', url: `/report/rep_change_tab?tab_id=${name}` },
   ];
 
   const configuration = (name) => tabConfigurations(name).find((item) => item.type === type);

--- a/app/views/report/_report_list.html.haml
+++ b/app/views/report/_report_list.html.haml
@@ -23,19 +23,15 @@
       - if @report.nil? && x_node.split('-').length >= 6
         = render :partial => 'layouts/warn_msg', :locals => {:message => _("No records found for this report")}
       - else
-        #rep_tabs
-          %ul.nav.nav-tabs{'role' => 'tablist'}
-            = miq_tab_header('report_info', @sb[:active_tab]) do
-              = _('Report Info')
-            %li
-            = miq_tab_header('saved_reports', @sb[:active_tab]) do
-              = _('Saved Reports')
-          .tab-content
-            = miq_tab_content('report_info', @sb[:active_tab]) do
-              = render :partial => "report_info"
-            = miq_tab_content('saved_reports', @sb[:active_tab]) do
-              = render :partial => "report_saved_reports"
-        :javascript
-          miq_tabs_init('#rep_tabs', '/report/rep_change_tab');
+        #rep-tabs-wrapper
+          = react('MiqCustomTab', {:containerId => 'rep-tabs',
+                                   :tabLabels   => report_tab_configuration,
+                                   :type        => 'REPORT',
+                                   :activeTab   => report_tab_index(@sb[:active_tab])})
+        #rep-tabs
+          = report_tab_content(:report_info, :active_tab => @sb[:active_tab]) do
+            = render :partial => "report_info"
+          = report_tab_content(:saved_reports, :active_tab => @sb[:active_tab]) do
+            = render :partial => "report_saved_reports"
     - else
       = render :partial => 'layouts/info_msg', :locals => {:message => _("Choose a Report to view from the menus on the left.")}

--- a/app/views/report/_report_list.html.haml
+++ b/app/views/report/_report_list.html.haml
@@ -28,7 +28,7 @@
                                    :tabLabels   => report_tab_configuration,
                                    :type        => 'REPORT',
                                    :activeTab   => report_tab_index(@sb[:active_tab])})
-        #rep-tabs
+        .miq_custom_tabs_container#rep-tabs
           = report_tab_content(:report_info, :active_tab => @sb[:active_tab]) do
             = render :partial => "report_info"
           = report_tab_content(:saved_reports, :active_tab => @sb[:active_tab]) do

--- a/cypress/e2e/ui/Overview/reports.cy.js
+++ b/cypress/e2e/ui/Overview/reports.cy.js
@@ -428,3 +428,50 @@ describe('Overview > Reports Tests', () => {
     });
   });
 });
+
+describe('Report Info / Saved Reports Tabs', () => {
+  beforeEach(() => {
+    cy.login();
+    cy.menu('Overview', 'Reports');
+    cy.accordion('Reports');
+    cy.selectAccordionItem(['Configuration Management', 'Virtual Machines']);
+    cy.contains('.clickable-row', 'Account Groups - Linux').click();
+  });
+
+  it('displays report tabs and switches between Report Info and Saved Reports', () => {
+    cy.get('#rep-tabs-wrapper').should('be.visible');
+    cy.get('.miq_custom_tabs').should('be.visible');
+
+    cy.get('#report_info').should('have.class', 'active');
+    cy.contains('Basic Information').should('be.visible');
+
+    cy.intercept('/report/rep_change_tab*').as('changeTab');
+    cy.contains('button', 'Saved Reports').should('be.visible').click();
+    cy.wait('@changeTab');
+
+    cy.get('#saved_reports').should('have.class', 'active');
+    cy.get('#gtl_div').should('be.visible');
+
+    cy.contains('button', 'Report Info').should('be.visible').click();
+    cy.wait('@changeTab');
+
+    cy.get('#report_info').should('have.class', 'active');
+    cy.contains('Basic Information').should('be.visible');
+  });
+
+  it('resets to Report Info tab when navigating away and back to a report', () => {
+    cy.intercept('/report/rep_change_tab*').as('changeTab');
+    cy.contains('button', 'Saved Reports').should('be.visible').click();
+    cy.wait('@changeTab');
+    cy.get('#saved_reports').should('have.class', 'active');
+
+    cy.get('#reports_accord.in li.list-group-item').contains('Configuration Management').click();
+
+    cy.selectAccordionItem(['Configuration Management', 'Virtual Machines']);
+    cy.contains('.clickable-row', 'Account Groups - Linux').click();
+
+    cy.get('#rep-tabs-wrapper').should('be.visible');
+    cy.get('#report_info').should('have.class', 'active');
+    cy.contains('Basic Information').should('be.visible');
+  });
+});


### PR DESCRIPTION
Fixes #8729  
Convert Report Summary Tabs to React.

## Before: ##
<img width="1728" height="996" alt="image" src="https://github.com/user-attachments/assets/7dfa5cb2-7735-45d2-b884-e1b72582bd27" />


## After: ##
<img width="1728" height="998" alt="image" src="https://github.com/user-attachments/assets/36819cc4-762d-4548-b318-66776cd8d036" />


@miq-bot add-label enhancement
@miq-bot add-reviewer @GilbertCherrie
@miq-bot assign @GilbertCherrie