### PR TITLE
Drop Capybara matchers from specs

### DIFF
--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'capybara/rspec'
-
 describe VmInfraController do
   let(:host_1x1)  { FactoryBot.create(:host_vmware_esx, :hardware => FactoryBot.create(:hardware, :cpu1x1, :ram1GB)) }
   let(:host_2x2)  { FactoryBot.create(:host_vmware_esx, :hardware => FactoryBot.create(:hardware, :cpu2x2, :ram1GB)) }

--- a/spec/support/custom_matchers/have_selector.rb
+++ b/spec/support/custom_matchers/have_selector.rb
@@ -1,0 +1,84 @@
+require "nokogiri"
+
+# Nokogiri-based replacements for Capybara's have_selector, have_text,
+# have_xpath, and have_link matchers.  These operate on plain HTML strings
+# (the value of `rendered` or `response.body` in view/controller specs).
+
+def parse_html(fragment)
+  Nokogiri::HTML(fragment.to_s)
+end
+
+RSpec::Matchers.define :have_selector do |selector, options = {}|
+  match do |html|
+    doc = parse_html(html)
+    nodes = doc.css(selector)
+    if options[:text]
+      text_filter = options[:text]
+      nodes = nodes.select { |n| n.text.include?(text_filter.to_s) }
+    end
+    nodes.any?
+  end
+
+  failure_message do |html|
+    "expected to find CSS selector #{selector.inspect}#{" with text #{options[:text].inspect}" if options[:text]} in:\n#{html}"
+  end
+
+  failure_message_when_negated do |html|
+    "expected not to find CSS selector #{selector.inspect}#{" with text #{options[:text].inspect}" if options[:text]} in:\n#{html}"
+  end
+end
+
+RSpec::Matchers.define :have_text do |text|
+  match do |html|
+    parse_html(html).text.include?(text.to_s)
+  end
+
+  failure_message do |html|
+    "expected to find text #{text.inspect} in:\n#{html}"
+  end
+
+  failure_message_when_negated do |html|
+    "expected not to find text #{text.inspect} in:\n#{html}"
+  end
+end
+
+RSpec::Matchers.define :have_xpath do |xpath, options = {}|
+  match do |html|
+    doc = parse_html(html)
+    nodes = doc.xpath(xpath)
+    if options[:text]
+      text_filter = options[:text]
+      nodes = nodes.select do |n|
+        if text_filter.kind_of?(Regexp)
+          n.text.match?(text_filter)
+        else
+          n.text.include?(text_filter.to_s)
+        end
+      end
+    end
+    nodes.any?
+  end
+
+  failure_message do |html|
+    "expected to find XPath #{xpath.inspect}#{" with text #{options[:text].inspect}" if options[:text]} in:\n#{html}"
+  end
+
+  failure_message_when_negated do |html|
+    "expected not to find XPath #{xpath.inspect}#{" with text #{options[:text].inspect}" if options[:text]} in:\n#{html}"
+  end
+end
+
+RSpec::Matchers.define :have_link do |text|
+  match do |html|
+    doc = parse_html(html)
+    doc.css("a").any? { |n| n.text.include?(text.to_s) }
+  end
+
+  failure_message do |html|
+    "expected to find a link with text #{text.inspect} in:\n#{html}"
+  end
+
+  failure_message_when_negated do |html|
+    "expected not to find a link with text #{text.inspect} in:\n#{html}"
+  end
+end

--- a/spec/views/dashboard/login.html.haml_spec.rb
+++ b/spec/views/dashboard/login.html.haml_spec.rb
@@ -9,18 +9,20 @@ describe "dashboard/login.html.haml" do
 
     it "when authentication is 'database'" do
       render :template => "dashboard/login"
-      expect(response).to have_selector("form#login_div:has(input#browser_name)")
-      expect(response).to have_selector("form#login_div:has(input#browser_version)")
-      expect(response).to have_selector("form#login_div:has(input#browser_os)")
-      expect(response).to have_selector("form#login_div:has(input#user_TZO)")
+      expect(rendered).to have_selector("form#login_div")
+      expect(rendered).to have_selector("input#browser_name")
+      expect(rendered).to have_selector("input#browser_version")
+      expect(rendered).to have_selector("input#browser_os")
+      expect(rendered).to have_selector("input#user_TZO")
     end
 
     it "when authentication is not 'database'" do
       render :template => "dashboard/login"
