### PR TITLE
Fix vm link on services subtable

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -185,7 +185,12 @@ module VmCommon
         action               = url[4]
       end
 
-      redirect_to(:controller => redirect_controller, :action => action)
+      # Include the tree node id in the URL so each VM navigates to a unique URL.
+      # Without this, Firefox serves a stale cache page because every redirect
+      # lands on the same /explorer URL regardless of which VM was clicked.
+      redirect_params = {:controller => redirect_controller, :action => action}
+      redirect_params[:id] = tree_node_id if action == "explorer"
+      redirect_to(redirect_params)
       return
     end
 


### PR DESCRIPTION
Fixes: #9252

Fixes an issue where the VM page summary page was being cached on Firefox. This meant that when you were trying to visit a VM summary page by a link, such as through the Services VM table, it visited URLs like http:/localhost:3000/vm_infra/show/1, which the UI was redirecting to http:/localhost:3000/vm_infra/explorer. Firefox was caching this page and because the URL wasn't changing it assumed you were viewing the same VM regardless of whether the ID was changed or not. This PR makes the explorer visit the URL http:/localhost:3000/vm_infra/explorer/v-1, which tells Firefox that it is visiting a new VM each time and rendering the correct VM summary page for each VM.