### PR TITLE
Fix vm explorer url

### DIFF
--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -26,6 +26,12 @@ module ApplicationController::Explorer
     end
   end
 
+  def redirect_to_explorer_with_error(message = _("Can't access selected records"), options = {})
+    session.delete(:exp_parms) if session.key?(:exp_parms)
+    flash_to_session(message, :error)
+    redirect_to({:action => 'explorer', :id => nil}.merge(options))
+  end
+
   def x_history
     self.x_node = x_tree[:active_node]
     params[:id] = parse_nodetype_and_id(x_node).last

--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -27,7 +27,7 @@ module ApplicationController::Explorer
   end
 
   def redirect_to_explorer_with_error(message = _("Can't access selected records"), options = {})
-    session.delete(:exp_parms) if session.key?(:exp_parms)
+    session.delete(:exp_parms)
     flash_to_session(message, :error)
     redirect_to({:action => 'explorer', :id => nil}.merge(options))
   end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -359,12 +359,47 @@ class CatalogController < ApplicationController
     end
 
     if params[:id] && !params[:button] # If a tree node id came in, show in one of the trees
-      @nodetype, id = parse_nodetype_and_id(params[:id])
-      self.x_active_tree   = 'sandt_tree'
-      self.x_active_accord = 'sandt'
-      st = ServiceTemplate.find(params[:id].split("-").last)
-      prefix = st.service_template_catalog_id ? "stc-#{st.service_template_catalog_id}_st-" : "-Unassigned_st-"
-      self.x_node = "#{prefix}#{id}"
+      node_id = normalize_catalog_node_id(params[:id])
+
+      if node_id.nil?
+        flash_to_session(_("Can't access selected records"), :error)
+        redirect_to(:action => 'explorer', :id => nil)
+        return
+      end
+
+      @nodetype, id = parse_nodetype_and_id(node_id)
+
+      if @nodetype == "ot"
+        ot = OrchestrationTemplate.find_by(:id => id)
+
+        if ot.nil?
+          flash_to_session(_("Can't access selected records"), :error)
+          redirect_to(:action => 'explorer', :id => nil)
+          return
+        end
+
+        self.x_active_tree   = :ot_tree
+        self.x_active_accord = 'ot'
+        x_tree_init(:ot_tree, :ot, "OrchestrationTemplate") unless x_tree
+        ot_type = template_to_node_name(ot)
+        x_tree[:open_nodes].push("xx-#{ot_type}") unless x_tree[:open_nodes].include?("xx-#{ot_type}")
+        self.x_node = "ot-#{ot.id}"
+        x_tree[:open_nodes].push(x_node)
+      else
+        st = ServiceTemplate.find_by(:id => id)
+
+        if st.nil?
+          flash_to_session(_("Can't access selected records"), :error)
+          redirect_to(:action => 'explorer', :id => nil)
+          return
+        end
+
+        self.x_active_tree   = 'sandt_tree'
+        self.x_active_accord = 'sandt'
+        prefix = st.service_template_catalog_id ? "stc-#{st.service_template_catalog_id}_st-" : "-Unassigned_st-"
+        self.x_node = "#{prefix}#{id}"
+      end
+
       get_node_info(x_node)
     else
       @in_a_form = false
@@ -411,25 +446,32 @@ class CatalogController < ApplicationController
         # link to Catalog Item clicked on catalog summary screen
         self.x_active_tree = :sandt_tree
         self.x_active_accord = 'sandt'
-        @record = ServiceTemplate.find(params[:rec_id])
+        @record = ServiceTemplate.find_by(:id => params[:rec_id])
       else
-        @record = ServiceTemplateCatalog.find(params[:id])
+        @record = ServiceTemplateCatalog.find_by(:id => params[:id])
       end
     elsif x_active_tree == :sandt_tree
       assert_privileges("catalog_items_view")
 
       identify_catalog(params[:id])
-      @record ||= ServiceTemplateCatalog.find(params[:id])
+      @record ||= ServiceTemplateCatalog.find_by(:id => params[:id])
     elsif x_active_tree == :ot_tree
       assert_privileges("orchestration_templates_view")
 
-      @record ||= OrchestrationTemplate.find(params[:id])
+      @record ||= OrchestrationTemplate.find_by(:id => params[:id])
     else
       assert_privileges("svc_catalog_provision", "svc_catalog_archive", "svc_catalog_unarchive")
 
       identify_catalog(params[:id])
-      @record ||= ServiceTemplateCatalog.find(params[:id])
+      @record ||= ServiceTemplateCatalog.find_by(:id => params[:id])
     end