-      expect(response).to have_selector("form#login_div:has(input#browser_name)")
-      expect(response).to have_selector("form#login_div:has(input#browser_version)")
-      expect(response).to have_selector("form#login_div:has(input#browser_os)")
-      expect(response).to have_selector("form#login_div:has(input#user_TZO)")
+      expect(rendered).to have_selector("form#login_div")
+      expect(rendered).to have_selector("input#browser_name")
+      expect(rendered).to have_selector("input#browser_version")
+      expect(rendered).to have_selector("input#browser_os")
+      expect(rendered).to have_selector("input#user_TZO")
     end
   end
 
@@ -35,7 +37,7 @@ describe "dashboard/login.html.haml" do
       stub_settings(:server => {}, :session => {:show_login_info => true}, :authentication => {})
       render :template => "dashboard/login"
       labels.each do |label|
-        expect(response).to have_selector('p', :text => label)
+        expect(rendered).to have_selector('p', :text => label)
       end
     end
 
@@ -43,7 +45,7 @@ describe "dashboard/login.html.haml" do
       stub_settings(:server => {}, :session => {:show_login_info => false}, :authentication => {})
       render :template => "dashboard/login"
       labels.each do |label|
-        expect(response).not_to have_selector('p', :text => label)
+        expect(rendered).not_to have_selector('p', :text => label)
       end
     end
   end

--- a/spec/views/layouts/_item.html.haml_spec.rb
+++ b/spec/views/layouts/_item.html.haml_spec.rb
@@ -7,14 +7,14 @@ describe "layouts/_item.html.haml" do
     assign(:lastaction, 'filesystems')
     render :template => "layouts/_item"
 
-    expect(response).to have_selector('label', :text => 'Name')
-    expect(response).to have_selector('label', :text => 'File Name')
-    expect(response).to have_selector('label', :text => 'File Version')
-    expect(response).to have_selector('label', :text => 'Size')
-    expect(response).to have_selector('label', :text => 'Contents Available')
-    expect(response).to have_selector('label', :text => 'Permissions')
-    expect(response).to have_selector('label', :text => 'Collected On')
-    expect(response).to have_selector('label', :text => 'Contents')
-    expect(response).to have_selector('a', :text => 'Download')
+    expect(rendered).to have_selector('label', :text => 'Name')
+    expect(rendered).to have_selector('label', :text => 'File Name')
+    expect(rendered).to have_selector('label', :text => 'File Version')
+    expect(rendered).to have_selector('label', :text => 'Size')
+    expect(rendered).to have_selector('label', :text => 'Contents Available')
+    expect(rendered).to have_selector('label', :text => 'Permissions')
+    expect(rendered).to have_selector('label', :text => 'Collected On')
+    expect(rendered).to have_selector('label', :text => 'Contents')
+    expect(rendered).to have_selector('a', :text => 'Download')
   end
 end

--- a/spec/views/miq_ae_class/_class_fields.html.haml_spec.rb
+++ b/spec/views/miq_ae_class/_class_fields.html.haml_spec.rb
@@ -18,8 +18,8 @@ describe "miq_ae_class/_class_fields.html.haml" do
 
     it "Check instance", :js => true do
       render :template => "miq_ae_class/_class_fields"
-      expect(response).to have_text('ae_var1')
-      expect(response).to have_text('Wilma')
+      expect(rendered).to have_text('ae_var1')
+      expect(rendered).to have_text('Wilma')
     end
   end
 

--- a/spec/views/miq_ae_class/_instance_fields.html.haml_spec.rb
+++ b/spec/views/miq_ae_class/_instance_fields.html.haml_spec.rb
@@ -17,8 +17,8 @@ describe "miq_ae_class/_instance_fields.html.haml" do
 
     it "Check instance", :js => true do
       render :template => "miq_ae_class/_instance_fields"
