### PR TITLE
Bump tanstack/react-query to v5

### DIFF
--- a/app/javascript/components/AeInlineMethod/NamespaceSelector.jsx
+++ b/app/javascript/components/AeInlineMethod/NamespaceSelector.jsx
@@ -1,6 +1,11 @@
-import { useState, useMemo, useCallback } from 'react';
+import {
+  useState,
+  useMemo,
+  useCallback,
+  Suspense,
+} from 'react';
 import PropTypes from 'prop-types';
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { Loading } from '@carbon/react';
 import { debounce } from 'lodash';
 import FilterNamespace from './FilterNamespace';
@@ -16,7 +21,7 @@ const NamespaceSelector = ({ onSelectMethod, selectedIds }) => {
   const [filterData, setFilterData] = useState({ searchText: '', selectedDomain: '' });
 
   /** Loads the domains and stores in domainData for 60 seconds. */
-  const { data: domainsData, isLoading: domainsLoading } = useQuery({
+  const { data: domainsData } = useSuspenseQuery({
     queryKey: ['domainsData'],
     queryFn: async() => (await http.get(namespaceUrls.aeDomainsUrl)).domains,
     staleTime: 60000,
@@ -26,7 +31,7 @@ const NamespaceSelector = ({ onSelectMethod, selectedIds }) => {
    * If condition works on page load
    * Else part would work if there is a change in filterData.
    */
-  const { data, isLoading: methodsLoading } = useQuery({
+  const { data } = useSuspenseQuery({
     queryKey: ['methodsData', filterData.searchText, filterData.selectedDomain],
     queryFn: async() => {
       if (!filterData.searchText && !filterData.selectedDomain) {
@@ -86,9 +91,7 @@ const NamespaceSelector = ({ onSelectMethod, selectedIds }) => {
     <div className="inline-method-selector">
       <FilterNamespace domains={domainsData} onSearch={onSearch} />
       <div className="inline-contents-wrapper">
-        {(domainsLoading || methodsLoading)
-          ? <Loading active small withOverlay={false} className="loading" />
-          : renderContents}
+        {renderContents}
       </div>
     </div>
   );
@@ -99,4 +102,15 @@ NamespaceSelector.propTypes = {
   selectedIds: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])).isRequired,
 };
 
-export default NamespaceSelector;
+const NamespaceSelectorWithSuspense = (props) => (
+  <Suspense fallback={<Loading active small withOverlay={false} className="loading" />}>
+    <NamespaceSelector {...props} />
+  </Suspense>
+);
+
+NamespaceSelectorWithSuspense.propTypes = {
+  onSelectMethod: PropTypes.func.isRequired,
+  selectedIds: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])).isRequired,
+};
+
+export default NamespaceSelectorWithSuspense;

--- a/config/webpack/loaders.js
+++ b/config/webpack/loaders.js
@@ -25,7 +25,7 @@ module.exports = [
       options: babelOptions,
     }],
     // Explicitly include @carbon packages and its nested es-toolkit package to be transpiled
-    exclude: /node_modules\/(?!(@carbon|es-toolkit))/,
+    exclude: /node_modules\/(?!(@carbon|@tanstack|es-toolkit))/,
   },
   {
     // matches both the actual path and the aliased one

--- a/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/select_methods.cy.js
+++ b/cypress/e2e/ui/Automation/Embedded-Automate/Explorer/select_methods.cy.js
@@ -1,0 +1,189 @@
+import { flashClassMap } from '../../../../../support/assertions/assertion_constants';
+
+// Menu options
+const AUTOMATION_MENU_OPTION = 'Automation';
+const EMBEDDED_AUTOMATION_MENU_OPTION = 'Embedded Automate';
+const EXPLORER_MENU_OPTION = 'Explorer';
+// Labels
+const DATA_STORE_ACCORDION_LABEL = 'Datastore';
+const DOMAIN_LABEL = 'Test_Domain';
+const NAMESPACE_LABEL = 'Test_Namespace';
+const CLASS_LABEL = 'Test_Class';
+const NONE_OPTION_LABEL = 'None';
+const MIQ_OPTION_LABEL = 'ManageIQ';
+// Toolbar options
+const TOOLBAR_CONFIGURATION = 'Configuration';
+const TOOLBAR_ADD_NEW_METHOD = 'Add a New Method';
+// Buttons
+const ADD_METHOD_BUTTON_TEXT = 'Add Method';
+// Selectors
+const SELECT_METHODS_TABLE_ROW =
+  '.cds--modal-content .miq-data-table.miq-inline-method-list tbody tr';
+
+describe(`Automate operations on Namespaces: Automation -> Embedded Automate -> Explorer -> Methods`, () => {
+  beforeEach(() => {
+    cy.appFactories([['create', 'miq_ae_domain', { name: DOMAIN_LABEL }]]).then(
+      (domainData) => {
+        expect(domainData.length).to.equal(1);
+        cy.appFactories([
+          [
+            'create',
+            'miq_ae_namespace',
+            { name: NAMESPACE_LABEL, domain_id: domainData?.[0].id },
+          ],
+        ]).then((namespaceData) => {
+          expect(namespaceData.length).to.equal(1);
+          cy.appFactories([
+            [
+              'create',
+              'miq_ae_class',
+              { name: CLASS_LABEL, namespace_id: namespaceData?.[0].id },
+            ],
+          ]).then((classData) => {
+            expect(classData.length).to.equal(1);
+          });
+        });
+      }
+    );
+
+    cy.login();
+    cy.menu(
+      AUTOMATION_MENU_OPTION,
+      EMBEDDED_AUTOMATION_MENU_OPTION,
+      EXPLORER_MENU_OPTION
+    );
+    cy.selectAccordionItem([
+      DATA_STORE_ACCORDION_LABEL,
+      DOMAIN_LABEL,
+      NAMESPACE_LABEL,
+      CLASS_LABEL,
+    ]);
+    cy.tabs({ tabLabel: 'Methods' });
+    cy.toolbar(TOOLBAR_CONFIGURATION, TOOLBAR_ADD_NEW_METHOD);
+    cy.get('.bootstrap-select').click();
+    cy.contains('ul.dropdown-menu li', 'Inline').click();
+    cy.contains(
+      '#embedded_methods_div button.cds--accordion__heading',
+      'Embedded Methods'
+    ).should('be.visible');
+  });
+
+  it('Verifies API caching for modal load, search, and domain filter operations', () => {
+    // Verify initial modal load caching:
+    // 1. First modal open - triggers API calls for domains and methods (count: 1 each)
+    // 2. Close and reopen modal within 60s - uses cached data, no new API calls (count: still 1 each)
+    cy.intercept('GET', '/miq_ae_class/ae_domains').as('getDomainsData');
+    cy.intercept('GET', '/miq_ae_class/ae_methods').as('getMethodsData');
+    // First modal open - should trigger initial API calls
+    cy.getFormButtonByTypeWithText({
+      buttonText: ADD_METHOD_BUTTON_TEXT,
+    }).click();
+    cy.wait('@getDomainsData');
+    cy.wait('@getMethodsData');
+    cy.get('@getDomainsData.all').should('have.length', 1);
+    cy.get('@getMethodsData.all').should('have.length', 1);
+    cy.get('.cds--loading').should('not.exist');
+    cy.expect_modal({
+      modalHeaderText: 'Select methods',
+      targetFooterButtonText: 'Cancel',
+    });
+    // Reopen modal within 60s - should use cached data, no new API calls
+    cy.getFormButtonByTypeWithText({
+      buttonText: ADD_METHOD_BUTTON_TEXT,
+    }).click();
+    cy.get('@getDomainsData.all').should('have.length', 1);
+    cy.get('@getMethodsData.all').should('have.length', 1);
+
+    // Verify search API caching and search functionality:
+    // 1. First search for 'im' - triggers API call (count: 1)
+    // 2. Re-search for 'im' - uses cache, no new API call (count: still 1)
+    // 3. Search for 'vm' - different query, triggers new API call (count: 2)
+    // 4. Search for 'unknown' - triggers API call, shows "No methods" message (count: 3)
+    cy.intercept('GET', '/miq_ae_class/ae_methods?search=*').as(
+      'searchMatchedMethods'
+    );
+    // First search: 'im' - should trigger API call and return results
+    cy.get('input#search-method').type('im');
+    cy.wait('@searchMatchedMethods');
+    cy.get('@searchMatchedMethods.all').should('have.length', 1);
+    cy.get(SELECT_METHODS_TABLE_ROW).should('have.length.greaterThan', 0);
+    cy.get('.cds--modal-content .cds--search-close').click();
+    // Re-search: 'im' - should use cached results, no new API call
+    cy.get('input#search-method').type('im');
+    cy.get('@searchMatchedMethods.all').should('have.length', 1);
+    cy.get(SELECT_METHODS_TABLE_ROW).should('have.length.greaterThan', 0);
+    cy.get('.cds--modal-content .cds--search-close').click();
+    // New search: 'vm' - different query, should trigger new API call
+    cy.get('input#search-method').type('vm');
+    cy.wait('@searchMatchedMethods');
+    cy.get('@searchMatchedMethods.all').should('have.length', 2);
+    cy.get(SELECT_METHODS_TABLE_ROW).should('have.length.greaterThan', 0);
+    cy.get('.cds--modal-content .cds--search-close').click();
+    // Search with no results: 'unknown' - should trigger API call and show info message
+    cy.get('input#search-method').type('unknown');
+    cy.wait('@searchMatchedMethods');
+    cy.expect_flash(flashClassMap.info, 'No methods');
+    cy.get('.cds--modal-content .cds--search-close').click();
+
+    // Verify domain filter API caching and filter functionality:
+    // 1. Select 'Test_Domain' - triggers API call, shows "No methods" (count: 1)
+    // 2. Select 'None' then re-select 'Test_Domain' - uses cache, no new API call (count: still 1)
+    // 3. Select 'ManageIQ' domain - different domain, triggers new API call with results (count: 2)
+    cy.intercept('GET', '/miq_ae_class/ae_methods?domain_id=*').as(
+      'domainMatchedMethods'
+    );
+    // First domain filter: 'Test_Domain' - should trigger API call with no results
+    cy.get('select#domain_id').select(DOMAIN_LABEL);
+    cy.wait('@domainMatchedMethods');
+    cy.get('@domainMatchedMethods.all').should('have.length', 1);
+    cy.expect_flash(flashClassMap.info, 'No methods');
+    // Re-select same domain: 'None' -> 'Test_Domain' - should use cached results, no new API call
+    cy.get('select#domain_id').select(NONE_OPTION_LABEL);
+    cy.get('select#domain_id').select(DOMAIN_LABEL);
+    cy.get('@domainMatchedMethods.all').should('have.length', 1);
+    // New domain filter: 'ManageIQ' - different domain, should trigger new API call with results
+    cy.get('select#domain_id').select(MIQ_OPTION_LABEL);
+    cy.wait('@domainMatchedMethods');
+    cy.get('@domainMatchedMethods.all').should('have.length', 2);
+    cy.get(SELECT_METHODS_TABLE_ROW).should('have.length.greaterThan', 0);
+  });
+
+  it('Verifies method selection and persistence in embedded methods table', () => {
+    // Verify method selection workflow and state persistence:
+    // 1. Open modal and select a method from the list
+    // 2. Confirm selection - method should appear in embedded methods table
+    // 3. Reopen modal - previously selected method should remain checked
+    // Open modal and select first method
+    cy.getFormButtonByTypeWithText({
+      buttonText: ADD_METHOD_BUTTON_TEXT,
+    }).click();
+    cy.get('.cds--loading').should('not.exist');
+    cy.get(
+      `${SELECT_METHODS_TABLE_ROW} .cds--table-column-checkbox input`
+    )
+      .eq(0)
+      .scrollIntoView()
+      .check({ force: true });
+    // Confirm selection
+    cy.get('#embedded_methods_div .miq-data-table tbody tr').should(
+      'have.length.greaterThan',
+      0
+    );
+    cy.expect_modal({
+      modalHeaderText: 'Selected methods',
+      targetFooterButtonText: 'OK',
+    });
+    // Reopen modal and verify previously selected method remains checked
+    cy.getFormButtonByTypeWithText({
+      buttonText: ADD_METHOD_BUTTON_TEXT,
+    }).click();
+    cy.get(`${SELECT_METHODS_TABLE_ROW} .cds--table-column-checkbox input`)
+      .eq(0)
+      .scrollIntoView()
+      .should('be.checked');
+  });
+
+  afterEach(() => {
+    cy.appDbState('restore');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@novnc/novnc": "~1.2.0",
     "@pf3/select": "~1.12.6",
     "@rails/actioncable": "^8.0.0",
-    "@tanstack/react-query": "^4.0.5",
+    "@tanstack/react-query": "^5.101.0",
     "@tshepomgaga/aws-sfn-graph": "0.0.6",
     "angular": "~1.8.3",
     "angular-animate": "~1.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2904,29 +2904,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/query-core@npm:4.44.0":
-  version: 4.44.0
-  resolution: "@tanstack/query-core@npm:4.44.0"
-  checksum: 10/f7f5c69cb2d44b58e1a9bfaa304a82724bb49f0ff63fd3abdfe377f15825ad910e1d31dd529d94e0650ff17229930eef2f54e281dbe99fa6cbd6a85e7c27bb9d
+"@tanstack/query-core@npm:5.101.2":
+  version: 5.101.2
+  resolution: "@tanstack/query-core@npm:5.101.2"
+  checksum: 10/567af5e3c21628745a08c1a5054d838597bc620dcbbeabe20cdd6ccffdcca85a8d38128f6e80829b6e04d10f79ca793a7dd8fddc8a3d6bef10c2d580ae214c7d
   languageName: node
   linkType: hard
 
-"@tanstack/react-query@npm:^4.0.5":
-  version: 4.44.0
-  resolution: "@tanstack/react-query@npm:4.44.0"
+"@tanstack/react-query@npm:^5.101.0":
+  version: 5.101.2
+  resolution: "@tanstack/react-query@npm:5.101.2"
   dependencies:
-    "@tanstack/query-core": "npm:4.44.0"
-    use-sync-external-store: "npm:^1.6.0"
+    "@tanstack/query-core": "npm:5.101.2"
   peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    react-native: "*"
-  peerDependenciesMeta:
-    react-dom:
-      optional: true
-    react-native:
-      optional: true
-  checksum: 10/1eda263fbabfbb0ec7fd9444c4240b62ba5e80205b652a2d82a28a7dfb5a19a626a7e58094b4b9f71edf16085473f9b1238c7796ce6e8925bca3aefc9f18a49b
+    react: ^18 || ^19
+  checksum: 10/0837c176b6afb01e3632010bbd8bdfeee7f46c4a25a50ed2ba9ddddce11c34431161d80dd8e53a2f55190c2313bbfb22a84a77308e6ccf29877b4818de68c4b3
   languageName: node
   linkType: hard
 
@@ -11249,7 +11241,7 @@ __metadata:
     "@novnc/novnc": "npm:~1.2.0"
     "@pf3/select": "npm:~1.12.6"
     "@rails/actioncable": "npm:^8.0.0"
-    "@tanstack/react-query": "npm:^4.0.5"
+    "@tanstack/react-query": "npm:^5.101.0"
     "@testing-library/dom": "npm:~10.4.1"
     "@testing-library/jest-dom": "npm:~6.9.1"
     "@testing-library/react": "npm:~16.3.2"
@@ -15568,15 +15560,6 @@ __metadata:
     punycode: "npm:^1.4.1"
     qs: "npm:^6.12.3"
   checksum: 10/e787d070f0756518b982a4653ef6cdf4d9030d8691eee2d483344faf2b530b71d302287fa63b292299455fea5075c502a5ad5f920cb790e95605847f957a65e4
-  languageName: node
-  linkType: hard
-
-"use-sync-external-store@npm:^1.6.0":
-  version: 1.6.0
-  resolution: "use-sync-external-store@npm:1.6.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10/b40ad2847ba220695bff2d4ba4f4d60391c0fb4fb012faa7a4c18eb38b69181936f5edc55a522c4d20a788d1a879b73c3810952c9d0fd128d01cb3f22042c09e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
PR to upgrade `@tanstack/react-query` to v5, which is compatible with React 18(https://github.com/ManageIQ/manageiq-ui-classic/pull/10147). Also replaces the existing loading state with [React Suspense](https://react.dev/reference/react/Suspense#suspense) by using [useSuspenseQuery](https://tanstack.com/query/v5/docs/framework/react/reference/useSuspenseQuery)

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
