### PR TITLE
Fix error modal

### DIFF
--- a/app/javascript/components/miq-error-modal/miq-error-modal.jsx
+++ b/app/javascript/components/miq-error-modal/miq-error-modal.jsx
@@ -51,9 +51,12 @@ const buildErrorDetails = ({ backendName, error, source }) => {
 
   let data = rawData;
   const isHtml = (contentType || '').match('text/html');
+  const isJson = (contentType || '').match('application/json');
 
   if (isHtml && data) {
     data = findError(data);
+  } else if (isJson && data?.error?.message) {
+    data = data.error.message;
   }
 
   if (source !== 'server') {


### PR DESCRIPTION
The error modal is currently not set up to correctly display error messages that are returned in nested objects. This PR fixes that so they are displayed if they exist.

Before:
<img width="802" height="367" alt="Screenshot 2026-08-26 at 11 15 37 AM" src="https://github.com/user-attachments/assets/3795782d-33f6-4ef4-a3fe-366117df894c" />

After:
<img width="810" height="371" alt="Screenshot 2026-08-26 at 11 16 22 AM" src="https://github.com/user-attachments/assets/7a9ffa48-6414-4eca-84d7-1b468d11a68b" />
