### PR TITLE
Fix template disk table

### DIFF
--- a/app/javascript/components/vm-disks/index.jsx
+++ b/app/javascript/components/vm-disks/index.jsx
@@ -3,11 +3,12 @@ import PropTypes from 'prop-types';
 import MiqDataTable from '../miq-data-table';
 import { tableData } from './helper';
 
-const VmDisks = ({ recordId }) => {
+const VmDisks = ({ recordId, isTemplate }) => {
   const [{ disks, isLoading }, setState] = useState({ disks: [], isLoading: true });
 
   useEffect(() => {
-    API.get(`/api/vms/${recordId}/disks?expand=resources&attributes=partitions_aligned`)
+    const base = isTemplate ? 'templates' : 'vms';
+    API.get(`/api/${base}/${recordId}/disks?expand=resources&attributes=partitions_aligned`)
       .then(({ resources }) => {
         setState({ disks: resources, isLoading: false });
       });
@@ -33,6 +34,11 @@ const VmDisks = ({ recordId }) => {
 
 VmDisks.propTypes = {
   recordId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  isTemplate: PropTypes.bool,
+};
+
+VmDisks.defaultProps = {
+  isTemplate: false,
 };
 
 export default VmDisks;

--- a/app/javascript/spec/vm-disks/vm-disks.spec.js
+++ b/app/javascript/spec/vm-disks/vm-disks.spec.js
@@ -43,6 +43,12 @@ describe('VmDisks Component', () => {
     expect(API.get).toHaveBeenCalledWith('/api/vms/3170/disks?expand=resources&attributes=partitions_aligned');
   });
 
+  it('should fetch disks from the templates API URL when isTemplate is true', async() => {
+    render(<VmDisks recordId={3170} isTemplate />);
+    await waitFor(() => screen.getByText('Hard Disk (SCSI 0:0)'));
+    expect(API.get).toHaveBeenCalledWith('/api/templates/3170/disks?expand=resources&attributes=partitions_aligned');
+  });
+
   it('should render correct number of rows', async() => {
     API.get = jest.fn(() => Promise.resolve({ resources: [mockDisks[0]] }));
     render(<VmDisks recordId={3170} />);

--- a/app/views/vm_common/_disks.html.haml
+++ b/app/views/vm_common/_disks.html.haml
@@ -1,2 +1,2 @@
 = render :partial => "layouts/flash_msg"
-= react('VmDisks', {:recordId => @record.id})
+= react('VmDisks', {:recordId => @record.id, :isTemplate => @record.kind_of?(::MiqTemplate)})


### PR DESCRIPTION
Follow-up to: https://github.com/ManageIQ/manageiq-ui-classic/pull/10167

Depends on: 
- [x] https://github.com/ManageIQ/manageiq-api/pull/1342

Fixes a bug where the number of disks table doesn't load for templates due to an incorrect API call.

Before:
<img width="1142" height="431" alt="Screenshot 2026-09-04 at 1 16 51 PM" src="https://github.com/user-attachments/assets/15710b02-6f21-4e31-a62e-e88927c6ffc5" />

After:
<img width="1156" height="227" alt="Screenshot 2026-09-04 at 1 17 55 PM" src="https://github.com/user-attachments/assets/7ab62871-fa3b-4589-9efc-291f64246e94" />