+
+    if @record.nil?
+      flash_to_session(_("Can't access selected records"), :error)
+      redirect_to(:action => 'explorer', :id => nil)
+      return
+    end
+
     params[:id] = x_build_node_id(@record) # Get the tree node id
     tree_select
   end
@@ -865,21 +907,24 @@ class CatalogController < ApplicationController
   end
 
   def ot_show
-    assert_privileges("orchestration_templates_view")
-    id = params.delete(:id)
-    ot = OrchestrationTemplate.find(id)
-    self.x_active_tree = :ot_tree
-    self.x_active_accord = 'ot'
-    x_tree_init(:ot_tree, :ot, "OrchestrationTemplate") unless x_tree
-    ot_type = template_to_node_name(ot)
-    x_tree[:open_nodes].push("xx-#{ot_type}") unless x_tree[:open_nodes].include?("xx-#{ot_type}")
-    self.x_node = "ot-#{ot.id}"
-    x_tree[:open_nodes].push(x_node)
     add_flash(params[:flash_message]) if params.key?(:flash_message)
-    explorer
+    redirect_to(:action => 'explorer', :id => "ot-#{params[:id]}")
   end
 
   private
+
+  # Convert a raw numeric id to a prefixed tree-node id.
+  # Tries ServiceTemplate first (prefix "st"), then OrchestrationTemplate (prefix "ot").
+  # Returns nil if the record does not exist (bad or deleted id).
+  def normalize_catalog_node_id(id)
+    return id if id.nil? || id.include?('-')
+
+    if (record = ServiceTemplate.find_by(:id => id))
+      TreeBuilder.build_node_id(record)          # => "st-<id>"
+    elsif (record = OrchestrationTemplate.find_by(:id => id))
+      TreeBuilder.build_node_id(record)          # => "ot-<id>"
+    end
+  end
 
   # Method to return the entry point name and its automation type
   # Used for summary and edit pages.

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -907,6 +907,7 @@ class CatalogController < ApplicationController
   end
 
   def ot_show
+    assert_privileges("orchestration_templates_view")
     add_flash(params[:flash_message]) if params.key?(:flash_message)
     redirect_to(:action => 'explorer', :id => "ot-#{params[:id]}")
   end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -362,24 +362,24 @@ class CatalogController < ApplicationController
       case @nodetype
       when "ot"
         assert_privileges("orchestration_templates_view")
-        ot = OrchestrationTemplate.find_by(:id => id)
-        redirect_to_explorer_with_error and return if ot.nil?
+        @record = OrchestrationTemplate.find_by(:id => id)
+        redirect_to_explorer_with_error and return if @record.nil?
 
         self.x_active_tree   = :ot_tree
         self.x_active_accord = 'ot'
         x_tree_init(:ot_tree, :ot, "OrchestrationTemplate") unless x_tree
-        ot_type = template_to_node_name(ot)
+        ot_type = template_to_node_name(@record)
         x_tree[:open_nodes].push("xx-#{ot_type}") unless x_tree[:open_nodes].include?("xx-#{ot_type}")
-        self.x_node = "ot-#{ot.id}"
+        self.x_node = "ot-#{@record.id}"
         x_tree[:open_nodes].push(x_node)
       when "st"
         assert_privileges("catalog_items_view")
-        st = ServiceTemplate.find_by(:id => id)
-        redirect_to_explorer_with_error and return if st.nil?
+        @record = ServiceTemplate.find_by(:id => id)
+        redirect_to_explorer_with_error and return if @record.nil?
 
         self.x_active_tree   = 'sandt_tree'
         self.x_active_accord = 'sandt'
-        prefix = st.service_template_catalog_id ? "stc-#{st.service_template_catalog_id}_st-" : "-Unassigned_st-"
+        prefix = @record.service_template_catalog_id ? "stc-#{@record.service_template_catalog_id}_st-" : "-Unassigned_st-"
         self.x_node = "#{prefix}#{id}"
       else
         redirect_to_explorer_with_error
@@ -417,7 +417,7 @@ class CatalogController < ApplicationController
   def identify_catalog(id = nil)
     kls = TreeBuilder.get_model_for_prefix(@nodetype) == "MiqTemplate" ? VmOrTemplate : ServiceTemplate
     @record = identify_record(id || params[:id], kls)
-    @tenants_tree = build_tenants_tree if kls == ServiceTemplate # Build the tree with available tenants for the Catalog Item/Bundle
+    @tenants_tree = build_tenants_tree if kls == ServiceTemplate && @record # Build the tree with available tenants for the Catalog Item/Bundle
     add_flash(_("This item is invalid"), :warning) unless @flash_array || @record.try(:template_valid?)
   end
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -330,6 +330,8 @@ class CatalogController < ApplicationController
 
   # VM or Template show selected, redirect to proper controller
   def show
