### PR TITLE
Fix content type translation

### DIFF
--- a/app/javascript/components/miq-error-modal/miq-error-modal.jsx
+++ b/app/javascript/components/miq-error-modal/miq-error-modal.jsx
@@ -128,7 +128,7 @@ const MiqErrorModal = () => {
           )}
           {contentType && (
             <p className="miq-error-modal-row">
-              <strong className="miq-error-modal-label">{__('Content-Type')}</strong>
+              <strong className="miq-error-modal-label">Content-Type</strong>
               {contentType}
             </p>
           )}


### PR DESCRIPTION
Fixes a bug in https://github.com/ManageIQ/manageiq/pull/23879

Remove translation from the Content-Type string in the error modal