### PR TITLE
Remove unused shared packages

### DIFF
--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -39,14 +39,11 @@ const gettextDir = i18n;
 
 const sharedPackages = [
   '@carbon/react',
-  'angular',
   'jquery',
   'lodash',
   'moment',
-  'prop-types',
   'react',
   'react-dom',
-  'react-redux',
 ];
 
 let packPaths = {};


### PR DESCRIPTION
Follow-up to https://github.com/ManageIQ/manageiq-ui-classic/pull/10219 (Should be merged only after https://github.com/ManageIQ/manageiq-providers-redfish/pull/247)

prop-types has been replaced by TypeScript, and connect from react-redux has been replaced with redux hooks in these PRs:
- Downstream PR#150 (merged)
- https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/573
- https://github.com/ManageIQ/manageiq-providers-ibm_power_vc/pull/163
- https://github.com/ManageIQ/manageiq-providers-cisco_intersight/pull/159
- https://github.com/ManageIQ/manageiq-providers-lenovo/pull/458
- https://github.com/ManageIQ/manageiq-providers-redfish/pull/247

Therefore, these packages are no longer required as shared dependencies.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