+    assert_privileges("catalog_items_view")
+
     @sb[:action] = nil
     @explorer = true if request.xml_http_request? # Ajax request means in explorer
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -330,20 +330,16 @@ class CatalogController < ApplicationController
 
   # VM or Template show selected, redirect to proper controller
   def show
-    assert_privileges("catalog_items_view")
-
     @sb[:action] = nil
     @explorer = true if request.xml_http_request? # Ajax request means in explorer
-    record = ServiceTemplate.find(params[:id])
-    if !@explorer
-      tree_node_id = TreeBuilder.build_node_id(record)
-      redirect_to(:controller => "catalog",
-                  :action     => "explorer",
-                  :id         => tree_node_id)
+
+    st = ServiceTemplate.find_by(:id => params[:id])
+    if st.nil?
+      redirect_to_explorer_with_error
       return
-    else
-      redirect_to(:action => 'show', :controller => record.class.base_model.to_s.underscore, :id => record.id)
     end
+
+    redirect_to(:controller => "catalog", :action => "explorer", :id => "st-#{st.id}")
   end
 
   def explorer
@@ -359,24 +355,13 @@ class CatalogController < ApplicationController
     end
 
     if params[:id] && !params[:button] # If a tree node id came in, show in one of the trees
-      node_id = normalize_catalog_node_id(params[:id])
+      @nodetype, id = parse_nodetype_and_id(params[:id])
 
-      if node_id.nil?
-        flash_to_session(_("Can't access selected records"), :error)
-        redirect_to(:action => 'explorer', :id => nil)
-        return
-      end
-
-      @nodetype, id = parse_nodetype_and_id(node_id)
-
-      if @nodetype == "ot"
+      case @nodetype
+      when "ot"
+        assert_privileges("orchestration_templates_view")
         ot = OrchestrationTemplate.find_by(:id => id)
-
-        if ot.nil?
-          flash_to_session(_("Can't access selected records"), :error)
-          redirect_to(:action => 'explorer', :id => nil)
-          return
-        end
+        redirect_to_explorer_with_error and return if ot.nil?
 
         self.x_active_tree   = :ot_tree
         self.x_active_accord = 'ot'
@@ -385,19 +370,18 @@ class CatalogController < ApplicationController
         x_tree[:open_nodes].push("xx-#{ot_type}") unless x_tree[:open_nodes].include?("xx-#{ot_type}")
         self.x_node = "ot-#{ot.id}"
         x_tree[:open_nodes].push(x_node)
-      else
+      when "st"
+        assert_privileges("catalog_items_view")
         st = ServiceTemplate.find_by(:id => id)
-
-        if st.nil?
-          flash_to_session(_("Can't access selected records"), :error)
-          redirect_to(:action => 'explorer', :id => nil)
-          return
-        end
+        redirect_to_explorer_with_error and return if st.nil?
 
         self.x_active_tree   = 'sandt_tree'
         self.x_active_accord = 'sandt'
         prefix = st.service_template_catalog_id ? "stc-#{st.service_template_catalog_id}_st-" : "-Unassigned_st-"
         self.x_node = "#{prefix}#{id}"
+      else
+        redirect_to_explorer_with_error
+        return
       end
 
       get_node_info(x_node)
@@ -467,8 +451,7 @@ class CatalogController < ApplicationController
     end
 
     if @record.nil?
-      flash_to_session(_("Can't access selected records"), :error)
-      redirect_to(:action => 'explorer', :id => nil)
+      redirect_to_explorer_with_error
       return
     end
 
@@ -913,19 +896,6 @@ class CatalogController < ApplicationController
   end
 
   private
-
-  # Convert a raw numeric id to a prefixed tree-node id.
-  # Tries ServiceTemplate first (prefix "st"), then OrchestrationTemplate (prefix "ot").
-  # Returns nil if the record does not exist (bad or deleted id).
-  def normalize_catalog_node_id(id)
-    return id if id.nil? || id.include?('-')
-
-    if (record = ServiceTemplate.find_by(:id => id))
-      TreeBuilder.build_node_id(record)          # => "st-<id>"
-    elsif (record = OrchestrationTemplate.find_by(:id => id))
-      TreeBuilder.build_node_id(record)          # => "ot-<id>"
-    end
-  end
 
   # Method to return the entry point name and its automation type
   # Used for summary and edit pages.

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -81,6 +81,13 @@ class MiqAeClassController < ApplicationController
   # Display any Automate Domain through Tenant's textual summary
   def show
     assert_privileges('miq_ae_domain_view')
+
+    unless MiqAeNamespace.exists?(:id => params[:id])
+      flash_to_session(_("Can't access selected records"), :error)
+      redirect_to(:controller => 'miq_ae_class', :action => 'explorer')
+      return
+    end
+
     @sb[:action] = nil
     @explorer = true
     build_accordions_and_trees
