### PR TITLE
Fix workflow credential mapping form bug

### DIFF
--- a/app/javascript/components/workflow-credential-mapping-form/workflow-credential-mapping-form.schema.js
+++ b/app/javascript/components/workflow-credential-mapping-form/workflow-credential-mapping-form.schema.js
@@ -52,7 +52,10 @@ const createSchema = (credentials, credentialReferences, payloadCredentials, wor
         id: index.toString(),
         CredentialsIdentifier: { text: value },
         CredentialRecord: {
-          text: credentials[value] ? workflowAuthentications.find((item) => item.value === credentials[value].credential_ref).label : '',
+          text: credentials[value]
+            ? (workflowAuthentications.find((item) => item.value === credentials[value].credential_ref) || {}).label
+              || credentials[value].credential_ref
+            : '',
         },
         CredentialField: { text: credentials[value] ? fieldLabels[credentials[value].credential_field] : '' },
         Delete: {
@@ -88,7 +91,7 @@ const createSchema = (credentials, credentialReferences, payloadCredentials, wor
           value: key,
           label: key,
         })),
-        resolveProps: (props, { meta, input }, formOptions) => {
+        resolveProps: (_props, { meta, input }, formOptions) => {
           // This ensures credentialReferences is set back to undefined when credential_references is reset to default
           if (meta.pristine && credentialReferences !== undefined) {
             setState((state) => ({


### PR DESCRIPTION
Fixes a bug where the workflow credential mapping form crashes when all fields are selected.

Before:
<img width="1155" height="528" alt="Screenshot 2026-08-26 at 11 52 16 AM" src="https://github.com/user-attachments/assets/adb94521-9490-4cf3-b8a0-b0ac324ef1c8" />

After:
<img width="1142" height="516" alt="Screenshot 2026-08-26 at 11 52 50 AM" src="https://github.com/user-attachments/assets/2826845d-a7a2-4b49-a78f-ab11b40a093f" />
