### PR TITLE
[WIP] Add dual y axis support to carbon charts

### DIFF
--- a/app/javascript/components/carbon-charts/areaChart.js
+++ b/app/javascript/components/carbon-charts/areaChart.js
@@ -4,6 +4,7 @@ import { AreaChart } from '@carbon/charts-react';
 const AreaChartGraph = ({
   data = null,
   title = '',
+  dualYAxis = null,
 }) => {
   const options = {
     title,
@@ -16,6 +17,14 @@ const AreaChartGraph = ({
         mapsTo: 'value',
         scaleType: 'linear',
       },
+      ...(dualYAxis && {
+        right: {
+          mapsTo: dualYAxis.mapsTo,
+          scaleType: 'linear',
+          title: dualYAxis.title,
+          correspondingDatasets: dualYAxis.correspondingDatasets,
+        },
+      }),
     },
     height: '400px',
     tooltip: {
@@ -33,6 +42,11 @@ const AreaChartGraph = ({
 AreaChartGraph.propTypes = {
   data: PropTypes.arrayOf(PropTypes.any),
   title: PropTypes.string,
+  dualYAxis: PropTypes.shape({
+    mapsTo: PropTypes.string.isRequired,
+    title: PropTypes.string,
+    correspondingDatasets: PropTypes.arrayOf(PropTypes.string).isRequired,
+  }),
 };
 
 export default AreaChartGraph;

--- a/app/javascript/components/carbon-charts/groupChart.js
+++ b/app/javascript/components/carbon-charts/groupChart.js
@@ -5,6 +5,7 @@ const GroupBarChart = ({
   data = null,
   title = '',
   showLegend = true,
+  dualYAxis = null,
 }) => {
   const options = {
     title,
@@ -17,6 +18,14 @@ const GroupBarChart = ({
         scaleType: 'labels',
         mapsTo: 'key',
       },
+      ...(dualYAxis && {
+        right: {
+          mapsTo: dualYAxis.mapsTo,
+          scaleType: 'linear',
+          title: dualYAxis.title,
+          correspondingDatasets: dualYAxis.correspondingDatasets,
+        },
+      }),
     },
     height: '400px',
     tooltip: {
@@ -35,6 +44,11 @@ GroupBarChart.propTypes = {
   data: PropTypes.arrayOf(PropTypes.any),
   title: PropTypes.string,
   showLegend: PropTypes.bool,
+  dualYAxis: PropTypes.shape({
+    mapsTo: PropTypes.string.isRequired,
+    title: PropTypes.string,
+    correspondingDatasets: PropTypes.arrayOf(PropTypes.string).isRequired,
+  }),
 };
 
 export default GroupBarChart;

--- a/app/javascript/components/carbon-charts/lineChart.js
+++ b/app/javascript/components/carbon-charts/lineChart.js
@@ -4,6 +4,7 @@ import { LineChart } from '@carbon/charts-react';
 const LineChartGraph = ({
   data = null,
   title = '',
+  dualYAxis = null,
 }) => {
   const options = {
     title,
@@ -16,6 +17,14 @@ const LineChartGraph = ({
         mapsTo: 'value',
         scaleType: 'linear',
       },
+      ...(dualYAxis && {
+        right: {
+          mapsTo: dualYAxis.mapsTo,
+          scaleType: 'linear',
+          title: dualYAxis.title,
+          correspondingDatasets: dualYAxis.correspondingDatasets,
+        },
+      }),
     },
     height: '400px',
     tooltip: {
@@ -33,6 +42,11 @@ const LineChartGraph = ({
 LineChartGraph.propTypes = {
   data: PropTypes.arrayOf(PropTypes.any),
   title: PropTypes.string,
+  dualYAxis: PropTypes.shape({
+    mapsTo: PropTypes.string.isRequired,
+    title: PropTypes.string,
+    correspondingDatasets: PropTypes.arrayOf(PropTypes.string).isRequired,
+  }),
 };
 
 export default LineChartGraph;

--- a/app/javascript/components/carbon-charts/stackBarChart.js
+++ b/app/javascript/components/carbon-charts/stackBarChart.js
@@ -5,6 +5,7 @@ const StackBarChartGraph = ({
   data = null,
   title = '',
   chart_options = null,
+  dualYAxis = null,
 }) => {
   const options = {
     title,
@@ -17,6 +18,14 @@ const StackBarChartGraph = ({
         mapsTo: 'key',
         scaleType: 'labels',
       },
+      ...(dualYAxis && {
+        right: {
+          mapsTo: dualYAxis.mapsTo,
+          scaleType: 'linear',
+          title: dualYAxis.title,
+          correspondingDatasets: dualYAxis.correspondingDatasets,
+        },
+      }),
     },
     height: '400px',
     tooltip: {
@@ -34,6 +43,11 @@ const StackBarChartGraph = ({
 StackBarChartGraph.propTypes = {
   data: PropTypes.arrayOf(PropTypes.any),
   title: PropTypes.string,
+  dualYAxis: PropTypes.shape({
+    mapsTo: PropTypes.string.isRequired,
+    title: PropTypes.string,
+    correspondingDatasets: PropTypes.arrayOf(PropTypes.string).isRequired,
+  }),
 };
 
 export default StackBarChartGraph;

--- a/app/javascript/components/carbon-charts/stackedAreaChart.js
+++ b/app/javascript/components/carbon-charts/stackedAreaChart.js
@@ -4,6 +4,7 @@ import { StackedAreaChart } from '@carbon/charts-react';
 const StackAreaChart = ({
   data = null,
   title = '',
+  dualYAxis = null,
 }) => {
   const options = {
     title,
@@ -17,6 +18,14 @@ const StackAreaChart = ({
         scaleType: 'linear',
         mapsTo: 'key',
       },
+      ...(dualYAxis && {
+        right: {
+          mapsTo: dualYAxis.mapsTo,
+          scaleType: 'linear',
+          title: dualYAxis.title,
+          correspondingDatasets: dualYAxis.correspondingDatasets,
+        },
+      }),
     },
     curve: 'curveMonotoneX',
     height: '400px',
@@ -35,6 +44,11 @@ const StackAreaChart = ({
 StackAreaChart.propTypes = {
   data: PropTypes.arrayOf(PropTypes.any),
   title: PropTypes.string,
+  dualYAxis: PropTypes.shape({
+    mapsTo: PropTypes.string.isRequired,
+    title: PropTypes.string,
+    correspondingDatasets: PropTypes.arrayOf(PropTypes.string).isRequired,
+  }),
 };
 
 export default StackAreaChart;


### PR DESCRIPTION
Add dual axis support to carbon charts to allow a left and right y axis.