@@ -88,7 +95,7 @@ class MiqAeClassController < ApplicationController
     self.x_node = "aen-#{params[:id]}"
     get_node_info(x_node)
 
-    render :layout => 'application'
+    render :action => 'explorer', :layout => 'application'
   end
 
   def set_right_cell_text(id, rec = nil)

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -83,8 +83,7 @@ class MiqAeClassController < ApplicationController
     assert_privileges('miq_ae_domain_view')
 
     unless MiqAeNamespace.exists?(:id => params[:id])
-      flash_to_session(_("Can't access selected records"), :error)
-      redirect_to(:controller => 'miq_ae_class', :action => 'explorer')
+      redirect_to_explorer_with_error
       return
     end
 

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -142,14 +142,21 @@ class MiqAeCustomizationController < ApplicationController
   def editor
     if params[:id].present?
       feature = 'dialog_edit_editor'
-      @record = Dialog.find(params[:id])
+      @record = Dialog.find_by(:id => params[:id])
     elsif params[:copy].present?
       feature = 'dialog_copy_editor'
-      @record = Dialog.find(params[:copy])
+      @record = Dialog.find_by(:id => params[:copy])
     else
       feature = 'dialog_new_editor'
       @record = Dialog.new
     end
+
+    if @record.nil?
+      flash_to_session(_("Can't access selected records"), :error)
+      redirect_to(:controller => 'miq_ae_customization', :action => 'explorer')
+      return
+    end
+
     assert_privileges(feature)
     @title = @record.id ? _("Editing %{name} Service Dialog") % {:name => @record.name} : _("Add a new Dialog")
   end

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -152,8 +152,7 @@ class MiqAeCustomizationController < ApplicationController
     end
 
     if @record.nil?
-      flash_to_session(_("Can't access selected records"), :error)
-      redirect_to(:controller => 'miq_ae_customization', :action => 'explorer')
+      redirect_to_explorer_with_error
       return
     end
 

--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -256,7 +256,7 @@ class OrchestrationStackController < ApplicationController
 
   def orchestration_templates_view
     template = find_record_with_rbac(OrchestrationStack, params[:id]).orchestration_template
-    javascript_redirect(:controller => 'catalog', :action => 'ot_show', :id => template.id)
+    javascript_redirect(:controller => 'catalog', :action => 'explorer', :id => "ot-#{template.id}")
   end
 
   def title

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -284,10 +284,25 @@ class StorageController < ApplicationController
     session.delete(:exp_parms)
     @in_a_form = false
     if params[:id] # If a tree node id came in, show in one of the trees
-      nodetype, id = params[:id].split("-")
+      node_id = normalize_storage_node_id(params[:id])
+
+      if node_id.exclude?('-')
+        flash_to_session(_("Can't access selected records"), :error)
+        redirect_to(:action => 'explorer', :id => nil)
+        return
+      end
+
+      nodetype, id = node_id.split("-")
       # treebuilder initializes x_node to root first time in locals_for_render,
       # need to set this here to force & activate node when link is clicked outside of explorer.
-      self.x_active_tree = :storage_tree
+      # StorageCluster nodes use the EmsFolder base-model prefix "f"; Storage nodes use "ds".
+      if nodetype == "f"
+        self.x_active_accord = 'storage_pod'
+        self.x_active_tree   = :storage_pod_tree
+      else
+        self.x_active_accord = 'storage'
+        self.x_active_tree   = :storage_tree
+      end
       self.x_node = "#{nodetype}-#{id}"
     end
 
@@ -489,6 +504,23 @@ class StorageController < ApplicationController
   end
 
   private
+
+  # Convert a raw numeric id (e.g. "2888") to a tree-node id (e.g. "ds-2888" or "f-124").
+  # Visiting /storage/explorer/:id directly with a plain DB id is a supported URL pattern;
+  # the split("-") call requires the prefixed format, so normalise it here.
+  # Checks Storage (prefix "ds") first, then StorageCluster. StorageCluster nodes use the
+  # EmsFolder base-model prefix "f" in the tree — not the "dsc" lookup prefix.
+  def normalize_storage_node_id(id)
+    return id if id.nil? || id.include?('-')
+
+    if (record = Storage.find_by(:id => id))
+      TreeBuilder.build_node_id(record)          # => "ds-<id>"
+    elsif StorageCluster.exists?(:id => id)
+      "f-#{id}"                                  # EmsFolder base model prefix
+    else
+      id
+    end
+  end
 
   def record_class
     %w[all_vms vms].include?(params[:display]) ? VmOrTemplate : Storage

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -287,8 +287,7 @@ class StorageController < ApplicationController
       node_id = normalize_storage_node_id(params[:id])
 
       if node_id.exclude?('-')
