### PR TITLE
Improve cypress reports test stability

### DIFF
--- a/cypress/e2e/ui/Overview/reports.cy.js
+++ b/cypress/e2e/ui/Overview/reports.cy.js
@@ -1,4 +1,4 @@
-import { flashClassMap } from "../../../support/assertions/assertion_constants";
+import { flashClassMap } from '../../../support/assertions/assertion_constants';
 
 describe('Overview > Reports Tests', () => {
   beforeEach(() => {
@@ -20,8 +20,6 @@ describe('Overview > Reports Tests', () => {
       cy.accordion('Reports');
       cy.expect_explorer_title('All Reports');
       cy.get('.miq-data-table.report-list').should('be.visible');
-      // FIXME: to be fixed by enhancing the toolbar command
-      cy.wait(2000);
 
       // Click add report
       cy.toolbar('Configuration', 'Add a new Report');
@@ -39,47 +37,75 @@ describe('Overview > Reports Tests', () => {
       let tableName = '';
 
       cy.get('.btn[data-id="chosen_model"]').click({ force: true });
-      cy.get('.btn[data-id="chosen_model"] ~ .dropdown-menu [data-original-index="1"] > a').then((option) => {
+      cy.get(
+        '.btn[data-id="chosen_model"] ~ .dropdown-menu [data-original-index="1"] > a'
+      ).then((option) => {
         cy.get(option).click({ force: true });
         basedOn = option[0].innerText;
         tableName = basedOn.substring(0, basedOn.length - 1).replace(' ', '');
       });
       cy.get('.btn[data-id="available_fields"]').click({ force: true });
-      cy.get('.btn[data-id="available_fields"] ~ .dropdown-menu [data-original-index="0"] > a > .text').then((option) => {
+      cy.get(
+        '.btn[data-id="available_fields"] ~ .dropdown-menu [data-original-index="0"] > a > .text'
+      ).then((option) => {
         cy.get(option).click({ force: true });
         columns.push(option[0].innerText.trim());
       });
-      cy.get('.btn[data-id="available_fields"] ~ .dropdown-menu [data-original-index="1"] > a > .text').then((option) => {
+      cy.get(
+        '.btn[data-id="available_fields"] ~ .dropdown-menu [data-original-index="1"] > a > .text'
+      ).then((option) => {
         cy.get(option).click({ force: true });
         columns.push(option[0].innerText.trim());
       });
-      cy.get('.btn[data-id="available_fields"]').click({ force: true});
-      cy.intercept('/report/form_field_changed/new?button=right').as('fieldsChanged');
-      cy.get('[alt="Move selected fields down"]').click({force: true});
+      cy.get('.btn[data-id="available_fields"]').click({ force: true });
+      // intercepts for tab changes
+      cy.intercept('POST', '/report/change_tab/edit_*?tab=edit_*').as(
+        'tabChange'
+      );
+      cy.intercept('GET', '/report/miq_report_edit?tab=edit_*').as('tabLoad');
+
+      cy.intercept('/report/form_field_changed/new?button=right').as(
+        'fieldsChanged'
+      );
+      cy.get('[alt="Move selected fields down"]').click({ force: true });
       cy.wait('@fieldsChanged').then(() => {
-      // Verify all report page tabs load correctly
+        // Verify all report page tabs load correctly
         cy.get('#Consolidation_tab > a').click({ force: true });
-        cy.get('#consolidate_div > h3').contains('Group Records by up to 3 Columns');
+        cy.wait(['@tabChange', '@tabLoad']);
+        cy.get('#consolidate_div > h3').contains(
+          'Group Records by up to 3 Columns'
+        );
         cy.get('#Formatting_tab > a').click({ force: true });
+        cy.wait(['@tabChange', '@tabLoad']);
         cy.get('#formatting_div > h3').contains('PDF Output');
         cy.get('#Styling_tab > a').click({ force: true });
+        cy.wait(['@tabChange', '@tabLoad']);
         cy.get('#styling_div > h3').contains('Specify Column Styles');
         cy.get('#Filter_tab > a').click({ force: true });
-        cy.get('#filter_div > h3').contains(`Primary (Record) Filter - Filters the ${tableName} table records`);
+        cy.wait(['@tabChange', '@tabLoad']);
+        cy.get('#filter_div > h3').contains(
+          `Primary (Record) Filter - Filters the ${tableName} table records`
+        );
       });
 
       // Set chart type and make sure chart loads correctly
       let sortBy = '';
       let chartType = '';
       cy.get('#Summary_tab > a').click({ force: true });
+      cy.wait(['@tabChange', '@tabLoad']);
       cy.get('#sort_div .btn').click({ force: true });
-      cy.get('#sort_div .btn ~ .dropdown-menu [data-original-index="1"] > a').then((option) => {
+      cy.get(
+        '#sort_div .btn ~ .dropdown-menu [data-original-index="1"] > a'
+      ).then((option) => {
         cy.get(option).click({ force: true });
         sortBy = option[0].innerText;
       });
       cy.get('#Charts_tab > a').click({ force: true });
+      cy.wait(['@tabChange', '@tabLoad']);
       cy.get('#chart_div .btn').click({ force: true });
-      cy.get('#chart_div .btn ~ .dropdown-menu [data-original-index="1"] > a').then((option) => {
+      cy.get(
+        '#chart_div .btn ~ .dropdown-menu [data-original-index="1"] > a'
+      ).then((option) => {
         cy.get(option).click({ force: true });
         chartType = option[0].innerText;
       });
@@ -87,10 +113,11 @@ describe('Overview > Reports Tests', () => {
 
       // Load report preview and verify column values
       cy.get('#Preview_tab > a').click({ force: true });
+      cy.wait(['@tabChange', '@tabLoad']);
       cy.get('#form_preview a').click({ force: true });
       cy.get('#form_preview h3').contains('Chart Preview (up to 50 rows)');
       cy.get('#form_preview h3').contains('Report Preview (up to 50 rows)');
-      cy.get('#form_preview table th').then((result) => {
+      cy.get('#form_preview table th').should((result) => {
         expect(result[0].innerText).to.eq(columns[0]);
         expect(result[1].innerText).to.eq(columns[1]);
       });
@@ -104,18 +131,34 @@ describe('Overview > Reports Tests', () => {
       cy.expect_show_list_title('My Company (All Groups) Reports');
       cy.get('.clickable-row').contains('Custom').click({ force: true });
       cy.expect_show_list_title('Custom Reports');
-      cy.get('.list-group-item').contains('Cypress Test Report').click();
+      cy.selectAccordionItem(
+        ['All Reports', /^My Company/, 'Custom', 'Cypress Test Report'],
+        {
+          onTreeSelectResponse: (res) => {
+            // Verify toolbar has been updated with Queue button
+            const reloadToolbars = res.response.body.reloadToolbars;
+            expect(reloadToolbars).to.not.be.undefined;
+            expect(reloadToolbars[0]).to.be.an('array');
+            const queueButton = reloadToolbars[0].find(
+              (btn) => btn.id === 'miq_report_run'
+            );
+            expect(queueButton).to.not.be.undefined;
+            expect(queueButton.enabled).to.be.true;
+          },
+        }
+      );
+      cy.expect_explorer_title('Report "');
+      cy.contains('#toolbar button#miq_report_run', 'Queue').scrollIntoView().should('exist');
 
       // Verify report was added with correct values on summary page
-      let tableHeaders = [];
-      let tableValues = [];
+      let tableHeaders;
+      let tableValues;
       let id;
-      cy.get('.label_header').then((headers) => {
-        const nums = [...Array(headers.length).keys()];
-        nums.forEach((index) => {
-          tableHeaders.push(headers[index].innerText);
+      cy.get('.label_header').should((headers) => {
+        tableHeaders = [];
+        headers.each((index, header) => {
+          tableHeaders.push(header.innerText);
         });
-      }).then(() => {
         expect(tableHeaders[0]).to.eq('ID');
         expect(tableHeaders[1]).to.eq('Title');
         expect(tableHeaders[2]).to.eq('Sort By');
@@ -126,128 +169,169 @@ describe('Overview > Reports Tests', () => {
         expect(tableHeaders[7]).to.eq('Updated On');
       });
 
-      cy.get('.content_value').then((values) => {
-        const nums = [...Array(values.length).keys()];
+      cy.get('.content_value').should((values) => {
+        tableValues = [];
         id = values[0].innerText;
-        nums.forEach((index) => {
-          tableValues.push(values[index].innerText);
+        values.each((index, value) => {
+          tableValues.push(value.innerText);
         });
-      }).then(() => {
         expect(tableValues[1]).to.eq('Cypress test report title');
         expect(tableValues[2]).to.eq(sortBy);
         expect(chartType).to.include(tableValues[3]);
         expect(basedOn).to.include(tableValues[4]);
         expect(tableValues[5]).to.eq('admin');
-      }).then(() => {
-        // Click edit report
-        cy.toolbar('Configuration', 'Edit this Report');
-        // Edit report information
-        cy.intercept(/\/report\/form_field_changed\/[0-9]+/).as('fieldsUpdated');
-        cy.get('#name').clear({ force: true }).type('Cypress Test Report Edit', { force: true });
-        cy.wait('@fieldsUpdated');
+      });
 
-        cy.get('#title').clear({ force: true }).type('Cypress test report title edit', { force: true });
-        cy.wait('@fieldsUpdated');
+      // Click edit report
+      cy.toolbar('Configuration', 'Edit this Report');
+      // Edit report information
+      cy.intercept(/\/report\/form_field_changed\/[0-9]+/).as('fieldsUpdated');
+      cy.get('#name')
+        .clear({ force: true })
+        .type('Cypress Test Report Edit', { force: true });
+      cy.wait('@fieldsUpdated');
 
-        cy.get('.btn[data-id="available_fields"]').click({ force: true });
-        cy.get('.btn[data-id="available_fields"] ~ .dropdown-menu [data-original-index="3"] > a > .text').then((option) => {
-          cy.get(option).click({ force: true });
-          columns.push(option[0].innerText.trim());
-        });
-        cy.get('.btn[data-id="available_fields"] > .filter-option').click({ force: true });
-        cy.intercept(`/report/form_field_changed/${id}?button=right`).as('fieldsChanged');
-        cy.get('.text-center > [alt="Move selected fields down"]').click({force: true});
-        cy.wait('@fieldsChanged');
+      cy.get('#title')
+        .clear({ force: true })
+        .type('Cypress test report title edit', { force: true });
+      cy.wait('@fieldsUpdated');
 
-        // Verify all report page tabs load correctly
-        cy.get('#Consolidation_tab > a').click({ force: true });
-        cy.get('#consolidate_div > h3').contains('Group Records by up to 3 Columns');
-        cy.get('#Formatting_tab > a').click({ force: true });
-        cy.get('#formatting_div > h3').contains('PDF Output');
-        cy.get('#Styling_tab > a').click({ force: true });
-        cy.get('#styling_div > h3').contains('Specify Column Styles');
-        cy.get('#Filter_tab > a').click({ force: true });
-        cy.get('#filter_div > h3').contains(`Primary (Record) Filter - Filters the ${tableName} table records`);
+      cy.get('.btn[data-id="available_fields"]').click({ force: true });
+      cy.get(
+        '.btn[data-id="available_fields"] ~ .dropdown-menu [data-original-index="3"] > a > .text'
+      ).then((option) => {
+        cy.get(option).click({ force: true });
+        columns.push(option[0].innerText.trim());
+      });
+      cy.get('.btn[data-id="available_fields"] > .filter-option').click({
+        force: true,
+      });
+      cy.get('.text-center > [alt="Move selected fields down"]').click({
+        force: true,
+      });
+      cy.wait('@fieldsUpdated');
 
-        // Edit report chart values and verify chart and report are correctly created
-        sortBy = '';
-        chartType = '';
-        cy.get('#Summary_tab > a').click({ force: true });
-        cy.get(':nth-child(2) > :nth-child(1) > .col-md-8 > .btn-group > .btn').click({ force: true });
-        cy.get(':nth-child(1) > .col-md-8 > .btn-group > .open > .dropdown-menu > [data-original-index="3"] > a').then((option) => {
-          cy.get(option).click({ force: true });
-          sortBy = option[0].innerText;
-        });
-        cy.get('#Charts_tab > a').click({ force: true });
-        cy.get('#chart_div').get(':nth-child(1) > .col-md-8 > .btn-group > .btn').click({ force: true });
-        cy.get(':nth-child(1) > .col-md-8 > .btn-group > .open > .dropdown-menu > [data-original-index="3"] > a').then((option) => {
-          cy.get(option).click({ force: true });
-          chartType = option[0].innerText;
-        });
-        cy.get('#chart_sample_div > fieldset');
+      // Verify all report page tabs load correctly
+      cy.get('#Consolidation_tab > a').click({ force: true });
+      cy.wait(['@tabChange', '@tabLoad']);
+      cy.get('#consolidate_div > h3').contains(
+        'Group Records by up to 3 Columns'
+      );
 
-        cy.get('#Preview_tab > a').click({ force: true });
-        cy.get('#form_preview > h3').get('a > .fa').click({ force: true });
-        cy.get('#form_preview').get('h3').contains('Chart Preview (up to 50 rows)');
-        cy.get('#form_preview').get('h3').contains('Report Preview (up to 50 rows)');
-        cy.get('#form_preview').get('th').then((result) => {
+      cy.get('#Formatting_tab > a').click({ force: true });
+      cy.wait(['@tabChange', '@tabLoad']);
+      cy.get('#formatting_div > h3').contains('PDF Output');
+
+      cy.get('#Styling_tab > a').click({ force: true });
+      cy.wait(['@tabChange', '@tabLoad']);
+      cy.get('#styling_div > h3').contains('Specify Column Styles');
+
+      cy.get('#Filter_tab > a').click({ force: true });
+      cy.wait(['@tabChange', '@tabLoad']);
+      cy.get('#filter_div > h3').should((h3) => {
+        expect(h3.text()).to.include(
+          `Primary (Record) Filter - Filters the ${tableName} table records`
+        );
+      });
+
+      // Edit report chart values and verify chart and report are correctly created
+      sortBy = '';
+      chartType = '';
+      cy.get('#Summary_tab > a').click({ force: true });
+      cy.wait(['@tabChange', '@tabLoad']);
+      cy.get(
+        ':nth-child(2) > :nth-child(1) > .col-md-8 > .btn-group > .btn'
+      ).click({ force: true });
+      cy.get(
+        ':nth-child(1) > .col-md-8 > .btn-group > .open > .dropdown-menu > [data-original-index="3"] > a'
+      ).then((option) => {
+        cy.get(option).click({ force: true });
+        sortBy = option[0].innerText;
+      });
+      cy.get('#Charts_tab > a').click({ force: true });
+      cy.wait(['@tabChange', '@tabLoad']);
+      cy.get('#chart_div')
+        .get(':nth-child(1) > .col-md-8 > .btn-group > .btn')
+        .click({ force: true });
+      cy.get(
+        ':nth-child(1) > .col-md-8 > .btn-group > .open > .dropdown-menu > [data-original-index="3"] > a'
+      ).then((option) => {
+        cy.get(option).click({ force: true });
+        chartType = option[0].innerText;
+      });
+      cy.get('#chart_sample_div > fieldset');
+
+      cy.get('#Preview_tab > a').click({ force: true });
+      cy.wait(['@tabChange', '@tabLoad']);
+      cy.get('#form_preview > h3').get('a > .fa').click({ force: true });
+      cy.get('#form_preview')
+        .get('h3')
+        .contains('Chart Preview (up to 50 rows)');
+      cy.get('#form_preview')
+        .get('h3')
+        .contains('Report Preview (up to 50 rows)');
+      cy.get('#form_preview')
+        .get('th')
+        .should((result) => {
           expect(result[0].innerText).to.eq(columns[0]);
           expect(result[1].innerText).to.eq(columns[1]);
           expect(result[2].innerText).to.eq(columns[2]);
         });
-        cy.get('#buttons_on > .btn-primary').click({ force: true }); // Click save button
-      }).then(() => {
-        cy.expect_flash(flashClassMap.success);
-        // Verify report was edited with correct values on summary page
-        tableHeaders = [];
-        tableValues = [];
-        cy.get('.list-group-item').contains('Cypress Test Report Edit').click();
-        cy.get('.label_header').then((headers) => {
-          const nums = [...Array(headers.length).keys()];
-          nums.forEach((index) => {
-            tableHeaders.push(headers[index].innerText);
-          });
-        }).then(() => {
-          expect(tableHeaders[0]).to.eq('ID');
-          expect(tableHeaders[1]).to.eq('Title');
-          expect(tableHeaders[2]).to.eq('Sort By');
-          expect(tableHeaders[3]).to.eq('Chart');
-          expect(tableHeaders[4]).to.eq('Based On');
-          expect(tableHeaders[5]).to.eq('User');
-          expect(tableHeaders[6]).to.eq('EVM Group');
-          expect(tableHeaders[7]).to.eq('Updated On');
-        });
 
-        cy.get('.content_value').then((values) => {
-          const nums = [...Array(values.length).keys()];
-          id = values[0].innerText;
-          nums.forEach((index) => {
-            tableValues.push(values[index].innerText);
-          });
-        }).then(() => {
-          expect(tableValues[0]).to.eq(`${id}`);
-          expect(tableValues[1]).to.eq('Cypress test report title edit');
-          expect(tableValues[2]).to.eq(sortBy);
-          expect(chartType).to.include(tableValues[3]);
-          expect(basedOn).to.include(tableValues[4]);
-          expect(tableValues[5]).to.eq('admin');
-        });
-
-        // Delete report
-        cy.interceptApi({
-          alias: 'deleteReport',
-          urlPattern: /\/report\/x_button\/[0-9]+\?pressed=miq_report_delete/,
-          triggerFn: () =>
-            cy.expect_browser_confirm_with_text({
-              confirmTriggerFn: () =>
-                cy.toolbar(
-                  'Configuration',
-                  'Delete this Report from the Database'
-                ),
-            }),
-        });
-        cy.expect_flash(flashClassMap.success);
+      cy.interceptApi({
+        alias: 'saveReport',
+        urlPattern: '/report/miq_report_edit/*?button=save',
+        triggerFn: () =>
+          cy.get('#buttons_on > .btn-primary').click({ force: true }),
       });
+      cy.expect_flash(flashClassMap.success);
+
+      // Verify report was edited with correct values on summary page
+      cy.get('.list-group-item').contains('Cypress Test Report Edit').click();
+      cy.get('.label_header').should((headers) => {
+        tableHeaders = [];
+        headers.each((index, header) => {
+          tableHeaders.push(header.innerText);
+        });
+
+        expect(tableHeaders[0]).to.eq('ID');
+        expect(tableHeaders[1]).to.eq('Title');
+        expect(tableHeaders[2]).to.eq('Sort By');
+        expect(tableHeaders[3]).to.eq('Chart');
+        expect(tableHeaders[4]).to.eq('Based On');
+        expect(tableHeaders[5]).to.eq('User');
+        expect(tableHeaders[6]).to.eq('EVM Group');
+        expect(tableHeaders[7]).to.eq('Updated On');
+      });
+
+      cy.get('.content_value').should((values) => {
+        tableValues = [];
+        id = values[0].innerText;
+        values.each((index, value) => {
+          tableValues.push(value.innerText);
+        });
+        expect(tableValues[0]).to.eq(`${id}`);
+        expect(tableValues[1]).to.eq('Cypress test report title edit');
+        expect(tableValues[2]).to.eq(sortBy);
+        expect(chartType).to.include(tableValues[3]);
+        expect(basedOn).to.include(tableValues[4]);
+        expect(tableValues[5]).to.eq('admin');
+      });
+
+      // Delete report
+      cy.interceptApi({
+        alias: 'deleteReport',
+        urlPattern: /\/report\/x_button\/[0-9]+\?pressed=miq_report_delete/,
+        triggerFn: () =>
+          cy.expect_browser_confirm_with_text({
+            confirmTriggerFn: () =>
+              cy.toolbar(
+                'Configuration',
+                'Delete this Report from the Database'
+              ),
+          }),
+      });
+      cy.expect_flash(flashClassMap.success);
     });
   });
 

--- a/cypress/support/commands/explorer.js
+++ b/cypress/support/commands/explorer.js
@@ -35,8 +35,10 @@ Cypress.Commands.add('accordionItem', (name) => {
  * For example, `[/^ManageIQ Region/, 'Zone', 'Server']`
  * will expand the accordion until it finds the item with the label 'Server' under 'Zone' under 'ManageIQ Region'.
  * If the path is not found, it will throw an error.
+ * @param {Object} options - Optional configuration object
+ * @param {Function} options.onTreeSelectResponse - Callback function invoked with tree select API response data
  */
-Cypress.Commands.add('selectAccordionItem', (accordionPath) => {
+Cypress.Commands.add('selectAccordionItem', (accordionPath, options = {}) => {
   cy.get('div.panel-collapse.collapse.in').then((accordionJqueryObject) => {
     /**
      * This variable stores the expanded accordion jquery object. This will be reassigned to the latest,
@@ -101,9 +103,12 @@ Cypress.Commands.add('selectAccordionItem', (accordionPath) => {
               urlPattern: /\/[^/]+\/tree_select\?id=.*&text=.*/,
               triggerFn: () => cy.wrap(currentLiElement).click(),
               waitOnlyIfRequestIntercepted: true,
-              onApiResponse: () => {
+              onApiResponse: (res) => {
                 cy.get('body').find('.spinner').should('not.exist');
                 cy.get('body').find('#spinner_div').should('not.be.visible');
+                if (options?.onTreeSelectResponse) {
+                  options.onTreeSelectResponse(res);
+                }
               },
             });
             return;

--- a/cypress/support/commands/toolbar.js
+++ b/cypress/support/commands/toolbar.js
@@ -4,80 +4,99 @@
 //               - matchedButtonIndex: Number (default: -1) - Index among buttons with matching text (0-based).
 //                                     Use -1 to automatically select the first enabled button.
 //                                     Use 0, 1, 2... to select a specific matched button by index.
-Cypress.Commands.add('toolbar', (toolbarButton, toolbarOption = '', otherOptions = {}) => {
-  const { matchedButtonIndex = -1 } = otherOptions;
+Cypress.Commands.add(
+  'toolbar',
+  (toolbarButton, toolbarOption = '', otherOptions = {}) => {
+    const { matchedButtonIndex = -1 } = otherOptions;
+    let targetToolbarButton;
 
-  const clickToolbarButton = cy
-    .get('#toolbar')
-    .find('button')
-    .then((buttons) => {
-      const matchedButtons = [...buttons].filter(
-        (btn) => btn.innerText.trim() === toolbarButton
-      );
-      const matchedButtonCount = matchedButtons.length;
-
-      if (matchedButtonCount === 0) {
-        cy.logAndThrowError(`cy.toolbar: Toolbar button: "${toolbarButton}" was not found`);
-      }
-
-      let targetToolbarButton;
-      // If matchedButtonIndex is -1 (default), intelligently select the button
-      if (matchedButtonIndex === -1) {
-        // If only one button matches, use it
-        if (matchedButtonCount === 1) {
-          targetToolbarButton = matchedButtons[0];
-        } else {
-          // Multiple buttons found - prefer the first enabled one
-          targetToolbarButton = matchedButtons.find((btn) => !btn.disabled);
-
-          if (!targetToolbarButton) {
-            // All buttons are disabled, use the first one (will fail with proper error)
-            targetToolbarButton = matchedButtons[0];
-          }
-        }
-      } else {
-        // Specific matched button index requested
-        if (matchedButtonIndex >= matchedButtonCount) {
-          cy.logAndThrowError(
-            `cy.toolbar: Matched button index ${matchedButtonIndex} out of range. Found ${matchedButtonCount} button(s) with text "${toolbarButton}". Index must be between 0 and ${matchedButtonCount - 1}.`
-          );
-        }
-        targetToolbarButton = matchedButtons[matchedButtonIndex];
-      }
-      return cy.wrap(targetToolbarButton).click();
-    });
-
-  // If toolbarOption is provided, wait for toolbar to open,
-  // then look for the given toolbar option
-  if (toolbarOption) {
-    return clickToolbarButton.then(() => {
-      return cy.get('.cds--overflow-menu-options li button').then((toolbarOptions) => {
-        const targetToolbarOption = [...toolbarOptions].find(
-          (option) => option.innerText.trim() === toolbarOption
+    const clickToolbarButton = cy
+      .get('#toolbar')
+      .find('button')
+      .should((buttons) => {
+        const matchedButtons = [...buttons].filter(
+          (btn) => btn.innerText.trim() === toolbarButton
         );
+        const matchedButtonCount = matchedButtons.length;
+        // Assert that at least one matching button exists (enables retry)
+        expect(
+          matchedButtons.length,
+          `Expected to find at least one toolbar button with text "${toolbarButton}"`
+        ).to.be.greaterThan(0);
 
-        if (!targetToolbarOption) {
-          cy.logAndThrowError(
-            `"${toolbarOption}" option was not found in the "${toolbarButton}" toolbar`
-          );
+        // If matchedButtonIndex is -1 (default), intelligently select the button
+        if (matchedButtonIndex === -1) {
+          // If only one button matches, use it
+          if (matchedButtonCount === 1) {
+            targetToolbarButton = matchedButtons[0];
+          } else {
+            // Multiple buttons found - prefer the first enabled one
+            targetToolbarButton = matchedButtons.find((btn) => !btn.disabled);
+
+            if (!targetToolbarButton) {
+              // All buttons are disabled, use the first one (will fail with proper error)
+              targetToolbarButton = matchedButtons[0];
+            }
+          }
+        } else {
+          // Specific matched button index requested
+          if (matchedButtonIndex >= matchedButtonCount) {
+            cy.logAndThrowError(
+              `cy.toolbar: Matched button index ${matchedButtonIndex} out of range. Found ${matchedButtonCount} button(s) with text "${toolbarButton}". Index must be between 0 and ${matchedButtonCount - 1}.`
+            );
+          }
+          targetToolbarButton = matchedButtons[matchedButtonIndex];
         }
-
-        return cy.interceptApi({
-          alias: 'toolbarOptionClick',
-          urlPattern: /\/x_button(\/\d+)?\?pressed=.*/,
-          waitOnlyIfRequestIntercepted: true,
-          triggerFn: () => cy.wrap(targetToolbarOption).click(),
-          onApiResponse: (interception) => {
-            expect(interception?.response?.statusCode).to.equal(200);
-          },
-        });
+        // Assert that the target button is enabled (enables retry)
+        expect(
+          targetToolbarButton.disabled,
+          `Expected toolbar button "${toolbarButton}" to be enabled`
+        ).to.be.false;
+      })
+      .then(() => {
+        return cy.wrap(targetToolbarButton).click();
       });
-    });
-  }
 
-  // else, just return the toolbar button click chain
-  return clickToolbarButton;
-});
+    // If toolbarOption is provided, wait for toolbar to open,
+    // then look for the given toolbar option
+    if (toolbarOption) {
+      let targetToolbarOption;
+
+      return clickToolbarButton.then(() => {
+        return cy
+          .get('.cds--overflow-menu-options li button')
+          .should((toolbarOptions) => {
+            targetToolbarOption = [...toolbarOptions].find(
+              (option) => option.innerText.trim() === toolbarOption
+            );
+            // Assert that the toolbar option exists (enables retry)
+            expect(
+              targetToolbarOption,
+              `Expected to find toolbar option "${toolbarOption}" in the "${toolbarButton}" toolbar`
+            ).to.not.be.undefined;
+            // Assert that the toolbar option is enabled (enables retry)
+            expect(
+              targetToolbarOption.disabled,
+              `Expected toolbar option "${toolbarOption}" to be enabled`
+            ).to.be.false;
+          })
+          .then(() => {
+            return cy.interceptApi({
+              alias: 'toolbarOptionClick',
+              urlPattern: /\/x_button(\/\d+)?\?pressed=.*/,
+              waitOnlyIfRequestIntercepted: true,
+              triggerFn: () => cy.wrap(targetToolbarOption).click(),
+              onApiResponse: (interception) => {
+                expect(interception?.response?.statusCode).to.equal(200);
+              },
+            });
+          });
+      });
+    }
+
+    return clickToolbarButton;
+  }
+);
 
 // toolbarButton: String for the text of the toolbar button to click.
 Cypress.Commands.add('toolbarItems', (toolbarButton) => {


### PR DESCRIPTION
PR to improve cypress stability for the reports test - can add/edit/delete report

As observed so far, there are two main points where it frequently fails to interact with the configuration toolbar button because the DOM is still being updated during the interaction
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
