### PR TITLE
Change Chargeback Assignments Form Alignment

### DIFF
--- a/app/stylesheet/chargeback-assignments.scss
+++ b/app/stylesheet/chargeback-assignments.scss
@@ -1,7 +1,5 @@
 .chargeback-assignments-form {
   padding: 1rem;
-  max-width: 1200px;
-  margin: 0 auto;
   overflow: visible !important;
 
   .form-section {


### PR DESCRIPTION
Change alignment of Chargeback Assignments form from center to left. 

Before:
<img width="1728" height="962" alt="Screenshot 2026-09-02 at 2 52 55 PM" src="https://github.com/user-attachments/assets/61d50f5f-16b4-4f3b-aa67-cafe54335edc" />

After:
<img width="1728" height="964" alt="Screenshot 2026-09-02 at 2 54 04 PM" src="https://github.com/user-attachments/assets/6b81ccbc-e08a-4897-828a-d8308e54f6de" />


@miq-bot add-label bug
@miq-bot add-reviewer @GilbertCherrie
@miq-bot assign @GilbertCherrie