-        flash_to_session(_("Can't access selected records"), :error)
-        redirect_to(:action => 'explorer', :id => nil)
+        redirect_to_explorer_with_error
         return
       end
 

--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -115,16 +115,18 @@ class VmCloudController < ApplicationController
   end
 
   def prefix_by_nodetype(nodetype)
-    case TreeBuilder.get_model_for_prefix(nodetype).underscore
+    model = TreeBuilder.get_model_for_prefix(nodetype)
+    return nil if model.nil?
+
+    case model.underscore
     when "miq_template" then "images"
     when "vm"           then "instances"
     end
   end
 
   def set_elements_and_redirect_unauthorized_user
-    params[:id] = normalize_vm_node_id(params[:id])
-    @nodetype, _id = parse_nodetype_and_id(params[:id])
-    prefix = prefix_by_nodetype(@nodetype)
+    prefix = setup_node_and_prefix
+    return true if prefix.nil?
 
     # Position in tree that matches selected record
     if role_allows?(:feature => "instances_accord") && prefix == "instances"

--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -122,6 +122,7 @@ class VmCloudController < ApplicationController
   end
 
   def set_elements_and_redirect_unauthorized_user
+    params[:id] = normalize_vm_node_id(params[:id])
     @nodetype, _id = parse_nodetype_and_id(params[:id])
     prefix = prefix_by_nodetype(@nodetype)
 

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -790,6 +790,16 @@ module VmCommon
 
   private
 
+  # Convert a raw numeric id (e.g. "2888") to a tree-node id (e.g. "v-2888").
+  # Visiting /explorer/:id directly with a plain DB id is a supported URL pattern;
+  # parse_nodetype_and_id requires the prefixed format, so normalise it here.
+  def normalize_vm_node_id(id)
+    return id if id.nil? || id.include?('-')
+
+    record = VmOrTemplate.find_by(:id => id)
+    record ? TreeBuilder.build_node_id(record) : id
+  end
+
   # if node is VM or Template is true - select parent node in explorer tree but show info of Vm/Template
   def resolve_node_info(id)
     nodetype, id = id.split("-")

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -800,6 +800,28 @@ module VmCommon
     record ? TreeBuilder.build_node_id(record) : id
   end
 
+  # Shared preamble for all VM explorer set_elements_and_redirect_unauthorized_user methods.
+  # Normalises params[:id], parses the nodetype, resolves the accordion prefix, and handles
+  # the case where the prefix is nil (bad/unrecognised node id) by redirecting back to the
+  # explorer with an error flash.
+  #
+  # Returns the resolved prefix string, or nil if a redirect was already issued (in which
+  # case the caller should return immediately).
+  def setup_node_and_prefix
+    params[:id] = normalize_vm_node_id(params[:id])
+    @nodetype, = parse_nodetype_and_id(params[:id])
+    prefix = prefix_by_nodetype(@nodetype)
+
+    if prefix.nil?
+      session.delete(:exp_parms)
+      flash_to_session(_("Can't access selected records"), :error)
+      redirect_to(:action => 'explorer', :id => nil)
+      return nil
+    end
+
+    prefix
+  end
+
   # if node is VM or Template is true - select parent node in explorer tree but show info of Vm/Template
   def resolve_node_info(id)
     nodetype, id = id.split("-")

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -813,9 +813,7 @@ module VmCommon
     prefix = prefix_by_nodetype(@nodetype)
 
     if prefix.nil?
-      session.delete(:exp_parms)
-      flash_to_session(_("Can't access selected records"), :error)
-      redirect_to(:action => 'explorer', :id => nil)
+      redirect_to_explorer_with_error
       return nil
     end
 

--- a/app/controllers/vm_infra_controller.rb
+++ b/app/controllers/vm_infra_controller.rb
@@ -42,16 +42,18 @@ class VmInfraController < ApplicationController
   end
 
   def prefix_by_nodetype(nodetype)
-    case TreeBuilder.get_model_for_prefix(nodetype).underscore
+    model = TreeBuilder.get_model_for_prefix(nodetype)
+    return nil if model.nil?
+
+    case model.underscore
     when "miq_template" then "templates"
     when "vm"           then "vms"
     end
   end
 
   def set_elements_and_redirect_unauthorized_user
-    params[:id] = normalize_vm_node_id(params[:id])
-    @nodetype, _id = parse_nodetype_and_id(params[:id])
-    prefix = prefix_by_nodetype(@nodetype)
+    prefix = setup_node_and_prefix
+    return true if prefix.nil?
 
     # Position in tree that matches selected record
     if role_allows?(:feature => "vandt_accord")

