### PR TITLE
Use flushSync to avoid async rendering

### DIFF
--- a/app/javascript/miq-component/react-blueprint.jsx
+++ b/app/javascript/miq-component/react-blueprint.jsx
@@ -1,4 +1,5 @@
 import { createRoot } from 'react-dom/client';
+import { flushSync } from 'react-dom';
 import { Provider } from 'react-redux';
 
 export default (ReactElement, mapPropsToInteract = () => undefined) => {
@@ -10,11 +11,17 @@ export default (ReactElement, mapPropsToInteract = () => undefined) => {
       root = createRoot(container);
       roots.set(container, root);
     }
-    root.render(
-      <Provider store={ManageIQ.redux.store}>
-        <ReactElement {...props} />
-      </Provider>
-    );
+    // Currently, the async render vs layout calculation race condition has only been
+    // observed in HAML forms that embed React components (e.g. Edit Catalog Item).
+    // This flushSync wrapper ensures synchronous rendering as a compatibility workaround
+    // and can likely be removed once these types of forms are fully converted to React
+    flushSync(() => {
+      root.render(
+        <Provider store={ManageIQ.redux.store}>
+          <ReactElement {...props} />
+        </Provider>
+      );
+    });
   }
 
   return {

--- a/app/javascript/miq-component/react-blueprint.jsx
+++ b/app/javascript/miq-component/react-blueprint.jsx
@@ -44,4 +44,4 @@ export default (ReactElement, mapPropsToInteract = () => undefined) => {
 
     component: ReactElement,
   };
-}
+};


### PR DESCRIPTION
Follow-up to #10147

This PR fixes a race condition caused by React 18's asynchronous `root.render`, where layout height calculations ([miqInitMainContent](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/javascript/oldjs/miq_application.js#L1241)) could occur before React components (like `react-tree-view`) finished rendering inside HAML forms. The render is now wrapped in `flushSync` to ensure it completes before layout calculations (I don't see any problems with the other `root.render` calls)

### Before:
The footer is not displayed at first, but resizing the window makes it appear since [miqInitMainContent is triggered on resize](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/javascript/oldjs/miq_application.js#L1410):
<img width="3356" height="1838" alt="image" src="https://github.com/user-attachments/assets/75a7c7ef-cdad-4026-82fe-c4582dd315e3" />

### After:
The footer will be be visible initially:
<img width="2960" height="1612" alt="image" src="https://github.com/user-attachments/assets/f73fb2b8-f275-467c-b7ee-2c6fc45210e9" />


<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
