### PR TITLE
Fix browser back/forward button

### DIFF
--- a/app/javascript/miq-redux/actions/notifications-actions.js
+++ b/app/javascript/miq-redux/actions/notifications-actions.js
@@ -18,7 +18,14 @@ export const initNotifications = (useLimit) => (dispatch) => {
         notifications,
         count: subcount,
       },
-    }));
+    }))
+    .catch((error) => {
+      console.error('Failed to load notifications:', error);
+      dispatch({
+        type: INIT_NOTIFICATIONS,
+        payload: { notifications: [], count: 0 },
+      });
+    });
 };
 
 export const addNotification = (notification) => (dispatch) => {

--- a/app/javascript/notifications/init.js
+++ b/app/javascript/notifications/init.js
@@ -4,6 +4,15 @@ import { API } from '../http_api';
 import { addNotification, initNotifications } from '../miq-redux/actions/notifications-actions';
 
 let cable;
+let intentionalDisconnect = false;
+
+const disconnectCable = () => {
+  if (cable) {
+    intentionalDisconnect = true;
+    cable.disconnect();
+    cable = undefined;
+  }
+};
 
 const init = () => {
   ManageIQ.redux.store.dispatch(initNotifications(true));
@@ -14,16 +23,21 @@ const init = () => {
 
   // Disconnect any existing consumer before creating a new one so repeated
   // calls (e.g. pageshow after bfcache restore) don't leak WebSockets.
-  if (cable) {
-    cable.disconnect();
-    cable = undefined;
-  }
+  // intentionalDisconnect is left true here; the disconnected callback will
+  // clear it once the WebSocket onclose fires asynchronously.
+  disconnectCable();
 
   // Connect to the actioncable server
   cable = ActionCable.createConsumer('/ws/notifications');
 
   cable.subscriptions.create('NotificationChannel', {
     disconnected: () => {
+      // Skip ws_init when we deliberately disconnected (pagehide / reconnect).
+      // Only refresh the token when the server drops the connection unexpectedly.
+      if (intentionalDisconnect) {
+        intentionalDisconnect = false;
+        return;
+      }
       API.ws_init().then(null, () => {
         // Do not try to reconnect if the server disconnects
         console.warn('Unable to retrieve a valid ws_token!');
@@ -41,10 +55,7 @@ const init = () => {
 // is allowed to put it into the Back-Forward Cache (bfcache).  An open
 // WebSocket blocks bfcache, causing the back button to trigger a full reload.
 window.addEventListener('pagehide', () => {
-  if (cable) {
-    cable.disconnect();
-    cable = undefined;
-  }
+  disconnectCable();
 });
 
 // When the page is restored from bfcache, force the spinner off (it may have

--- a/app/javascript/notifications/init.js
+++ b/app/javascript/notifications/init.js
@@ -3,27 +3,52 @@ import * as ActionCable from '@rails/actioncable';
 import { API } from '../http_api';
 import { addNotification, initNotifications } from '../miq-redux/actions/notifications-actions';
 
+let cable;
+
 const init = () => {
   ManageIQ.redux.store.dispatch(initNotifications(true));
 
-  if (ManageIQ.asynchronous_notifications) {
-    // Connect to the actioncable server
-    const cable = ActionCable.createConsumer('/ws/notifications');
-
-    cable.subscriptions.create('NotificationChannel', {
-      disconnected: () => {
-        API.ws_init().then(null, () => {
-          console.warn('Unable to retrieve a valid ws_token!');
-          // Do not try to reconnect if the server disconnects
-          cable.connection.close({ allowReconnect: false });
-        });
-      },
-      received: (data) => {
-        // Pass the data further to the redux store
-        ManageIQ.redux.store.dispatch(addNotification(data));
-      },
-    });
+  if (!ManageIQ.asynchronous_notifications) {
+    return;
   }
+
+  // Connect to the actioncable server
+  cable = ActionCable.createConsumer('/ws/notifications');
+
+  cable.subscriptions.create('NotificationChannel', {
+    disconnected: () => {
+      API.ws_init().then(null, () => {
+        // Do not try to reconnect if the server disconnects
+        cable.connection.close({ allowReconnect: false });
+      });
+    },
+    received: (data) => {
+      // Pass the data further to the redux store
+      ManageIQ.redux.store.dispatch(addNotification(data));
+    },
+  });
 };
+
+// Disconnect the ActionCable consumer when the page is hidden so the browser
+// is allowed to put it into the Back-Forward Cache (bfcache).  An open
+// WebSocket blocks bfcache, causing the back button to trigger a full reload.
+window.addEventListener('pagehide', () => {
+  if (cable) {
+    cable.disconnect();
+    cable = undefined;
+  }
+});
+
+// When the page is restored from bfcache, force the spinner off (it may have
+// been left on by an in-flight XHR that was suspended when the page was cached)
+// and then re-open the ActionCable connection.
+window.addEventListener('pageshow', (event) => {
+  if (event.persisted) {
+    if (window.miqSparkleOff) {
+      window.miqSparkleOff();
+    }
+    init();
+  }
+});
 
 export default init;

--- a/app/javascript/notifications/init.js
+++ b/app/javascript/notifications/init.js
@@ -12,6 +12,13 @@ const init = () => {
     return;
   }
 
+  // Disconnect any existing consumer before creating a new one so repeated
+  // calls (e.g. pageshow after bfcache restore) don't leak WebSockets.
+  if (cable) {
+    cable.disconnect();
+    cable = undefined;
+  }
+
   // Connect to the actioncable server
   cable = ActionCable.createConsumer('/ws/notifications');
 
@@ -19,6 +26,7 @@ const init = () => {
     disconnected: () => {
       API.ws_init().then(null, () => {
         // Do not try to reconnect if the server disconnects
+        console.warn('Unable to retrieve a valid ws_token!');
         cable.connection.close({ allowReconnect: false });
       });
     },


### PR DESCRIPTION
This may have been broken by this PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/9753
Fixes a bug where the browser back button leads to page being stuck loading.

Before:
On any page when you click the browser back button it leads to the page being stuck loading.
<img width="935" height="389" alt="Screenshot 2026-07-24 at 4 34 29 PM" src="https://github.com/user-attachments/assets/d9ec85fb-7b35-4047-b7f2-1f2c7d173c24" />

After:
When you click back the page loads now.
<img width="935" height="383" alt="Screenshot 2026-07-24 at 4 34 44 PM" src="https://github.com/user-attachments/assets/e4c2e535-2c5b-4f03-8138-519cc1c9369a" />