--- a/app/controllers/vm_infra_controller.rb
+++ b/app/controllers/vm_infra_controller.rb
@@ -49,6 +49,7 @@ class VmInfraController < ApplicationController
   end
 
   def set_elements_and_redirect_unauthorized_user
+    params[:id] = normalize_vm_node_id(params[:id])
     @nodetype, _id = parse_nodetype_and_id(params[:id])
     prefix = prefix_by_nodetype(@nodetype)
 

--- a/app/controllers/vm_or_template_controller.rb
+++ b/app/controllers/vm_or_template_controller.rb
@@ -39,6 +39,7 @@ class VmOrTemplateController < ApplicationController
   end
 
   def set_elements_and_redirect_unauthorized_user
+    params[:id] = normalize_vm_node_id(params[:id])
     @nodetype, = parse_nodetype_and_id(params[:id])
     prefix = prefix_by_nodetype(@nodetype)
 

--- a/app/controllers/vm_or_template_controller.rb
+++ b/app/controllers/vm_or_template_controller.rb
@@ -32,16 +32,18 @@ class VmOrTemplateController < ApplicationController
   end
 
   def prefix_by_nodetype(nodetype)
-    case TreeBuilder.get_model_for_prefix(nodetype).underscore
+    model = TreeBuilder.get_model_for_prefix(nodetype)
+    return nil if model.nil?
+
+    case model.underscore
     when "miq_template" then "templates_images"
     when "vm"           then "vms_instances"
     end
   end
 
   def set_elements_and_redirect_unauthorized_user
-    params[:id] = normalize_vm_node_id(params[:id])
-    @nodetype, = parse_nodetype_and_id(params[:id])
-    prefix = prefix_by_nodetype(@nodetype)
+    prefix = setup_node_and_prefix
+    return true if prefix.nil?
 
     # Position in tree that matches selected record
     if role_allows?(:feature => "#{prefix}_filter_accord")

--- a/spec/controllers/application_controller/explorer_spec.rb
+++ b/spec/controllers/application_controller/explorer_spec.rb
@@ -78,23 +78,34 @@ describe ReportController do
                    :selectable => true}]
       expect(nodes).to eq(expected)
     end
+  end
+end
 
-    describe "#redirect_to_explorer_with_error" do
-      it "sets default flash error and redirects to explorer" do
-        session[:exp_parms] = {:test => 1}
-        controller.send(:redirect_to_explorer_with_error)
+describe CatalogController do
+  describe "#redirect_to_explorer_with_error" do
+    before do
+      EvmSpecHelper.create_guid_miq_server_zone
+      stub_user(:features => :all)
+      controller.instance_variable_set(:@settings, {})
+    end
 
-        expect(session[:exp_parms]).to be_nil
-        expect(session[:flash_msgs]).to include({:message => "Can't access selected records", :level => :error})
-        expect(response).to redirect_to(:action => 'explorer', :id => nil)
+    it "sets default flash error and redirects to explorer" do
+      session[:exp_parms] = {:test => 1}
+      get :explorer, :params => {:id => "invalid-0"}
+
+      expect(session[:exp_parms]).to be_nil
+      expect(session[:flash_msgs]).to include({:message => "Can't access selected records", :level => :error})
+      expect(response).to redirect_to(:action => 'explorer', :id => nil)
+    end
+
+    it "accepts a custom error message" do
+      allow(controller).to receive(:redirect_to_explorer_with_error).and_wrap_original do |m, *args|
+        m.call("Custom error")
       end
+      get :explorer, :params => {:id => "invalid-0"}
 
-      it "accepts a custom error message and options" do
-        controller.send(:redirect_to_explorer_with_error, "Custom error", :controller => 'other')
-
-        expect(session[:flash_msgs]).to include({:message => "Custom error", :level => :error})
-        expect(response).to redirect_to(:controller => 'other', :action => 'explorer', :id => nil)
-      end
+      expect(session[:flash_msgs]).to include({:message => "Custom error", :level => :error})
+      expect(response).to redirect_to(:action => 'explorer', :id => nil)
     end
   end
 end

--- a/spec/controllers/application_controller/explorer_spec.rb
+++ b/spec/controllers/application_controller/explorer_spec.rb
@@ -78,5 +78,23 @@ describe ReportController do
                    :selectable => true}]
       expect(nodes).to eq(expected)
     end
