### PR TITLE
Add shutdown guest support

### DIFF
--- a/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
+++ b/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
@@ -24,7 +24,10 @@ module ApplicationHelper::Toolbar::Cloud::InstanceOperationsButtonGroupMixin
             :icon    => "fa fa-stop fa-lg",
             :confirm => N_("Shutdown Guest OS this Instance?"),
             :klass   => ApplicationHelper::Button::GenericFeatureButton,
-            :options => {:feature => :shutdown_guest}),
+            :options => {
+              :feature => :shutdown_guest
+            }
+            ),
           included_class.button(
             :instance_start,
             nil,

--- a/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
+++ b/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
@@ -24,7 +24,7 @@ module ApplicationHelper::Toolbar::Cloud::InstanceOperationsButtonGroupMixin
             :icon    => "fa fa-stop fa-lg",
             :confirm => N_("Shutdown Guest OS this Instance?"),
             :klass   => ApplicationHelper::Button::GenericFeatureButton,
-            :options => {:feature => :shutdown_guest}),  
+            :options => {:feature => :shutdown_guest}),
           included_class.button(
             :instance_start,
             nil,

--- a/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
+++ b/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
@@ -22,7 +22,7 @@ module ApplicationHelper::Toolbar::Cloud::InstanceOperationsButtonGroupMixin
             N_('Shutdown Guest OS this Instance'),
             N_('Shutdown Guest'),
             :icon    => "fa fa-stop fa-lg",
-            :confirm => N_("Shutdown Guest OS this Instance?"),
+            :confirm => N_("Shutdown Guest OS on this Instance?"),
             :klass   => ApplicationHelper::Button::GenericFeatureButton,
             :options => {
               :feature => :shutdown_guest

--- a/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
+++ b/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
@@ -27,7 +27,7 @@ module ApplicationHelper::Toolbar::Cloud::InstanceOperationsButtonGroupMixin
             :options => {
               :feature => :shutdown_guest
             }
-            ),
+          ),
           included_class.button(
             :instance_start,
             nil,

--- a/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
+++ b/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
@@ -19,7 +19,7 @@ module ApplicationHelper::Toolbar::Cloud::InstanceOperationsButtonGroupMixin
           included_class.button(
             :vm_guest_shutdown,
             nil,
-            N_('Shutdown Guest OS this Instance'),
+            N_('Shutdown Guest OS on this Instance'),
             N_('Shutdown Guest'),
             :icon    => "fa fa-power-off fa-lg",
             :confirm => N_("Shutdown Guest OS on this Instance?"),

--- a/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
+++ b/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
@@ -21,7 +21,7 @@ module ApplicationHelper::Toolbar::Cloud::InstanceOperationsButtonGroupMixin
             nil,
             N_('Shutdown Guest OS this Instance'),
             N_('Shutdown Guest'),
-            :icon    => "fa fa-stop fa-lg",
+            :icon    => "fa fa-power-off fa-lg",
             :confirm => N_("Shutdown Guest OS on this Instance?"),
             :klass   => ApplicationHelper::Button::GenericFeatureButton,
             :options => {

--- a/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
+++ b/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
@@ -17,6 +17,15 @@ module ApplicationHelper::Toolbar::Cloud::InstanceOperationsButtonGroupMixin
             :klass   => ApplicationHelper::Button::GenericFeatureButton,
             :options => {:feature => :stop}),
           included_class.button(
+            :vm_guest_shutdown,
+            nil,
+            N_('Shutdown Guest OS this Instance'),
+            N_('Shutdown Guest'),
+            :icon    => "fa fa-stop fa-lg",
+            :confirm => N_("Shutdown Guest OS this Instance?"),
+            :klass   => ApplicationHelper::Button::GenericFeatureButton,
+            :options => {:feature => :shutdown_guest}),  
+          included_class.button(
             :instance_start,
             nil,
             N_('Start this Instance'),

--- a/app/helpers/application_helper/toolbar/vm_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_clouds_center.rb
@@ -212,7 +212,8 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           :send_checked => true,
           :confirm      => N_("Shutdown Guest OS the selected items?"),
           :enabled      => false,
-          :onwhen       => "1+"),
+          :onwhen       => "1+"
+          ),
         button(
           :instance_start,
           nil,

--- a/app/helpers/application_helper/toolbar/vm_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_clouds_center.rb
@@ -210,7 +210,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           :icon         => "fa fa-stop fa-lg",
           :url_parms    => "main_div",
           :send_checked => true,
-          :confirm      => N_("Shutdown Guest OS the selected items?"),
+          :confirm      => N_("Shutdown Guest OS on the selected items?"),
           :enabled      => false,
           :onwhen       => "1+"
         ),

--- a/app/helpers/application_helper/toolbar/vm_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_clouds_center.rb
@@ -203,18 +203,6 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           :enabled      => false,
           :onwhen       => "1+"),
         button(
-          :vm_guest_shutdown,
-          nil,
-          N_('Shutdown Guest OS the selected items'),
-          N_('Shutdown Guest OS'),
-          :icon         => "fa fa-stop fa-lg",
-          :url_parms    => "main_div",
-          :send_checked => true,
-          :confirm      => N_("Shutdown Guest OS on the selected items?"),
-          :enabled      => false,
-          :onwhen       => "1+"
-        ),
-        button(
           :instance_start,
           nil,
           N_('Start the selected items'),
@@ -270,6 +258,18 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           :enabled      => false,
           :onwhen       => "1+"),
         separator,
