### PR TITLE
Use a shared core method for copying objects

### DIFF
--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -686,7 +686,7 @@ module ApplicationController::Performance
     end
     rpts = [rpt]
     if perf_parent? # Build the parent report, if asked for
-      p_rpt = Marshal.load(Marshal.dump(rpt)) # Deep clone the main report
+      p_rpt = copy_object(rpt)
       p_rpt.where_clause[1] = @perf_options[:parent]
       p_rpt.where_clause[2] = @perf_record.send(ApplicationHelper::VALID_PERF_PARENTS[@perf_options[:parent]]).id
       rpts.push(p_rpt)
@@ -1351,7 +1351,7 @@ module ApplicationController::Performance
   def perf_remove_report_cols(report, charts = nil)
     charts ||= @charts.first
     new_rpt = MiqReport.new(report.attributes) # Make a copy of the report
-    new_rpt.table = Marshal.load(Marshal.dump(report.table))
+    new_rpt.table = copy_object(report.table)
     keepcols = []
     keepcols += %w[timestamp statistic_time] unless @top_chart
     keepcols += ["resource_name"] if charts[:type].include?("Pie")


### PR DESCRIPTION
Similar to https://github.com/ManageIQ/manageiq-ui-classic/pull/10173, this creates an intention-revealing method instead of calling Marshal.dump/load directly. We already have similar methods in core for copy_array and copy_hash, so this extends the methods to copy_object as well.

@jrafanie Please review.

Co-dependent on:
- [x] https://github.com/ManageIQ/manageiq/pull/23929