+
+    describe "#redirect_to_explorer_with_error" do
+      it "sets default flash error and redirects to explorer" do
+        session[:exp_parms] = {:test => 1}
+        controller.send(:redirect_to_explorer_with_error)
+
+        expect(session[:exp_parms]).to be_nil
+        expect(session[:flash_msgs]).to include({:message => "Can't access selected records", :level => :error})
+        expect(response).to redirect_to(:action => 'explorer', :id => nil)
+      end
+
+      it "accepts a custom error message and options" do
+        controller.send(:redirect_to_explorer_with_error, "Custom error", :controller => 'other')
+
+        expect(session[:flash_msgs]).to include({:message => "Custom error", :level => :error})
+        expect(response).to redirect_to(:controller => 'other', :action => 'explorer', :id => nil)
+      end
+    end
   end
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -528,6 +528,124 @@ describe CatalogController do
         expect(response).to have_http_status 200
         expect(response).to render_template(:partial => 'catalog/_ot_tree_show')
       end
+
+    end
+
+    describe "#show" do
+      it "redirects to explorer with st- prefixed id for a ServiceTemplate" do
+        st = FactoryBot.create(:service_template)
+        get :show, :params => {:id => st.id}
+
+        expect(response).to redirect_to(:controller => "catalog", :action => "explorer", :id => "st-#{st.id}")
+      end
+
+      it "redirects to explorer with error flash when record does not exist" do
+        get :show, :params => {:id => "999999"}
+
+        expect(response).to redirect_to(:action => 'explorer', :id => nil)
+        expect(session[:flash_msgs]).to include({:message => "Can't access selected records", :level => :error})
+      end
+    end
+
+    describe "#explorer" do
+      before do
+        EvmSpecHelper.create_guid_miq_server_zone
+        session[:settings] = {:views => {}}
+      end
+
+      it "shows an existing orchestration template when ot prefixed id is passed" do
+        expect(controller).to receive(:assert_privileges).with("orchestration_templates_view")
+        ot = FactoryBot.create(:orchestration_template_amazon)
+        get :explorer, :params => {:id => "ot-#{ot.id}"}
+
+        expect(response).to have_http_status 200
+        expect(controller.send(:current_record)).to eq(ot)
+        expect(controller.send(:x_active_tree)).to eq(:ot_tree)
+      end
+
+      it "shows an existing service template when st prefixed id is passed" do
+        expect(controller).to receive(:assert_privileges).with("catalog_items_view")
+        st = FactoryBot.create(:service_template)
+        get :explorer, :params => {:id => "st-#{st.id}"}
+
+        expect(response).to have_http_status 200
+        expect(controller.send(:current_record)).to eq(st)
+        expect(controller.send(:x_active_tree)).to eq('sandt_tree')
+      end
+
+      it "redirects with error flash when a raw numeric id without a prefix is passed" do
+        get :explorer, :params => {:id => "123"}
+
+        expect(response).to redirect_to(:action => 'explorer', :id => nil)
+        expect(session[:flash_msgs]).to include({:message => "Can't access selected records", :level => :error})
+      end
+
+      it "redirects with error flash when an unrecognised nodetype prefix is passed" do
+        get :explorer, :params => {:id => "abc-123"}
+
+        expect(response).to redirect_to(:action => 'explorer', :id => nil)
+        expect(session[:flash_msgs]).to include({:message => "Can't access selected records", :level => :error})
+      end
+
+      it "redirects with error flash when non-existent st id is passed" do
+        get :explorer, :params => {:id => "st-999999"}
+
+        expect(response).to redirect_to(:action => 'explorer', :id => nil)
+        expect(session[:flash_msgs]).to include({:message => "Can't access selected records", :level => :error})
+      end
+
+      it "redirects with error flash when non-existent ot id is passed" do
+        get :explorer, :params => {:id => "ot-999999"}
+
+        expect(response).to redirect_to(:action => 'explorer', :id => nil)
+        expect(session[:flash_msgs]).to include({:message => "Can't access selected records", :level => :error})
+      end
+
+      it "redirects with error flash when non-existent raw numeric id is passed" do
+        get :explorer, :params => {:id => "999999"}
+
+        expect(response).to redirect_to(:action => 'explorer', :id => nil)
+        expect(session[:flash_msgs]).to include({:message => "Can't access selected records", :level => :error})
+      end
+    end
+
+    describe "#x_show" do
+      before do
+        EvmSpecHelper.create_guid_miq_server_zone
+        session[:settings] = {:views => {}}
+      end
+
+      it "redirects with error flash when record does not exist in stcat_tree" do
+        seed_session_trees('catalog', :stcat_tree, 'root')
+        post :x_show, :params => {:id => "999999"}
+
+        expect(response).to redirect_to(:action => 'explorer', :id => nil)
+        expect(session[:flash_msgs]).to include({:message => "Can't access selected records", :level => :error})
+      end
+
+      it "redirects with error flash when rec_id does not exist in stcat_tree" do
+        seed_session_trees('catalog', :stcat_tree, 'root')
+        post :x_show, :params => {:rec_id => "999999"}
+
+        expect(response).to redirect_to(:action => 'explorer', :id => nil)
+        expect(session[:flash_msgs]).to include({:message => "Can't access selected records", :level => :error})
+      end
+
+      it "redirects with error flash when record does not exist in sandt_tree" do
+        seed_session_trees('catalog', :sandt_tree, 'root')
+        post :x_show, :params => {:id => "999999"}
+
+        expect(response).to redirect_to(:action => 'explorer', :id => nil)
+        expect(session[:flash_msgs]).to include({:message => "Can't access selected records", :level => :error})
+      end
+
+      it "redirects with error flash when record does not exist in ot_tree" do
+        seed_session_trees('catalog', :ot_tree, 'root')
+        post :x_show, :params => {:id => "999999"}
+
+        expect(response).to redirect_to(:action => 'explorer', :id => nil)
+        expect(session[:flash_msgs]).to include({:message => "Can't access selected records", :level => :error})
+      end
     end
 
     describe "#set_resource_action" do

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -559,18 +559,20 @@ describe CatalogController do
         get :explorer, :params => {:id => "ot-#{ot.id}"}
 
         expect(response).to have_http_status 200
