### PR TITLE
Fix performance chart tooltip

### DIFF
--- a/app/javascript/components/performance-charts/areaChart.js
+++ b/app/javascript/components/performance-charts/areaChart.js
@@ -12,10 +12,12 @@ const AreaChartGraph = ({
     title,
     axes: {
       bottom: {
+        title: __('Date'),
         mapsTo: 'key',
         scaleType: 'time',
       },
       left: {
+        title: __('Value'),
         mapsTo: 'value',
         scaleType: 'linear',
         ticks: {
@@ -27,6 +29,17 @@ const AreaChartGraph = ({
     tooltip: {
       truncation: {
         type: 'none',
+      },
+      valueFormatter(value, label) {
+        if (value instanceof Date || label === __('Date') || label === 'x-value') {
+          return value instanceof Date
+            ? value.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+            : value;
+        }
+        if (label === 'Group' || label === __('Group')) {
+          return value;
+        }
+        return getYAxisValue(format, value);
       },
     },
   };

--- a/app/javascript/components/performance-charts/areaChart.js
+++ b/app/javascript/components/performance-charts/areaChart.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import { AreaChart } from '@carbon/charts-react';
-import { getYAxisValue } from './helpers';
+import { getTickFormatter, getTooltipOptions } from './helpers';
 
 const AreaChartGraph = ({
   data = null,
@@ -21,27 +21,12 @@ const AreaChartGraph = ({
         mapsTo: 'value',
         scaleType: 'linear',
         ticks: {
-          formatter(n) { return getYAxisValue(format, n); },
+          formatter: getTickFormatter(format),
         },
       },
     },
     height: size,
-    tooltip: {
-      truncation: {
-        type: 'none',
-      },
-      valueFormatter(value, label) {
-        if (value instanceof Date || label === __('Date') || label === 'x-value') {
-          return value instanceof Date
-            ? value.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
-            : value;
-        }
-        if (label === 'Group' || label === __('Group')) {
-          return value;
-        }
-        return getYAxisValue(format, value);
-      },
-    },
+    tooltip: getTooltipOptions(format),
   };
 
   return (

--- a/app/javascript/components/performance-charts/groupChart.js
+++ b/app/javascript/components/performance-charts/groupChart.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import { GroupedBarChart } from '@carbon/charts-react';
-import { getYAxisValue } from './helpers';
+import { getTickFormatter, getTooltipOptions } from './helpers';
 
 const GroupBarChart = ({
   data = null,
@@ -15,7 +15,7 @@ const GroupBarChart = ({
         title: __('Value'),
         mapsTo: 'value',
         ticks: {
-          formatter(n) { return getYAxisValue(format, n); },
+          formatter: getTickFormatter(format),
         },
       },
       bottom: {
@@ -25,22 +25,7 @@ const GroupBarChart = ({
       },
     },
     height: size,
-    tooltip: {
-      truncation: {
-        type: 'none',
-      },
-      valueFormatter(value, label) {
-        if (value instanceof Date || label === __('Date') || label === 'x-value') {
-          return value instanceof Date
-            ? value.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
-            : value;
-        }
-        if (label === 'Group' || label === __('Group')) {
-          return value;
-        }
-        return getYAxisValue(format, value);
-      },
-    },
+    tooltip: getTooltipOptions(format),
   };
 
   return (

--- a/app/javascript/components/performance-charts/groupChart.js
+++ b/app/javascript/components/performance-charts/groupChart.js
@@ -12,12 +12,14 @@ const GroupBarChart = ({
     title,
     axes: {
       left: {
+        title: __('Value'),
         mapsTo: 'value',
         ticks: {
           formatter(n) { return getYAxisValue(format, n); },
         },
       },
       bottom: {
+        title: __('Date'),
         scaleType: 'labels',
         mapsTo: 'key',
       },
@@ -26,6 +28,17 @@ const GroupBarChart = ({
     tooltip: {
       truncation: {
         type: 'none',
+      },
+      valueFormatter(value, label) {
+        if (value instanceof Date || label === __('Date') || label === 'x-value') {
+          return value instanceof Date
+            ? value.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+            : value;
+        }
+        if (label === 'Group' || label === __('Group')) {
+          return value;
+        }
+        return getYAxisValue(format, value);
       },
     },
   };

--- a/app/javascript/components/performance-charts/helpers.js
+++ b/app/javascript/components/performance-charts/helpers.js
@@ -1,8 +1,21 @@
 export const getYAxisValue = (format, value) => {
-  // eslint-disable-next-line no-useless-escape
-  if (format) {
-    const tmp = /^([0-9\,\.]+)(.*)/.exec(ManageIQ.charts.formatters[format.function].c3(format.options)(value));
-    return [`${numeral(tmp[1]).value()}${tmp[2]}`];
+  if (value === null || value === undefined) {
+    return value;
+  }
+  if (format && ManageIQ?.charts?.formatters?.[format.function]?.c3) {
+    try {
+      const formatted = ManageIQ.charts.formatters[format.function].c3(format.options)(value);
+      if (formatted !== null && formatted !== undefined) {
+        // eslint-disable-next-line no-useless-escape
+        const tmp = /^([0-9\,\.]+)(.*)/.exec(String(formatted));
+        if (tmp) {
+          return `${numeral(tmp[1]).value()}${tmp[2]}`;
+        }
+        return String(formatted);
+      }
+    } catch (_e) {
+      return value;
+    }
   }
   return value;
 };

--- a/app/javascript/components/performance-charts/helpers.js
+++ b/app/javascript/components/performance-charts/helpers.js
@@ -1,21 +1,29 @@
 export const getYAxisValue = (format, value) => {
-  if (value === null || value === undefined) {
-    return value;
-  }
-  if (format && ManageIQ?.charts?.formatters?.[format.function]?.c3) {
-    try {
-      const formatted = ManageIQ.charts.formatters[format.function].c3(format.options)(value);
-      if (formatted !== null && formatted !== undefined) {
-        // eslint-disable-next-line no-useless-escape
-        const tmp = /^([0-9\,\.]+)(.*)/.exec(String(formatted));
-        if (tmp) {
-          return `${numeral(tmp[1]).value()}${tmp[2]}`;
-        }
-        return String(formatted);
-      }
-    } catch (_e) {
-      return value;
+  if (format) {
+    // eslint-disable-next-line no-useless-escape
+    const match = /^([0-9\,\.]+)(.*)/.exec(String(ManageIQ.charts.formatters[format.function].c3(format.options)(value)));
+    if (match) {
+      return `${numeral(match[1]).value()}${match[2]}`;
     }
   }
   return value;
 };
+
+export const getTickFormatter = (format) => (n) => getYAxisValue(format, n);
+
+export const getTooltipOptions = (format) => ({
+  truncation: {
+    type: 'none',
+  },
+  valueFormatter(value, label) {
+    if (value instanceof Date || label === 'x-value') {
+      return value instanceof Date
+        ? value.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+        : value;
+    }
+    if (label === 'Group') {
+      return value;
+    }
+    return getYAxisValue(format, value);
+  },
+});

--- a/app/javascript/components/performance-charts/lineChart.js
+++ b/app/javascript/components/performance-charts/lineChart.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import { LineChart } from '@carbon/charts-react';
-import { getYAxisValue } from './helpers';
+import { getTickFormatter, getTooltipOptions } from './helpers';
 
 const LineChartGraph = ({
   data = null,
@@ -21,27 +21,12 @@ const LineChartGraph = ({
         mapsTo: 'value',
         scaleType: 'linear',
         ticks: {
-          formatter(n) { return getYAxisValue(format, n); },
+          formatter: getTickFormatter(format),
         },
       },
     },
     height: size,
-    tooltip: {
-      truncation: {
-        type: 'none',
-      },
-      valueFormatter(value, label) {
-        if (value instanceof Date || label === __('Date') || label === 'x-value') {
-          return value instanceof Date
-            ? value.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
-            : value;
-        }
-        if (label === 'Group' || label === __('Group')) {
-          return value;
-        }
-        return getYAxisValue(format, value);
-      },
-    },
+    tooltip: getTooltipOptions(format),
   };
 
   return (

--- a/app/javascript/components/performance-charts/lineChart.js
+++ b/app/javascript/components/performance-charts/lineChart.js
@@ -12,10 +12,12 @@ const LineChartGraph = ({
     title,
     axes: {
       bottom: {
+        title: __('Date'),
         mapsTo: 'key',
         scaleType: 'time',
       },
       left: {
+        title: __('Value'),
         mapsTo: 'value',
         scaleType: 'linear',
         ticks: {
@@ -27,6 +29,17 @@ const LineChartGraph = ({
     tooltip: {
       truncation: {
         type: 'none',
+      },
+      valueFormatter(value, label) {
+        if (value instanceof Date || label === __('Date') || label === 'x-value') {
+          return value instanceof Date
+            ? value.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+            : value;
+        }
+        if (label === 'Group' || label === __('Group')) {
+          return value;
+        }
+        return getYAxisValue(format, value);
       },
     },
   };


### PR DESCRIPTION
Fixes part of https://github.com/ManageIQ/manageiq/issues/23959

Fix the performance chart tooltips to better display data.

Before:
<img width="400" height="518" alt="Screenshot 2026-09-11 at 1 15 56 PM" src="https://github.com/user-attachments/assets/7695858b-cc33-4a57-908e-c538fc744357" />
<img width="413" height="513" alt="Screenshot 2026-09-11 at 1 16 36 PM" src="https://github.com/user-attachments/assets/3b05a7ee-25e5-4234-a34d-bc5639524efd" />

After:
<img width="818" height="1034" alt="image" src="https://github.com/user-attachments/assets/5fd863d0-adcb-40d3-891c-57452c124586" />
<img width="420" height="541" alt="Screenshot 2026-09-11 at 1 15 25 PM" src="https://github.com/user-attachments/assets/0e0931e6-a9ea-4e95-bc7f-813c9e712352" />


