### PR TITLE
Fix services filter

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -199,6 +199,12 @@ module ApplicationController::Filter
   def listnav_search_selected(id = nil)
     id ||= params[:id]
     @edit = session[:edit]
+    if @edit.nil?
+      add_flash(_("Error occurred, search filter not applied."), :error)
+      flash_to_session
+      javascript_redirect(:action => 'show_list')
+      return
+    end
     @edit[:selected] = true # Set a flag, this is checked whether to load initial default or clear was clicked
     if id.to_i.zero?
       clear_selected_search


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/10150

This PR fixes an issue with the filter. This issue is hard to recreate but assuming the issue is with the session expiring/being `nil` then we can fix this by creating checks/returns that allow the app to fail gracefully. When the user reattempts the filter, it should fix this issue due to the page reload resetting the session.

<img width="1060" height="422" alt="Screenshot 2026-07-06 at 10 45 50 AM" src="https://github.com/user-attachments/assets/51893a85-0ad1-4c9f-8344-1aae190e02be" />