-        expect(controller.send(:current_record)).to eq(ot)
+        expect(assigns(:record)).to eq(ot)
         expect(controller.send(:x_active_tree)).to eq(:ot_tree)
       end
 
       it "shows an existing service template when st prefixed id is passed" do
         expect(controller).to receive(:assert_privileges).with("catalog_items_view")
+        allow(controller).to receive(:get_node_info)
+        allow(controller).to receive(:build_accordions_and_trees)
+        allow(controller).to receive(:render)
         st = FactoryBot.create(:service_template)
         get :explorer, :params => {:id => "st-#{st.id}"}
 
-        expect(response).to have_http_status 200
-        expect(controller.send(:current_record)).to eq(st)
-        expect(controller.send(:x_active_tree)).to eq('sandt_tree')
+        expect(assigns(:record)).to eq(st)
+        expect(controller.send(:x_active_tree)).to eq(:sandt_tree)
       end
 
       it "redirects with error flash when a raw numeric id without a prefix is passed" do

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -1081,7 +1081,7 @@ describe MiqAeClassController do
     it 'calls build_accordions_and_trees, get_node_info and sets @explorer' do
       expect(controller).to receive(:get_node_info).with("aen-#{ae_domain.id}")
       expect(controller).to receive(:build_accordions_and_trees)
-      expect(controller).to receive(:render).with(:layout => 'application')
+      expect(controller).to receive(:render).with(:action => 'explorer', :layout => 'application')
       controller.send(:show)
       expect(controller.instance_variable_get(:@explorer)).to be(true)
     end

--- a/spec/controllers/orchestration_stack_controller_spec.rb
+++ b/spec/controllers/orchestration_stack_controller_spec.rb
@@ -160,7 +160,7 @@ describe OrchestrationStackController do
         post :button, :params => {:id => record.id, :pressed => "orchestration_templates_view"}
         expect(response.status).to eq(200)
         expect(response.body).to include("window.location.href")
-        expect(response.body).to include("/catalog/ot_show/")
+        expect(response.body).to include("/catalog/explorer/ot-")
       end
     end
 


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/6696

Fixes an issue where trying to access URLs related to the VMs:

`/vm_or_template/explorer/:id`
`/vm_cloud/explorer/:id`
`/vm_infra/explorer/:id`

throws an error. This PR fixes this issue and now the page correctly redirects to the correct record.

This PR also fixes the redirect for the storage explorer and catalog explorer with example URLS:

`/storage/explorer/:id`
`/catalog/explorer/:id` or `/catalog/ot_show/:id` (Orchestration templates only, this path already exists on master)

Other explorer fixes:
`/miq_ae_class/show/:id` (This path already exists on master, this PR just fixes the page)
`/miq_ae_customization/editor/:id` (This path already exists on master, this PR just fixes the error handling of a bad URL)
 
Note: The catalog controller only supports the catalog item and orchestration item templates. You can not use raw IDs to direct to service catalogs or catalogs.


Before:
<img width="1145" height="699" alt="Screenshot 2026-08-20 at 2 32 49 PM" src="https://github.com/user-attachments/assets/2735e65f-419f-4376-b7e2-93ae5be9fa74" />

After:
<img width="1156" height="616" alt="Screenshot 2026-08-20 at 2 33 18 PM" src="https://github.com/user-attachments/assets/827c036a-5ec3-4c9c-a040-eeec8ad2af62" />