### PR TITLE
Remove default props from vm/template disk table

### DIFF
--- a/app/javascript/components/vm-disks/index.jsx
+++ b/app/javascript/components/vm-disks/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import MiqDataTable from '../miq-data-table';
 import { tableData } from './helper';
 
-const VmDisks = ({ recordId, isTemplate }) => {
+const VmDisks = ({ recordId, isTemplate = false }) => {
   const [{ disks, isLoading }, setState] = useState({ disks: [], isLoading: true });
 
   useEffect(() => {
@@ -35,10 +35,6 @@ const VmDisks = ({ recordId, isTemplate }) => {
 VmDisks.propTypes = {
   recordId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   isTemplate: PropTypes.bool,
-};
-
-VmDisks.defaultProps = {
-  isTemplate: false,
 };
 
 export default VmDisks;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -136,6 +136,7 @@ const sharedReactRules = {
   'react/jsx-pascal-case': ['error', { allowAllCaps: true, ignore: [] }],
   'react/jsx-props-no-multi-spaces': 'error',
   'react/jsx-sort-default-props': ['off', { ignoreCase: true }],
+  'react/require-default-props': ['warn', { functions: 'defaultArguments' }],
   'react/jsx-sort-props': [
     'off',
     {


### PR DESCRIPTION
Follow-up to #10271 

Removes the default props from the vm and template disk table React component as they are not needed in React 19.