### PR TITLE
Pin decode-uri-component to >=0.5.0 <1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
     "angular-sanitize": "~1.8.3",
     "bootstrap-select": "~1.13.18",
     "braces": "~3.0.3",
+    "decode-uri-component": ">=0.5.0 <1.0.0",
     "elliptic": "npm:@soatok/elliptic-to-noble@9999.0.0",
     "final-form": "5.0.0",
     "get-intrinsic": "<=1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7359,10 +7359,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decode-uri-component@npm:^0.2.0":
-  version: 0.2.2
-  resolution: "decode-uri-component@npm:0.2.2"
-  checksum: 10/17a0e5fa400bf9ea84432226e252aa7b5e72793e16bf80b907c99b46a799aeacc139ec20ea57121e50c7bd875a1a4365928f884e92abf02e21a5a13790a0f33e
+"decode-uri-component@npm:>=0.5.0 <1.0.0":
+  version: 0.5.0
+  resolution: "decode-uri-component@npm:0.5.0"
+  checksum: 10/7bd7ed31824ea982a54c1e3ab6284a4541a09125ad6b419d3c5db976ceb700334f15bd5f82af5fe9925e2f9f78b750b6dd60fc80a8fc0498ae2b55da8177e49b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add a yarn resolution to force decode-uri-component to 0.5.0+. The transitive dependency from webpack's snapdragon chain requests ^0.2.0, which under semver's 0.x rules resolves to >=0.2.0 <0.3.0 — the caret locks the minor version (not the major) when the major is zero. A plain `yarn up` would never cross that boundary, so the explicit range >=0.5.0 <1.0.0 is used instead to pick up future 0.x patch/minor releases automatically.

@GilbertCherrie Please review. This one was interesting.