### PR TITLE
Fix error modal z-index

### DIFF
--- a/app/stylesheet/miq-error-modal.scss
+++ b/app/stylesheet/miq-error-modal.scss
@@ -1,4 +1,7 @@
 .miq-error-modal {
+  // Ensure error modal always appears on top of other modals
+  z-index: 20001;
+
   .cds--modal-container {
     max-inline-size: 64rem;
   }


### PR DESCRIPTION
Follow-up to https://github.com/ManageIQ/manageiq-ui-classic/pull/9650

**Before:** when an error occurs from a modal, the error modal gets rendered behind the original modal
<img width="2912" height="1436" alt="image" src="https://github.com/user-attachments/assets/3848026f-c47a-4c35-bc02-3a67f0f7ed0f" />

**After:**
<img width="3330" height="1292" alt="image" src="https://github.com/user-attachments/assets/70cca809-07c4-4f6e-8eb7-df811b37ee18" />


<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