+        button(
+          :vm_guest_shutdown,
+          nil,
+          N_('Shutdown Guest OS the selected items'),
+          N_('Shutdown Guest OS'),
+          :icon         => "fa fa-stop fa-lg",
+          :url_parms    => "main_div",
+          :send_checked => true,
+          :confirm      => N_("Shutdown Guest OS on the selected items?"),
+          :enabled      => false,
+          :onwhen       => "1+"
+        ),
         button(
           :instance_guest_restart,
           nil,

--- a/app/helpers/application_helper/toolbar/vm_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_clouds_center.rb
@@ -263,7 +263,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           nil,
           N_('Shutdown Guest OS the selected items'),
           N_('Shutdown Guest OS'),
-          :icon         => "fa fa-stop fa-lg",
+          :icon         => "fa fa-power-off fa-lg",
           :url_parms    => "main_div",
           :send_checked => true,
           :confirm      => N_("Shutdown Guest OS on the selected items?"),

--- a/app/helpers/application_helper/toolbar/vm_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_clouds_center.rb
@@ -212,7 +212,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           :send_checked => true,
           :confirm      => N_("Shutdown Guest OS the selected items?"),
           :enabled      => false,
-          :onwhen       => "1+"),   
+          :onwhen       => "1+"),
         button(
           :instance_start,
           nil,

--- a/app/helpers/application_helper/toolbar/vm_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_clouds_center.rb
@@ -261,7 +261,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
         button(
           :vm_guest_shutdown,
           nil,
-          N_('Shutdown Guest OS the selected items'),
+          N_('Shutdown Guest OS on the selected items'),
           N_('Shutdown Guest OS'),
           :icon         => "fa fa-power-off fa-lg",
           :url_parms    => "main_div",

--- a/app/helpers/application_helper/toolbar/vm_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_clouds_center.rb
@@ -203,6 +203,17 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           :enabled      => false,
           :onwhen       => "1+"),
         button(
+          :vm_guest_shutdown,
+          nil,
+          N_('Shutdown Guest OS the selected items'),
+          N_('Shutdown Guest OS'),
+          :icon         => "fa fa-stop fa-lg",
+          :url_parms    => "main_div",
+          :send_checked => true,
+          :confirm      => N_("Shutdown Guest OS the selected items?"),
+          :enabled      => false,
+          :onwhen       => "1+"),   
+        button(
           :instance_start,
           nil,
           N_('Start the selected items'),

--- a/app/helpers/application_helper/toolbar/vm_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_clouds_center.rb
@@ -213,7 +213,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           :confirm      => N_("Shutdown Guest OS the selected items?"),
           :enabled      => false,
           :onwhen       => "1+"
-          ),
+        ),
         button(
           :instance_start,
           nil,


### PR DESCRIPTION
## Summary

This change adds the Shutdown Guest action to the VM actions menu in the UI.
With this update, users can initiate a guest shutdown directly from the VM screen.

## Changes Made

- Added the Shutdown Guest action in the VM actions menu
- Enabled users to trigger the action from the UI