### PR TITLE
Convert Service Dialogs Summary Screen Header Tabs to React

### DIFF
--- a/app/helpers/miq_ae_customization_helper.rb
+++ b/app/helpers/miq_ae_customization_helper.rb
@@ -3,6 +3,24 @@ module MiqAeCustomizationHelper
   include SharedHelper::AbShowHelper
   include SharedHelper::AbListHelper
 
+  DIALOG_TAB_IDS = %w[sample_tab info_tab].freeze
+
+  def dialog_tab_configuration
+    DIALOG_TAB_IDS.map(&:to_sym)
+  end
+
+  def dialog_tab_content(key_name, &)
+    if DIALOG_TAB_IDS.include?(key_name.to_s)
+      class_name = key_name == :sample_tab ? 'tab_content active' : 'tab_content'
+      tag.div(:id => key_name, :class => class_name, &)
+    end
+  end
+
+  def dialog_tab_index(active_tab)
+    index = DIALOG_TAB_IDS.index(active_tab.to_s)
+    index || 0
+  end
+
   def editor_automation_types
     AUTOMATION_TYPES.to_json
   end
@@ -10,7 +28,7 @@ module MiqAeCustomizationHelper
   def dialog_id_action
     url = request.parameters
     if url[:id].present?
-      {:id => @record.id.to_s, :action => 'edit'}
+      {:id => url[:id].to_s, :action => 'edit'}
     elsif url[:copy].present?
       {:id => url[:copy], :action => 'copy'}
     else

--- a/app/javascript/components/miq-custom-tab/helper.js
+++ b/app/javascript/components/miq-custom-tab/helper.js
@@ -110,6 +110,12 @@ const aeClass = {
   schema: __('Schema'),
 };
 
+/** Tab labels used for the Dialog details page. */
+const dialog = {
+  sample_tab: __('Sample'),
+  info_tab: __('Basic Info'),
+};
+
 /** Function to select the tab labels. */
 export const labelConfig = (type) => {
   const configMap = {
@@ -127,6 +133,7 @@ export const labelConfig = (type) => {
     SERVICE: service,
     REPORT: report,
     AE_CLASS: aeClass,
+    DIALOG: dialog,
   };
 
   return configMap[type];

--- a/app/javascript/components/miq-custom-tab/index.jsx
+++ b/app/javascript/components/miq-custom-tab/index.jsx
@@ -27,6 +27,7 @@ const MiqCustomTab = ({
     { type: 'CATALOG_EDIT', js: () => name === 'detail' && dispatch(miqCustomTabActions.incrementClickCount()) },
     { type: 'CATALOG_REQUEST_INFO', url: `/miq_request/prov_field_changed?tab_id=${name}&edit_mode=true` },
     { type: 'UTILIZATION' },
+    { type: 'DIALOG', url: `/miq_ae_customization/change_tab?tab_id=${name}` },
     {
       type: 'SETTINGS',
       url: name === 'tags'

--- a/app/views/miq_ae_customization/_dialog_details.html.haml
+++ b/app/views/miq_ae_customization/_dialog_details.html.haml
@@ -2,16 +2,13 @@
 -# Need to include the tree JS files in case no tree is initially displayed
 - if @record
   = render :partial => "layouts/flash_msg"
-  #dialog_info_tabs
-    %ul.nav.nav-tabs{'role' => 'tablist'}
-      = miq_tab_header('sample_tab', @sb[:active_tab]) do
-        = _('Sample')
-      = miq_tab_header('info_tab', @sb[:active_tab]) do
-        = _('Basic Info')
-    .tab-content
-      = miq_tab_content('sample_tab', @sb[:active_tab]) do
-        = render :partial => "dialog_sample"
-      = miq_tab_content('info_tab', @sb[:active_tab]) do
-        = render :partial => "dialog_info"
-  :javascript
-    miq_tabs_init('#dialog_info_tabs', '/miq_ae_customization/change_tab/');
+  .miq_custom_tab_wrapper
+    = react('MiqCustomTab', {:containerId => 'dialog-info-tabs',
+                             :tabLabels   => dialog_tab_configuration,
+                             :type        => 'DIALOG',
+                             :activeTab   => dialog_tab_index(@sb[:active_tab])})
+  .miq_custom_tabs_container#dialog-info-tabs
+    = dialog_tab_content(:sample_tab) do
+      = render :partial => "dialog_sample"
+    = dialog_tab_content(:info_tab) do
+      = render :partial => "dialog_info"

--- a/cypress/e2e/ui/Automation/Embedded-Automate/customization.cy.js
+++ b/cypress/e2e/ui/Automation/Embedded-Automate/customization.cy.js
@@ -196,3 +196,55 @@ describe('Automation > Embedded Automate > Customization', () => {
     });
   });
 });
+
+describe('Dialog Details Tabs', () => {
+  const DIALOG_LABEL = 'Tab Test Dialog';
+
+  beforeEach(() => {
+    cy.appFactories([
+      ['create', 'dialog', {label: DIALOG_LABEL}],
+    ]);
+    cy.login();
+    cy.menu('Automation', 'Embedded Automate', 'Customization');
+    cy.accordion('Service Dialogs');
+    cy.selectAccordionItem(['All Dialogs', DIALOG_LABEL]);
+  });
+
+  afterEach(() => {
+    cy.appDbState('restore');
+  });
+
+  it('displays dialog tabs and switches between them', () => {
+    // Verify the React tab wrapper and tab list are visible
+    cy.get('.miq_custom_tab_wrapper').should('be.visible');
+    cy.get('.miq_custom_tabs').should('be.visible');
+
+    // Sample tab is active by default — its content panel should be visible
+    cy.get('#sample_tab').should('have.class', 'active');
+
+    // Switch to Basic Info tab and verify its content panel becomes active
+    cy.contains('button', 'Basic Info').should('be.visible').click();
+    cy.get('#info_tab').should('have.class', 'active');
+    cy.get('#info_tab').contains('Basic Information').should('be.visible');
+
+    // Switch back to Sample tab
+    cy.contains('button', 'Sample').should('be.visible').click();
+    cy.get('#sample_tab').should('have.class', 'active');
+  });
+
+  it('resets to default tab when navigating away and back', () => {
+    // Switch to the Basic Info tab
+    cy.contains('button', 'Basic Info').should('be.visible').click();
+    cy.get('#info_tab').should('have.class', 'active');
+
+    // Navigate away by clicking the root 'All Dialogs' node
+    cy.selectAccordionItem(['All Dialogs']);
+
+    // Navigate back to the dialog record
+    cy.selectAccordionItem(['All Dialogs', DIALOG_LABEL]);
+
+    // Tabs should have re-rendered with the default (Sample) tab active
+    cy.get('.miq_custom_tab_wrapper').should('be.visible');
+    cy.get('#sample_tab').should('have.class', 'active');
+  });
+});


### PR DESCRIPTION
Fixes #8729 
Convert Service Dialog Summary Screen Header Tabs to React.

## Before:  ## 
<img width="1728" height="996" alt="image" src="https://github.com/user-attachments/assets/62358fc9-efe8-4143-acea-0925b2b18785" />


## After:  ##
<img width="1728" height="997" alt="image" src="https://github.com/user-attachments/assets/27dfea0f-3b5b-4e2c-9088-f98177eb6951" />

@miq-bot add-label enhancement
@miq-bot add-reviewer @GilbertCherrie
@miq-bot assign @GilbertCherrie