-      expect(response).to have_text('ae_var1')
-      expect(response).to have_text('hello world')
+      expect(rendered).to have_text('ae_var1')
+      expect(rendered).to have_text('hello world')
     end
   end
 end

--- a/spec/views/miq_ae_class/_method_inputs.html.haml_spec.rb
+++ b/spec/views/miq_ae_class/_method_inputs.html.haml_spec.rb
@@ -21,8 +21,8 @@ describe "miq_ae_class/_method_inputs.html.haml" do
 
     it "Check inputs", :js => true do
       render :template => "miq_ae_class/_method_inputs"
-      expect(response).to have_text('ae_result')
-      expect(response).to have_text('ae_next_state')
+      expect(rendered).to have_text('ae_result')
+      expect(rendered).to have_text('ae_next_state')
     end
   end
 end

--- a/spec/views/report/_db_widget_remove.html.haml_spec.rb
+++ b/spec/views/report/_db_widget_remove.html.haml_spec.rb
@@ -8,7 +8,7 @@ describe "report/_db_widget_remove.html.haml" do
     widget = FactoryBot.create(:miq_widget)
     render :partial => "report/db_widget_remove",
            :locals  => {:widget => widget}
-    expect(response).to have_selector('a.pull-right')
-    expect(response).to have_selector('i.fa.fa-remove')
+    expect(rendered).to have_selector('a.pull-right')
+    expect(rendered).to have_selector('i.fa.fa-remove')
   end
 end

--- a/spec/views/report/_report_list.html.haml_spec.rb
+++ b/spec/views/report/_report_list.html.haml_spec.rb
@@ -28,7 +28,7 @@ describe "report/_report_list.html.haml" do
 
     it 'Check if report list is present' do
       render :template => "report/_report_list"
-      expect(response).to have_selector("//div[@id=\"report_list_div\"]")
+      expect(rendered).to have_xpath("//div[@id='report_list_div']")
     end
   end
 end

--- a/spec/views/report/_widget_form_menu.html.haml_spec.rb
+++ b/spec/views/report/_widget_form_menu.html.haml_spec.rb
@@ -7,6 +7,6 @@ describe "report/_widget_form_menu.html.haml" do
 
   it "correctly renders patternfly classes" do
     render :template => "report/_widget_form_menu"
-    expect(response).to have_selector('a.fa.fa-close.pull-right')
+    expect(rendered).to have_selector('a.fa.fa-close.pull-right')
   end
 end

--- a/spec/views/utilization/_utilization_options.html.haml_spec.rb
+++ b/spec/views/utilization/_utilization_options.html.haml_spec.rb
@@ -13,10 +13,10 @@ describe "utilization/_utilization_options.html.haml" do
            :locals  => {:cap_type => nil}
   end
   it "check if correct fields are being displayed if cap_type is set" do
-    expect(response).not_to have_selector('label', :text => 'Selected Day')
+    expect(rendered).not_to have_selector('label', :text => 'Selected Day')
     # render with cap_type variable set
     render :partial => "utilization/utilization_options",
            :locals  => {:cap_type => "summ"}
-    expect(response).to have_selector('label', :text => 'Selected Day')
+    expect(rendered).to have_selector('label', :text => 'Selected Day')
   end
 end


### PR DESCRIPTION
Replace Capybara's have_selector, have_text, have_xpath, and have_link
matchers with Nokogiri-based equivalents in
spec/support/custom_matchers/have_selector.rb.  Capybara is being
removed as a dependency from the core ManageIQ repository. (https://github.com/ManageIQ/manageiq/pull/23933)

The new matchers operate on plain HTML strings (rendered, response.body,
or any helper return value) using Nokogiri::HTML for CSS/XPath queries.
have_selector and have_xpath both support an optional :text filter
(string or Regexp).

Also fix view specs that were incorrectly using response instead of
rendered: response is an ActionDispatch::Response object and does not
expose the rendered HTML string in view specs.

Additional fixups:
- _report_list spec: have_selector with an XPath string converted to
  have_xpath
- login spec: form#login_div:has(input#X) pseudo-selector (unsupported
  by Nokogiri) split into two separate have_selector assertions

@GilbertCherrie @jrafanie Please review.
