### PR TITLE
Replace Automation Manager strings with Automation Provider

### DIFF
--- a/app/helpers/application_helper/title.rb
+++ b/app/helpers/application_helper/title.rb
@@ -24,7 +24,7 @@ module ApplicationHelper
 
       case layout
       when "automation_manager"
-        _("Automation Managers")
+        _("Automation Providers")
       when "catalogs"
         _("Catalogs")
       when "configuration"

--- a/app/javascript/spec/tree-view/tree-view.spec.js
+++ b/app/javascript/spec/tree-view/tree-view.spec.js
@@ -46,8 +46,8 @@ describe('Tree View component', () => {
           },
           {
             key: 'at-19',
-            text: 'Ansible Tower Automation Manager',
-            tooltip: 'Provider: Ansible Tower Automation Manager',
+            text: 'Ansible Tower Automation Provider',
+            tooltip: 'Provider: Ansible Tower Automation Provider',
             image:
               '/assets/svg/vendor-ansible-53cf0c18065b8e2c8b99cbde9dca3ac9245ec363b700af6e9fd2bc5b743c85a9.svg',
             selectable: true,

--- a/app/views/layouts/_tag_edit_items.html.haml
+++ b/app/views/layouts/_tag_edit_items.html.haml
@@ -6,7 +6,7 @@
       - when "ManageIQ::Providers::ExternalAutomationManager::OrchestrationStack"
         = n_("%{amount} Automation Job Being Tagged", "%{amount} Automation Jobs Being Tagged", @tagitems.length) % t
       - when "ManageIQ::Providers::AnsibleTower::AutomationManager"
-        = n_("%{amount} Automation Manager (Ansible Tower) Being Tagged", "%{amount} Automation Managers (Ansible Tower) Being Tagged", @tagitems.length) % t
+        = n_("%{amount} Automation Provider (Ansible Tower) Being Tagged", "%{amount} Automation Providers (Ansible Tower) Being Tagged", @tagitems.length) % t
       - when "AvailabilityZone"
         = n_("%{amount} Availability Zone Being Tagged", "%{amount} Availability Zones Being Tagged", @tagitems.length) % t
       - when "CloudNetwork"

--- a/cypress/e2e/ui/menu.cy.js
+++ b/cypress/e2e/ui/menu.cy.js
@@ -113,7 +113,7 @@ describe('Menu', () => {
     });
 
     it('Automation >', () => {
-      cy.menu('Automation', 'Automation', 'Providers').expect_show_list_title('Automation Managers');
+      cy.menu('Automation', 'Automation', 'Providers').expect_show_list_title('Automation Providers');
       cy.menu('Automation', 'Automation', 'Configured Systems').expect_show_list_title('Configured Systems');
       cy.menu('Automation', 'Automation', 'Templates').expect_show_list_title('Templates');
       cy.menu('Automation', 'Automation', 'Jobs').expect_show_list_title('Automation Jobs');

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1214,10 +1214,10 @@ describe CatalogController do
           expect(controller.instance_variable_get(:@edit)[:new][:available_managers]).to eq([[ems_ansible_tower.name, ems_ansible_tower.id]])
         end
 
-        context "with other automation managers" do
+        context "with other automation providers" do
           let!(:embedded_ansible) { FactoryBot.create(:provider_embedded_ansible).automation_manager }
 
-          it "doesn't include other automation managers" do
+          it "doesn't include other automation providers" do
             controller.send(:set_form_vars)
             expect(controller.instance_variable_get(:@edit)[:new][:available_managers]).to eq([[ems_ansible_tower.name, ems_ansible_tower.id]])
           end


### PR DESCRIPTION
Replace Automation Manager strings with Automation Provider instead.

Relevant PRs:
- https://github.com/ManageIQ/manageiq-ui-service/pull/2110
- https://github.com/ManageIQ/manageiq/pull/23915
- https://github.com/ManageIQ/manageiq-content/pull/793
- https://github.com/ManageIQ/manageiq-documentation/pull/1905
- https://github.com/ManageIQ/manageiq-providers-awx/pull/65
- https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/344
- https://github.com/ManageIQ/manageiq-api-client/pull/165